### PR TITLE
feat: add Airtable view filtering support

### DIFF
--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -90,7 +90,11 @@ export class AirtableClient {
     const baseUrl = this.getBaseUrl();
 
     do {
-      const url = offset ? `${baseUrl}?offset=${offset}` : baseUrl;
+      const params = new URLSearchParams();
+      if (this.settings.viewId) params.set('view', this.settings.viewId);
+      if (offset) params.set('offset', offset);
+      const query = params.toString();
+      const url = query ? `${baseUrl}?${query}` : baseUrl;
       const response = await this.rateLimiter.execute(() =>
         requestUrl({
           url,

--- a/src/services/field-cache.ts
+++ b/src/services/field-cache.ts
@@ -43,12 +43,12 @@ export class FieldCache {
    */
   clearTables(baseId: string): void {
     this.cachedTables.delete(baseId);
-    // Clear fields and views that belong to this base
-    for (const key of [...this.cachedFields.keys(), ...this.cachedViews.keys()]) {
-      if (key.startsWith(`${baseId}-`)) {
-        this.cachedFields.delete(key);
-        this.cachedViews.delete(key);
-      }
+    const prefix = `${baseId}-`;
+    for (const key of this.cachedFields.keys()) {
+      if (key.startsWith(prefix)) this.cachedFields.delete(key);
+    }
+    for (const key of this.cachedViews.keys()) {
+      if (key.startsWith(prefix)) this.cachedViews.delete(key);
     }
   }
 
@@ -124,15 +124,9 @@ export class FieldCache {
   }
 
   /**
-   * Fetches fields for a specific table.
+   * Fetches and caches both fields and views for a table in a single API call.
    */
-  async fetchFields(apiKey: string, baseId: string, tableId: string): Promise<AirtableField[]> {
-    this.clearCacheIfApiKeyChanged(apiKey);
-
-    const cacheKey = this.getCacheKey(baseId, tableId);
-    const cachedFields = this.cachedFields.get(cacheKey);
-    if (cachedFields) return cachedFields;
-
+  private async fetchTableMetadata(apiKey: string, baseId: string, tableId: string): Promise<void> {
     const response = await requestUrl({
       url: `${AIRTABLE_META_API_URL}/bases/${baseId}/tables`,
       method: "GET",
@@ -140,7 +134,7 @@ export class FieldCache {
     });
 
     if (response.status !== 200) {
-      throw new Error(`Failed to fetch table fields: HTTP ${response.status}`);
+      throw new Error(`Failed to fetch table metadata: HTTP ${response.status}`);
     }
 
     const json = response.json;
@@ -149,6 +143,8 @@ export class FieldCache {
     if (!table) {
       throw new Error(`Table with ID ${tableId} not found`);
     }
+
+    const cacheKey = this.getCacheKey(baseId, tableId);
 
     const fields: AirtableField[] = table.fields.map((f: {
       id: string;
@@ -161,9 +157,32 @@ export class FieldCache {
       type: f.type,
       description: f.description
     }));
-
     this.cachedFields.set(cacheKey, fields);
-    return fields;
+
+    const views: AirtableView[] = (table.views || []).map((v: {
+      id: string;
+      name: string;
+      type: string;
+    }) => ({
+      id: v.id,
+      name: v.name,
+      type: v.type
+    }));
+    this.cachedViews.set(cacheKey, views);
+  }
+
+  /**
+   * Fetches fields for a specific table.
+   */
+  async fetchFields(apiKey: string, baseId: string, tableId: string): Promise<AirtableField[]> {
+    this.clearCacheIfApiKeyChanged(apiKey);
+
+    const cacheKey = this.getCacheKey(baseId, tableId);
+    const cached = this.cachedFields.get(cacheKey);
+    if (cached) return cached;
+
+    await this.fetchTableMetadata(apiKey, baseId, tableId);
+    return this.cachedFields.get(cacheKey)!;
   }
 
   /**
@@ -176,35 +195,8 @@ export class FieldCache {
     const cached = this.cachedViews.get(cacheKey);
     if (cached) return cached;
 
-    const response = await requestUrl({
-      url: `${AIRTABLE_META_API_URL}/bases/${baseId}/tables`,
-      method: "GET",
-      headers: { "Authorization": `Bearer ${apiKey}` },
-    });
-
-    if (response.status !== 200) {
-      throw new Error(`Failed to fetch table views: HTTP ${response.status}`);
-    }
-
-    const json = response.json;
-    const table = json.tables.find((t: { id: string }) => t.id === tableId);
-
-    if (!table) {
-      throw new Error(`Table with ID ${tableId} not found`);
-    }
-
-    const views: AirtableView[] = (table.views || []).map((v: {
-      id: string;
-      name: string;
-      type: string;
-    }) => ({
-      id: v.id,
-      name: v.name,
-      type: v.type
-    }));
-
-    this.cachedViews.set(cacheKey, views);
-    return views;
+    await this.fetchTableMetadata(apiKey, baseId, tableId);
+    return this.cachedViews.get(cacheKey)!;
   }
 
   /**

--- a/src/services/field-cache.ts
+++ b/src/services/field-cache.ts
@@ -6,7 +6,7 @@
 
 import { requestUrl } from "obsidian";
 import { AIRTABLE_META_API_URL } from '../constants';
-import type { AirtableField, AirtableBase, AirtableTable } from '../types';
+import type { AirtableField, AirtableBase, AirtableTable, AirtableView } from '../types';
 
 /**
  * Caches Airtable metadata (bases, tables, fields) to minimize API calls.
@@ -15,6 +15,7 @@ export class FieldCache {
   private cachedBases: AirtableBase[] | null = null;
   private cachedTables: Map<string, AirtableTable[]> = new Map();
   private cachedFields: Map<string, AirtableField[]> = new Map();
+  private cachedViews: Map<string, AirtableView[]> = new Map();
   private lastApiKey = "";
 
   /**
@@ -34,6 +35,7 @@ export class FieldCache {
     this.cachedBases = null;
     this.cachedTables.clear();
     this.cachedFields.clear();
+    this.cachedViews.clear();
   }
 
   /**
@@ -41,10 +43,11 @@ export class FieldCache {
    */
   clearTables(baseId: string): void {
     this.cachedTables.delete(baseId);
-    // Clear fields that belong to this base
-    for (const key of this.cachedFields.keys()) {
+    // Clear fields and views that belong to this base
+    for (const key of [...this.cachedFields.keys(), ...this.cachedViews.keys()]) {
       if (key.startsWith(`${baseId}-`)) {
         this.cachedFields.delete(key);
+        this.cachedViews.delete(key);
       }
     }
   }
@@ -161,6 +164,54 @@ export class FieldCache {
 
     this.cachedFields.set(cacheKey, fields);
     return fields;
+  }
+
+  /**
+   * Fetches views for a specific table.
+   */
+  async fetchViews(apiKey: string, baseId: string, tableId: string): Promise<AirtableView[]> {
+    this.clearCacheIfApiKeyChanged(apiKey);
+
+    const cacheKey = this.getCacheKey(baseId, tableId);
+    const cached = this.cachedViews.get(cacheKey);
+    if (cached) return cached;
+
+    const response = await requestUrl({
+      url: `${AIRTABLE_META_API_URL}/bases/${baseId}/tables`,
+      method: "GET",
+      headers: { "Authorization": `Bearer ${apiKey}` },
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch table views: HTTP ${response.status}`);
+    }
+
+    const json = response.json;
+    const table = json.tables.find((t: { id: string }) => t.id === tableId);
+
+    if (!table) {
+      throw new Error(`Table with ID ${tableId} not found`);
+    }
+
+    const views: AirtableView[] = (table.views || []).map((v: {
+      id: string;
+      name: string;
+      type: string;
+    }) => ({
+      id: v.id,
+      name: v.name,
+      type: v.type
+    }));
+
+    this.cachedViews.set(cacheKey, views);
+    return views;
+  }
+
+  /**
+   * Clears cached views for a specific base/table combination.
+   */
+  clearViews(baseId: string, tableId: string): void {
+    this.cachedViews.delete(this.getCacheKey(baseId, tableId));
   }
 
   /**

--- a/src/types/airtable.types.ts
+++ b/src/types/airtable.types.ts
@@ -30,6 +30,15 @@ export interface AirtableTable {
 }
 
 /**
+ * Represents an Airtable view within a table.
+ */
+export interface AirtableView {
+  id: string;
+  name: string;
+  type: string;
+}
+
+/**
  * Represents a note fetched from Airtable.
  */
 export interface RemoteNote {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export type {
   AirtableField,
   AirtableBase,
   AirtableTable,
+  AirtableView,
   RemoteNote,
   SyncResult,
   ConflictInfo,

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -25,6 +25,7 @@ export interface AutoNoteImporterSettings {
   apiKey: string;
   baseId: string;
   tableId: string;
+  viewId: string;
   folderPath: string;
   templatePath: string;
   syncInterval: number;
@@ -51,6 +52,7 @@ export const DEFAULT_SETTINGS: AutoNoteImporterSettings = {
   apiKey: "",
   baseId: "",
   tableId: "",
+  viewId: "",
   folderPath: "Crawling",
   templatePath: "",
   syncInterval: 0,

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -182,6 +182,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           dropdown.setValue(this.plugin.settings.tableId);
           dropdown.onChange(async (value) => {
             this.plugin.settings.tableId = value;
+            this.plugin.settings.viewId = "";
             await this.plugin.saveSettings();
             this.debounceDisplay();
           });
@@ -195,8 +196,39 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       }));
 
     if (this.plugin.settings.tableId) {
+      this.renderViewSelector(containerEl);
       this.renderFieldSelectors(containerEl);
     }
+  }
+
+  private renderViewSelector(containerEl: HTMLElement): void {
+    new Setting(containerEl)
+      .setName("Select view (optional)")
+      .setDesc("Filter synced records by an Airtable view. Leave empty to sync all records.")
+      .addDropdown(async dropdown => {
+        try {
+          dropdown.addOption("", "-- All records (no view filter) --");
+          const views = await this.fieldCache.fetchViews(
+            this.plugin.settings.apiKey,
+            this.plugin.settings.baseId,
+            this.plugin.settings.tableId
+          );
+          for (const view of views) {
+            dropdown.addOption(view.id, `${view.name} (${view.type})`);
+          }
+          dropdown.setValue(this.plugin.settings.viewId);
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.viewId = value;
+            await this.plugin.saveSettings();
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Check table ID or network.';
+          new Notice(`Auto Note Importer: Failed to fetch views. ${message}`);
+        }
+      })
+      .addExtraButton(button => this.configureRefreshButton(button, "Refresh view list", () => {
+        this.fieldCache.clearViews(this.plugin.settings.baseId, this.plugin.settings.tableId);
+      }));
   }
 
   private renderFieldSelectors(containerEl: HTMLElement): void {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -148,6 +148,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           dropdown.onChange(async (value) => {
             this.plugin.settings.baseId = value;
             this.plugin.settings.tableId = "";
+            this.plugin.settings.viewId = "";
             await this.plugin.saveSettings();
             this.debounceDisplay();
           });

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -390,7 +390,7 @@ async function test(name, fn) {
         p.airtableClient.updateSettings(p.settings);
 
         return JSON.stringify({
-          pass: allCount >= viewCount && views.length > 0,
+          pass: views.length > 0 && allCount > 0 && allCount >= viewCount,
           detail: 'views=' + views.length + ', viewFiltered=' + viewCount + ', allRecords=' + allCount + ', selectedView=' + nonDefault.name,
           viewName: nonDefault.name
         });

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -345,6 +345,59 @@ async function test(name, fn) {
       return { pass: r.pass, detail: r.detail || 'ok' };
     });
 
+    await test('from-airtable / view filter', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+
+        // 1. Verify fetchViews returns available views
+        const views = await p.fieldCache.fetchViews(
+          p.settings.apiKey, p.settings.baseId, p.settings.tableId
+        );
+        if (!views || views.length === 0) {
+          return JSON.stringify({ pass: false, detail: 'No views found in table' });
+        }
+
+        // 2. Pick the first non-default view (Grid views are usually the default)
+        const nonDefault = views.find(v => v.name !== 'Grid view') || views[0];
+
+        // 3. Sync with view filter
+        const oldViewId = p.settings.viewId;
+        p.settings.viewId = nonDefault.id;
+        p.airtableClient.updateSettings(p.settings);
+
+        await p.syncQueue.enqueue('from-airtable', 'all');
+        await new Promise(r => setTimeout(r, 5000));
+        const viewFiles = app.vault.getFiles().filter(
+          f => f.path.startsWith(p.settings.folderPath + '/') && f.extension === 'md'
+        );
+        const viewCount = viewFiles.length;
+
+        // 4. Sync without view filter
+        p.settings.viewId = '';
+        p.airtableClient.updateSettings(p.settings);
+        p.settings.allowOverwrite = true;
+
+        await p.syncQueue.enqueue('from-airtable', 'all');
+        await new Promise(r => setTimeout(r, 5000));
+        const allFiles = app.vault.getFiles().filter(
+          f => f.path.startsWith(p.settings.folderPath + '/') && f.extension === 'md'
+        );
+        const allCount = allFiles.length;
+
+        // Restore
+        p.settings.viewId = oldViewId;
+        p.airtableClient.updateSettings(p.settings);
+
+        return JSON.stringify({
+          pass: allCount >= viewCount && views.length > 0,
+          detail: 'views=' + views.length + ', viewFiltered=' + viewCount + ', allRecords=' + allCount + ', selectedView=' + nonDefault.name,
+          viewName: nonDefault.name
+        });
+      })()`, 30000);
+      return { pass: r.pass, detail: r.detail || 'ok' };
+    });
+
     await test('from-airtable / current', async () => {
       const r = await run(`(async () => {
         ${HELPERS}

--- a/tests/services/airtable-client-view.test.ts
+++ b/tests/services/airtable-client-view.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for AirtableClient view parameter support.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AirtableClient } from '../../src/services/airtable-client';
+import type { AutoNoteImporterSettings } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { RateLimiter } from '../../src/services/rate-limiter';
+
+vi.mock('obsidian', () => ({
+  requestUrl: vi.fn(),
+}));
+
+import { requestUrl } from 'obsidian';
+
+const mockRequestUrl = vi.mocked(requestUrl);
+
+function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    apiKey: 'pat-test-key',
+    baseId: 'appTestBase',
+    tableId: 'tblTestTable',
+    ...overrides,
+  };
+}
+
+describe('AirtableClient view parameter', () => {
+  let rateLimiter: RateLimiter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimiter = new RateLimiter(0);
+  });
+
+  it('should not include view parameter when viewId is empty', async () => {
+    const settings = createSettings({ viewId: '' });
+    const client = new AirtableClient(settings, rateLimiter);
+
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: { records: [] },
+      headers: {},
+      text: '',
+      arrayBuffer: new ArrayBuffer(0),
+    });
+
+    await client.fetchNotes();
+
+    const calledUrl = mockRequestUrl.mock.calls[0][0].url;
+    expect(calledUrl).not.toContain('view=');
+  });
+
+  it('should include view parameter when viewId is set', async () => {
+    const settings = createSettings({ viewId: 'viwTestView123' });
+    const client = new AirtableClient(settings, rateLimiter);
+
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: { records: [] },
+      headers: {},
+      text: '',
+      arrayBuffer: new ArrayBuffer(0),
+    });
+
+    await client.fetchNotes();
+
+    const calledUrl = mockRequestUrl.mock.calls[0][0].url;
+    expect(calledUrl).toContain('view=viwTestView123');
+  });
+
+  it('should include both view and offset parameters during pagination', async () => {
+    const settings = createSettings({ viewId: 'viwTestView123' });
+    const client = new AirtableClient(settings, rateLimiter);
+
+    mockRequestUrl
+      .mockResolvedValueOnce({
+        status: 200,
+        json: {
+          records: [{ id: 'rec1', fields: { title: 'Note 1' } }],
+          offset: 'nextPage123',
+        },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: {
+          records: [{ id: 'rec2', fields: { title: 'Note 2' } }],
+        },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+    const notes = await client.fetchNotes();
+
+    expect(notes).toHaveLength(2);
+
+    // First call: view only
+    const firstUrl = mockRequestUrl.mock.calls[0][0].url;
+    expect(firstUrl).toContain('view=viwTestView123');
+    expect(firstUrl).not.toContain('offset=');
+
+    // Second call: view + offset
+    const secondUrl = mockRequestUrl.mock.calls[1][0].url;
+    expect(secondUrl).toContain('view=viwTestView123');
+    expect(secondUrl).toContain('offset=nextPage123');
+  });
+});


### PR DESCRIPTION
## Summary
- Airtable View 필터링 지원 추가 — 특정 View의 필터/정렬을 적용해 레코드 동기화
- Settings UI에 View 선택 드롭다운 추가 (테이블 선택 후 표시)
- FieldCache에 View 메타데이터 캐싱 기능 추가

## Changes
### Types
- `AutoNoteImporterSettings`에 `viewId` 필드 추가
- `AirtableView` 인터페이스 정의 및 export

### Services
- `AirtableClient.fetchNotes()`에 `?view=` 쿼리 파라미터 지원 (페이지네이션과 결합)
- `FieldCache`에 `fetchViews()` / `clearViews()` 메서드 추가

### UI
- Settings에 View 선택 드롭다운 (optional, 기본값: 전체 레코드)
- 테이블 변경 시 viewId 자동 초기화

### Tests
- 유닛 테스트 3건 (view 파라미터 유무, 페이지네이션 결합)
- E2E 테스트 골격 추가 (View 필터 셋업 후 활성화 예정)

## Test plan
- [x] `npm run build` — 빌드 통과
- [x] `npx vitest run` — 267 tests passed
- [ ] Airtable에서 View 선택 후 필터된 레코드만 동기화되는지 수동 확인

Closes #22