### PR TITLE
test: add comprehensive tests for sync pipeline modules

### DIFF
--- a/tests/__mocks__/obsidian.mock.ts
+++ b/tests/__mocks__/obsidian.mock.ts
@@ -53,7 +53,7 @@ export function createMockApp() {
           return createMockTFile(path);
         }
         if (folders.has(path)) {
-          return { path, children: [] };
+          return createMockTFolder(path);
         }
         return null;
       }),

--- a/tests/__mocks__/obsidian.mock.ts
+++ b/tests/__mocks__/obsidian.mock.ts
@@ -12,6 +12,80 @@ export const TFile = vi.fn();
 
 export const TFolder = vi.fn();
 
+export const MarkdownView = vi.fn();
+
+export const requestUrl = vi.fn();
+
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/$/, '');
+}
+
+/**
+ * Creates a mock TFile instance that passes instanceof checks.
+ */
+export function createMockTFile(path: string, extension = 'md') {
+  const name = path.split('/').pop() || '';
+  const basename = name.replace(/\.[^.]+$/, '');
+  const file = Object.create(TFile.prototype);
+  return Object.assign(file, { path, extension, name, basename });
+}
+
+/**
+ * Creates a mock TFolder instance that passes instanceof checks.
+ */
+export function createMockTFolder(path: string, children: unknown[] = []) {
+  const folder = Object.create(TFolder.prototype);
+  return Object.assign(folder, { path, children });
+}
+
+/**
+ * Creates a mock Obsidian App with vault operations.
+ */
+export function createMockApp() {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  const eventHandlers = new Map<string, ((...args: unknown[]) => void)[]>();
+
+  return {
+    vault: {
+      getAbstractFileByPath: vi.fn((path: string) => {
+        if (files.has(path)) {
+          return createMockTFile(path);
+        }
+        if (folders.has(path)) {
+          return { path, children: [] };
+        }
+        return null;
+      }),
+      read: vi.fn(async (file: { path: string }) => files.get(file.path) || ''),
+      create: vi.fn(async (path: string, content: string) => {
+        files.set(path, content);
+        return createMockTFile(path);
+      }),
+      modify: vi.fn(async (file: { path: string }, content: string) => {
+        files.set(file.path, content);
+      }),
+      createFolder: vi.fn(async (path: string) => {
+        folders.add(path);
+      }),
+      adapter: {
+        exists: vi.fn(async (path: string) => files.has(path) || folders.has(path)),
+      },
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        const handlers = eventHandlers.get(event) || [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+        return { event, handler };
+      }),
+      offref: vi.fn(),
+      getFiles: vi.fn(() => [...files.keys()].map(p => createMockTFile(p))),
+    },
+    workspace: {
+      getActiveViewOfType: vi.fn(() => null),
+    },
+    // Test helpers (not part of Obsidian API)
+    _files: files,
+    _folders: folders,
+    _eventHandlers: eventHandlers,
+  };
 }

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for SyncOrchestrator.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SyncOrchestrator } from '../../src/core/sync-orchestrator';
+import type { StatusBarHandle, StatusBarController } from '../../src/core/sync-orchestrator';
+import type { AutoNoteImporterSettings } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/types';
+// Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
+import { createMockApp, createMockTFile, createMockTFolder } from 'obsidian';
+import { createMockAirtableClient } from '../__mocks__/airtable-client.mock';
+import { FieldCache } from '../../src/services/field-cache';
+import { FrontmatterParser } from '../../src/file-operations/frontmatter-parser';
+import { FileWatcher } from '../../src/file-operations/file-watcher';
+import { ConflictResolver } from '../../src/core/conflict-resolver';
+import type { App } from 'obsidian';
+
+function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    apiKey: 'pat-test',
+    baseId: 'appTest',
+    tableId: 'tblTest',
+    folderPath: 'Sync',
+    bidirectionalSync: true,
+    ...overrides,
+  };
+}
+
+function createMockStatusBar(): StatusBarController & { lastItem: StatusBarHandle } {
+  const handle: StatusBarHandle = {
+    setText: vi.fn(),
+    remove: vi.fn(),
+  };
+  return {
+    createItem: vi.fn(() => handle),
+    lastItem: handle,
+  };
+}
+
+describe('SyncOrchestrator', () => {
+  let mockApp: ReturnType<typeof createMockApp>;
+  let mockClient: ReturnType<typeof createMockAirtableClient>;
+  let fieldCache: FieldCache;
+  let frontmatterParser: FrontmatterParser;
+  let fileWatcher: FileWatcher;
+  let conflictResolver: ConflictResolver;
+  let statusBar: ReturnType<typeof createMockStatusBar>;
+  let orchestrator: SyncOrchestrator;
+  let settings: AutoNoteImporterSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    settings = createSettings();
+    mockApp = createMockApp();
+    mockClient = createMockAirtableClient();
+    fieldCache = new FieldCache();
+    frontmatterParser = new FrontmatterParser(mockApp as unknown as App);
+    fileWatcher = new FileWatcher(mockApp as unknown as App, settings, vi.fn());
+    conflictResolver = new ConflictResolver(settings, mockClient as never);
+    statusBar = createMockStatusBar();
+
+    orchestrator = new SyncOrchestrator(
+      mockApp as unknown as App,
+      settings,
+      mockClient as never,
+      fieldCache,
+      frontmatterParser,
+      fileWatcher,
+      conflictResolver,
+      statusBar
+    );
+  });
+
+  describe('processSyncRequest — from-airtable', () => {
+    it('should create status bar item and remove it after sync', async () => {
+      mockClient.fetchNotes.mockResolvedValue([]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+
+      await orchestrator.processSyncRequest('from-airtable', 'all');
+
+      expect(statusBar.createItem).toHaveBeenCalledTimes(1);
+      expect(statusBar.lastItem.setText).toHaveBeenCalled();
+      expect(statusBar.lastItem.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create sync folder if it does not exist', async () => {
+      mockClient.fetchNotes.mockResolvedValue([]);
+      mockApp.vault.adapter.exists.mockResolvedValue(false);
+
+      await orchestrator.processSyncRequest('from-airtable', 'all');
+
+      expect(mockApp.vault.createFolder).toHaveBeenCalledWith('Sync');
+    });
+
+    it('should create notes from fetched records', async () => {
+      mockClient.fetchNotes.mockResolvedValue([
+        { id: 'rec1', primaryField: 'rec1', fields: { title: 'Note 1' } },
+      ]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+      await orchestrator.processSyncRequest('from-airtable', 'all');
+
+      expect(mockApp.vault.create).toHaveBeenCalled();
+    });
+
+    it('should set and clear syncing flag on fileWatcher', async () => {
+      mockClient.fetchNotes.mockResolvedValue([]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+
+      const setSyncingSpy = vi.spyOn(fileWatcher, 'setSyncing');
+      const clearPendingSpy = vi.spyOn(fileWatcher, 'clearPending');
+
+      await orchestrator.processSyncRequest('from-airtable', 'all');
+
+      expect(setSyncingSpy).toHaveBeenCalledWith(true);
+      expect(setSyncingSpy).toHaveBeenCalledWith(false);
+      expect(clearPendingSpy).toHaveBeenCalled();
+    });
+
+    it('should remove status bar even when sync throws', async () => {
+      mockClient.fetchNotes.mockRejectedValue(new Error('API down'));
+
+      await orchestrator.processSyncRequest('from-airtable', 'all');
+
+      expect(statusBar.lastItem.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('processSyncRequest — to-airtable', () => {
+    it('should notice when no files to sync', async () => {
+      mockApp.workspace.getActiveViewOfType.mockReturnValue(null);
+
+      await orchestrator.processSyncRequest('to-airtable', 'current');
+
+      // Error is caught and shown via Notice — status bar still cleaned up
+      expect(statusBar.lastItem.remove).toHaveBeenCalled();
+    });
+  });
+
+  describe('processSyncRequest — bidirectional', () => {
+    it('should execute two phases when autoSyncFormulas is true', async () => {
+      settings.autoSyncFormulas = true;
+      settings.formulaSyncDelay = 0;
+      orchestrator.updateSettings(settings);
+
+      const file = createMockTFile('Sync/note.md');
+      const folder = createMockTFolder('Sync', [file]);
+      mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
+        if (path === 'Sync') return folder;
+        return file;
+      });
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+
+      vi.spyOn(frontmatterParser, 'getRecordId').mockReturnValue('rec1');
+      vi.spyOn(frontmatterParser, 'extractSyncableFields').mockReturnValue({ Name: 'test' });
+      vi.spyOn(conflictResolver, 'shouldSkipConflictDetection').mockReturnValue(true);
+
+      mockClient.batchUpdate.mockResolvedValue([{ success: true, recordId: 'rec1', updatedFields: {} }]);
+      mockClient.fetchNotes.mockResolvedValue([]);
+
+      await orchestrator.processSyncRequest('bidirectional', 'all');
+
+      // Phase 1: push to Airtable
+      expect(mockClient.batchUpdate).toHaveBeenCalled();
+      // Phase 2: pull back
+      expect(mockClient.fetchNotes).toHaveBeenCalled();
+    });
+
+    it('should skip phase 2 when autoSyncFormulas is false', async () => {
+      settings.autoSyncFormulas = false;
+      orchestrator.updateSettings(settings);
+
+      const file = createMockTFile('Sync/note.md');
+      const folder = createMockTFolder('Sync', [file]);
+      mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
+        if (path === 'Sync') return folder;
+        return file;
+      });
+
+      vi.spyOn(frontmatterParser, 'getRecordId').mockReturnValue('rec1');
+      vi.spyOn(frontmatterParser, 'extractSyncableFields').mockReturnValue({ Name: 'test' });
+      vi.spyOn(conflictResolver, 'shouldSkipConflictDetection').mockReturnValue(true);
+
+      mockClient.batchUpdate.mockResolvedValue([{ success: true, recordId: 'rec1', updatedFields: {} }]);
+
+      await orchestrator.processSyncRequest('bidirectional', 'all');
+
+      expect(mockClient.batchUpdate).toHaveBeenCalled();
+      expect(mockClient.fetchNotes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processSyncRequest — scope: current', () => {
+    it('should sync current file from airtable', async () => {
+      const file = createMockTFile('Sync/note.md');
+      mockApp.workspace.getActiveViewOfType.mockReturnValue({ file });
+
+      vi.spyOn(frontmatterParser, 'getRecordId').mockReturnValue('rec1');
+
+      mockClient.fetchRecord.mockResolvedValue({
+        id: 'rec1', primaryField: 'rec1', fields: { title: 'Updated' },
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+      mockApp.vault.read.mockResolvedValue('old content');
+
+      await orchestrator.processSyncRequest('from-airtable', 'current');
+
+      expect(mockClient.fetchRecord).toHaveBeenCalledWith('rec1');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('should catch errors and show notice without throwing', async () => {
+      mockClient.fetchNotes.mockRejectedValue(new Error('Network error'));
+
+      // Should not throw
+      await expect(
+        orchestrator.processSyncRequest('from-airtable', 'all')
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -107,7 +107,7 @@ describe('SyncOrchestrator', () => {
       expect(mockApp.vault.create).toHaveBeenCalled();
     });
 
-    it('should set and clear syncing flag on fileWatcher', async () => {
+    it('should set and clear syncing flag on fileWatcher in correct order', async () => {
       mockClient.fetchNotes.mockResolvedValue([]);
       mockApp.vault.adapter.exists.mockResolvedValue(true);
 
@@ -116,22 +116,26 @@ describe('SyncOrchestrator', () => {
 
       await orchestrator.processSyncRequest('from-airtable', 'all');
 
-      expect(setSyncingSpy).toHaveBeenCalledWith(true);
-      expect(setSyncingSpy).toHaveBeenCalledWith(false);
+      expect(setSyncingSpy).toHaveBeenNthCalledWith(1, true);
+      expect(setSyncingSpy).toHaveBeenNthCalledWith(2, false);
       expect(clearPendingSpy).toHaveBeenCalled();
     });
 
-    it('should remove status bar even when sync throws', async () => {
+    it('should remove status bar and reset syncing even when sync throws', async () => {
       mockClient.fetchNotes.mockRejectedValue(new Error('API down'));
+
+      const setSyncingSpy = vi.spyOn(fileWatcher, 'setSyncing');
 
       await orchestrator.processSyncRequest('from-airtable', 'all');
 
       expect(statusBar.lastItem.remove).toHaveBeenCalledTimes(1);
+      // setSyncing(false) must be called even on error (via finally block in syncFromAirtable)
+      expect(setSyncingSpy).toHaveBeenCalledWith(false);
     });
   });
 
   describe('processSyncRequest — to-airtable', () => {
-    it('should notice when no files to sync', async () => {
+    it('should clean up status bar when active file is missing', async () => {
       mockApp.workspace.getActiveViewOfType.mockReturnValue(null);
 
       await orchestrator.processSyncRequest('to-airtable', 'current');

--- a/tests/file-operations/file-watcher.test.ts
+++ b/tests/file-operations/file-watcher.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FileWatcher } from '../../src/file-operations/file-watcher';
 import type { AutoNoteImporterSettings } from '../../src/types';
 import { DEFAULT_SETTINGS } from '../../src/types';
+import { DEBUG_DELAY_MULTIPLIER } from '../../src/constants';
 // Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
 import { createMockApp, createMockTFile } from 'obsidian';
 import type { App } from 'obsidian';
@@ -19,6 +20,15 @@ function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): Auto
     fileWatchDebounce: 100,
     ...overrides,
   };
+}
+
+/**
+ * Extracts the 'modify' event handler registered via vault.on().
+ */
+function getModifyHandler(mockApp: ReturnType<typeof createMockApp>): (...args: unknown[]) => void {
+  const call = mockApp.vault.on.mock.calls.find(([event]) => event === 'modify');
+  if (!call) throw new Error('No modify handler registered');
+  return call[1];
 }
 
 describe('FileWatcher', () => {
@@ -92,7 +102,7 @@ describe('FileWatcher', () => {
       mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
 
       // Simulate file modify event
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
 
       // Should not fire immediately
@@ -109,7 +119,7 @@ describe('FileWatcher', () => {
       watcher.setup();
 
       const file = createMockTFile('OtherFolder/note.md');
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
 
       await vi.advanceTimersByTimeAsync(200);
@@ -123,7 +133,7 @@ describe('FileWatcher', () => {
       watcher.setSyncing(true);
 
       const file = createMockTFile('Sync/note1.md');
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
 
       await vi.advanceTimersByTimeAsync(200);
@@ -143,7 +153,7 @@ describe('FileWatcher', () => {
         .mockReturnValueOnce(file1)
         .mockReturnValueOnce(file2);
 
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file1);
 
       await vi.advanceTimersByTimeAsync(50);
@@ -162,15 +172,17 @@ describe('FileWatcher', () => {
       const file = createMockTFile('Sync/note1.md');
       mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
 
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
+
+      const debugDebounce = 100 * DEBUG_DELAY_MULTIPLIER;
 
       // Should not fire after normal debounce
       await vi.advanceTimersByTimeAsync(100);
       expect(onFilesReady).not.toHaveBeenCalled();
 
-      // Should fire after debug multiplied debounce (100 * 5 = 500ms)
-      await vi.advanceTimersByTimeAsync(400);
+      // Should fire after debug multiplied debounce
+      await vi.advanceTimersByTimeAsync(debugDebounce - 100);
       expect(onFilesReady).toHaveBeenCalledTimes(1);
     });
   });
@@ -195,7 +207,7 @@ describe('FileWatcher', () => {
       const file = createMockTFile('Sync/note1.md');
       mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
 
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
 
       const pending = watcher.getPendingFiles();
@@ -214,7 +226,7 @@ describe('FileWatcher', () => {
       watcher.updateSettings(createSettings({ folderPath: 'NewFolder' }));
 
       const file = createMockTFile('Sync/note1.md');
-      const handler = mockApp.vault.on.mock.calls[0][1];
+      const handler = getModifyHandler(mockApp);
       handler(file);
 
       await vi.advanceTimersByTimeAsync(200);

--- a/tests/file-operations/file-watcher.test.ts
+++ b/tests/file-operations/file-watcher.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for FileWatcher service.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FileWatcher } from '../../src/file-operations/file-watcher';
+import type { AutoNoteImporterSettings } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/types';
+// Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
+import { createMockApp, createMockTFile } from 'obsidian';
+import type { App } from 'obsidian';
+
+function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    folderPath: 'Sync',
+    bidirectionalSync: true,
+    watchForChanges: true,
+    fileWatchDebounce: 100,
+    ...overrides,
+  };
+}
+
+describe('FileWatcher', () => {
+  let mockApp: ReturnType<typeof createMockApp>;
+  let onFilesReady: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockApp = createMockApp();
+    onFilesReady = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('setup', () => {
+    it('should register vault modify listener when bidirectional + watchForChanges', () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      expect(mockApp.vault.on).toHaveBeenCalledWith('modify', expect.any(Function));
+    });
+
+    it('should not register listener when bidirectionalSync is false', () => {
+      const watcher = new FileWatcher(
+        mockApp as unknown as App,
+        createSettings({ bidirectionalSync: false }),
+        onFilesReady
+      );
+      watcher.setup();
+
+      expect(mockApp.vault.on).not.toHaveBeenCalled();
+    });
+
+    it('should not register listener when watchForChanges is false', () => {
+      const watcher = new FileWatcher(
+        mockApp as unknown as App,
+        createSettings({ watchForChanges: false }),
+        onFilesReady
+      );
+      watcher.setup();
+
+      expect(mockApp.vault.on).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('teardown', () => {
+    it('should unregister event listener and clear timer', () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      watcher.teardown();
+
+      expect(mockApp.vault.offref).toHaveBeenCalled();
+    });
+
+    it('should be safe to call teardown without setup', () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      expect(() => watcher.teardown()).not.toThrow();
+    });
+  });
+
+  describe('file change handling', () => {
+    it('should debounce file changes and call onFilesReady', async () => {
+      const settings = createSettings({ fileWatchDebounce: 100 });
+      const watcher = new FileWatcher(mockApp as unknown as App, settings, onFilesReady);
+      watcher.setup();
+
+      const file = createMockTFile('Sync/note1.md');
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+
+      // Simulate file modify event
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      // Should not fire immediately
+      expect(onFilesReady).not.toHaveBeenCalled();
+
+      // After debounce
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onFilesReady).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore files outside sync folder', async () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      const file = createMockTFile('OtherFolder/note.md');
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(onFilesReady).not.toHaveBeenCalled();
+    });
+
+    it('should ignore changes while syncing (external)', async () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      watcher.setSyncing(true);
+
+      const file = createMockTFile('Sync/note1.md');
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(onFilesReady).not.toHaveBeenCalled();
+
+      watcher.setSyncing(false);
+    });
+
+    it('should merge multiple rapid changes via debounce', async () => {
+      const settings = createSettings({ fileWatchDebounce: 100 });
+      const watcher = new FileWatcher(mockApp as unknown as App, settings, onFilesReady);
+      watcher.setup();
+
+      const file1 = createMockTFile('Sync/note1.md');
+      const file2 = createMockTFile('Sync/note2.md');
+      mockApp.vault.getAbstractFileByPath
+        .mockReturnValueOnce(file1)
+        .mockReturnValueOnce(file2);
+
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file1);
+
+      await vi.advanceTimersByTimeAsync(50);
+      handler(file2);
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onFilesReady).toHaveBeenCalledTimes(1);
+    });
+
+    it('should apply debug mode multiplier to debounce', async () => {
+      const settings = createSettings({ fileWatchDebounce: 100, debugMode: true });
+      const watcher = new FileWatcher(mockApp as unknown as App, settings, onFilesReady);
+      watcher.setup();
+
+      const file = createMockTFile('Sync/note1.md');
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      // Should not fire after normal debounce
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onFilesReady).not.toHaveBeenCalled();
+
+      // Should fire after debug multiplied debounce (100 * 5 = 500ms)
+      await vi.advanceTimersByTimeAsync(400);
+      expect(onFilesReady).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('syncing state', () => {
+    it('should track external syncing state', () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+
+      expect(watcher.syncing).toBe(false);
+      watcher.setSyncing(true);
+      expect(watcher.syncing).toBe(true);
+      watcher.setSyncing(false);
+      expect(watcher.syncing).toBe(false);
+    });
+  });
+
+  describe('getPendingFiles / clearPending', () => {
+    it('should return pending files and clear them', async () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      const file = createMockTFile('Sync/note1.md');
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      const pending = watcher.getPendingFiles();
+      expect(pending).toHaveLength(1);
+
+      watcher.clearPending();
+      expect(watcher.getPendingFiles()).toHaveLength(0);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should use updated settings', async () => {
+      const watcher = new FileWatcher(mockApp as unknown as App, createSettings(), onFilesReady);
+      watcher.setup();
+
+      watcher.updateSettings(createSettings({ folderPath: 'NewFolder' }));
+
+      const file = createMockTFile('Sync/note1.md');
+      const handler = mockApp.vault.on.mock.calls[0][1];
+      handler(file);
+
+      await vi.advanceTimersByTimeAsync(200);
+      // File is in old folder 'Sync', not 'NewFolder' — should be ignored
+      expect(onFilesReady).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/services/airtable-client.test.ts
+++ b/tests/services/airtable-client.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for AirtableClient service.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AirtableClient } from '../../src/services/airtable-client';
+import type { AutoNoteImporterSettings } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { AIRTABLE_BATCH_SIZE } from '../../src/constants';
+import { RateLimiter } from '../../src/services/rate-limiter';
+import { requestUrl } from 'obsidian';
+
+const mockRequestUrl = vi.mocked(requestUrl);
+
+function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    apiKey: 'pat-test',
+    baseId: 'appTest',
+    tableId: 'tblTest',
+    ...overrides,
+  };
+}
+
+function mockResponse(json: unknown, status = 200) {
+  return { status, json, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0) };
+}
+
+describe('AirtableClient', () => {
+  let client: AirtableClient;
+  let rateLimiter: RateLimiter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimiter = new RateLimiter(0);
+    client = new AirtableClient(createSettings(), rateLimiter);
+  });
+
+  describe('validateSettings', () => {
+    it('should throw when apiKey is missing', async () => {
+      client = new AirtableClient(createSettings({ apiKey: '' }), rateLimiter);
+      await expect(client.fetchNotes()).rejects.toThrow('API key, base ID, and table ID must be set');
+    });
+
+    it('should throw when baseId is missing', async () => {
+      client = new AirtableClient(createSettings({ baseId: '' }), rateLimiter);
+      await expect(client.fetchNotes()).rejects.toThrow('API key, base ID, and table ID must be set');
+    });
+
+    it('should throw when tableId is missing', async () => {
+      client = new AirtableClient(createSettings({ tableId: '' }), rateLimiter);
+      await expect(client.fetchNotes()).rejects.toThrow('API key, base ID, and table ID must be set');
+    });
+  });
+
+  describe('fetchNotes', () => {
+    it('should fetch all records without pagination', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse({
+        records: [
+          { id: 'rec1', fields: { Name: 'Note 1' } },
+          { id: 'rec2', fields: { Name: 'Note 2' } },
+        ],
+      }));
+
+      const notes = await client.fetchNotes();
+      expect(notes).toHaveLength(2);
+      expect(notes[0]).toEqual({ id: 'rec1', primaryField: 'rec1', fields: { Name: 'Note 1' } });
+    });
+
+    it('should handle pagination with offset', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockResponse({
+          records: [{ id: 'rec1', fields: {} }],
+          offset: 'page2',
+        }))
+        .mockResolvedValueOnce(mockResponse({
+          records: [{ id: 'rec2', fields: {} }],
+          offset: 'page3',
+        }))
+        .mockResolvedValueOnce(mockResponse({
+          records: [{ id: 'rec3', fields: {} }],
+        }));
+
+      const notes = await client.fetchNotes();
+      expect(notes).toHaveLength(3);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(3);
+
+      // Verify offset is passed in URL
+      const secondUrl = mockRequestUrl.mock.calls[1][0].url;
+      expect(secondUrl).toContain('offset=page2');
+    });
+
+    it('should throw on non-200 response', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse(
+        { error: { message: 'Not authorized' } }, 401
+      ));
+
+      await expect(client.fetchNotes()).rejects.toThrow('Failed to fetch remote notes');
+    });
+  });
+
+  describe('fetchRecord', () => {
+    it('should fetch a single record', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse({
+        id: 'rec123', fields: { Name: 'Test' },
+      }));
+
+      const note = await client.fetchRecord('rec123');
+      expect(note).toEqual({ id: 'rec123', primaryField: 'rec123', fields: { Name: 'Test' } });
+    });
+
+    it('should return null for 404', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse({}, 404));
+
+      const note = await client.fetchRecord('recMissing');
+      expect(note).toBeNull();
+    });
+
+    it('should throw on invalid record ID', async () => {
+      await expect(client.fetchRecord('invalid')).rejects.toThrow('Invalid Airtable record ID');
+    });
+
+    it('should throw on empty record ID', async () => {
+      await expect(client.fetchRecord('')).rejects.toThrow('Invalid Airtable record ID');
+    });
+  });
+
+  describe('updateRecord', () => {
+    it('should return success result on 200', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse({
+        id: 'rec123', fields: { Name: 'Updated' },
+      }));
+
+      const result = await client.updateRecord('rec123', { Name: 'Updated' });
+      expect(result).toEqual({
+        success: true,
+        recordId: 'rec123',
+        updatedFields: { Name: 'Updated' },
+      });
+    });
+
+    it('should return failure result on non-200', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse(
+        { error: { message: 'Field not found' } }, 422
+      ));
+
+      const result = await client.updateRecord('rec123', { Bad: 'field' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('Failed to update');
+      }
+    });
+
+    it('should catch thrown errors and return failure', async () => {
+      mockRequestUrl.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await client.updateRecord('rec123', {});
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Network error');
+      }
+    });
+  });
+
+  describe('batchUpdate', () => {
+    it('should return empty array for no updates', async () => {
+      const results = await client.batchUpdate([]);
+      expect(results).toEqual([]);
+    });
+
+    it('should batch update records', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse({
+        records: [
+          { id: 'rec1', fields: { Name: 'A' } },
+          { id: 'rec2', fields: { Name: 'B' } },
+        ],
+      }));
+
+      const results = await client.batchUpdate([
+        { recordId: 'rec1', fields: { Name: 'A' } },
+        { recordId: 'rec2', fields: { Name: 'B' } },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({ success: true, recordId: 'rec1', updatedFields: { Name: 'A' } });
+    });
+
+    it('should throw when exceeding batch size', async () => {
+      const updates = Array.from({ length: AIRTABLE_BATCH_SIZE + 1 }, (_, i) => ({
+        recordId: `rec${i}`,
+        fields: {},
+      }));
+
+      await expect(client.batchUpdate(updates))
+        .rejects.toThrow(`Maximum ${AIRTABLE_BATCH_SIZE} records allowed`);
+    });
+
+    it('should return failure for all records on non-200', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockResponse(
+        { error: { message: 'Server error' } }, 500
+      ));
+
+      const results = await client.batchUpdate([
+        { recordId: 'rec1', fields: {} },
+        { recordId: 'rec2', fields: {} },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results.every(r => !r.success)).toBe(true);
+    });
+
+    it('should return failure for all records on thrown error', async () => {
+      mockRequestUrl.mockRejectedValueOnce(new Error('Connection lost'));
+
+      const results = await client.batchUpdate([
+        { recordId: 'rec1', fields: {} },
+      ]);
+
+      expect(results[0].success).toBe(false);
+      if (!results[0].success) {
+        expect(results[0].error).toBe('Connection lost');
+      }
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should use updated settings for subsequent calls', async () => {
+      mockRequestUrl.mockResolvedValue(mockResponse({ records: [] }));
+
+      await client.fetchNotes();
+      const firstUrl = mockRequestUrl.mock.calls[0][0].url;
+      expect(firstUrl).toContain('appTest/tblTest');
+
+      client.updateSettings(createSettings({ baseId: 'appNew', tableId: 'tblNew' }));
+      await client.fetchNotes();
+      const secondUrl = mockRequestUrl.mock.calls[1][0].url;
+      expect(secondUrl).toContain('appNew/tblNew');
+    });
+  });
+});

--- a/tests/services/field-cache.test.ts
+++ b/tests/services/field-cache.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for FieldCache service.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FieldCache } from '../../src/services/field-cache';
+import { requestUrl } from 'obsidian';
+
+const mockRequestUrl = vi.mocked(requestUrl);
+
+function mockTablesResponse(tables: { id: string; name: string; fields?: unknown[]; views?: unknown[] }[]) {
+  return {
+    status: 200,
+    json: { tables },
+    headers: {},
+    text: '',
+    arrayBuffer: new ArrayBuffer(0),
+  };
+}
+
+function mockBasesResponse(bases: { id: string; name: string }[]) {
+  return {
+    status: 200,
+    json: { bases },
+    headers: {},
+    text: '',
+    arrayBuffer: new ArrayBuffer(0),
+  };
+}
+
+describe('FieldCache', () => {
+  let cache: FieldCache;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache = new FieldCache();
+  });
+
+  describe('fetchBases', () => {
+    it('should fetch and cache bases', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockBasesResponse([
+        { id: 'app1', name: 'Base 1' },
+        { id: 'app2', name: 'Base 2' },
+      ]));
+
+      const bases = await cache.fetchBases('pat-key');
+      expect(bases).toHaveLength(2);
+      expect(bases[0]).toEqual({ id: 'app1', name: 'Base 1' });
+
+      // Second call should use cache
+      const cached = await cache.fetchBases('pat-key');
+      expect(cached).toEqual(bases);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear cache when API key changes', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app1', name: 'Base 1' }]))
+        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app2', name: 'Base 2' }]));
+
+      await cache.fetchBases('key-1');
+      const bases = await cache.fetchBases('key-2');
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+      expect(bases[0].id).toBe('app2');
+    });
+
+    it('should throw on non-200 response', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 401, json: {}, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0),
+      });
+
+      await expect(cache.fetchBases('bad-key')).rejects.toThrow('HTTP 401');
+    });
+  });
+
+  describe('fetchTables', () => {
+    it('should fetch and cache tables', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockTablesResponse([
+        { id: 'tbl1', name: 'Table 1' },
+        { id: 'tbl2', name: 'Table 2' },
+      ]));
+
+      const tables = await cache.fetchTables('pat-key', 'app1');
+      expect(tables).toHaveLength(2);
+
+      // Cache hit
+      await cache.fetchTables('pat-key', 'app1');
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetchFields and fetchViews (shared metadata)', () => {
+    const tablesResponse = mockTablesResponse([{
+      id: 'tbl1',
+      name: 'Table 1',
+      fields: [
+        { id: 'fld1', name: 'Name', type: 'singleLineText' },
+        { id: 'fld2', name: 'Count', type: 'number' },
+      ],
+      views: [
+        { id: 'viw1', name: 'Grid view', type: 'grid' },
+        { id: 'viw2', name: 'Kanban', type: 'kanban' },
+      ],
+    }]);
+
+    it('should fetch fields and populate views cache in one API call', async () => {
+      mockRequestUrl.mockResolvedValueOnce(tablesResponse);
+
+      const fields = await cache.fetchFields('pat-key', 'app1', 'tbl1');
+      expect(fields).toHaveLength(2);
+      expect(fields[0]).toEqual({ id: 'fld1', name: 'Name', type: 'singleLineText', description: undefined });
+
+      // Views should now be cached (no extra API call)
+      const views = await cache.fetchViews('pat-key', 'app1', 'tbl1');
+      expect(views).toHaveLength(2);
+      expect(views[1]).toEqual({ id: 'viw2', name: 'Kanban', type: 'kanban' });
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch views and populate fields cache in one API call', async () => {
+      mockRequestUrl.mockResolvedValueOnce(tablesResponse);
+
+      const views = await cache.fetchViews('pat-key', 'app1', 'tbl1');
+      expect(views).toHaveLength(2);
+
+      // Fields should now be cached
+      const fields = await cache.fetchFields('pat-key', 'app1', 'tbl1');
+      expect(fields).toHaveLength(2);
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when table not found', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockTablesResponse([
+        { id: 'tbl99', name: 'Other' },
+      ]));
+
+      await expect(cache.fetchFields('pat-key', 'app1', 'tblMissing'))
+        .rejects.toThrow('Table with ID tblMissing not found');
+    });
+
+    it('should handle tables with no views', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockTablesResponse([{
+        id: 'tbl1',
+        name: 'Table 1',
+        fields: [{ id: 'fld1', name: 'Name', type: 'singleLineText' }],
+      }]));
+
+      const views = await cache.fetchViews('pat-key', 'app1', 'tbl1');
+      expect(views).toEqual([]);
+    });
+  });
+
+  describe('cache invalidation', () => {
+    it('clearBases should clear all caches', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app1', name: 'B' }]))
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T', fields: [{ id: 'f1', name: 'N', type: 'text' }], views: [],
+        }]))
+        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app1', name: 'B' }]))
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T', fields: [{ id: 'f1', name: 'N', type: 'text' }], views: [],
+        }]));
+
+      await cache.fetchBases('key');
+      await cache.fetchFields('key', 'app1', 'tbl1');
+
+      cache.clearBases();
+
+      await cache.fetchBases('key');
+      await cache.fetchFields('key', 'app1', 'tbl1');
+      expect(mockRequestUrl).toHaveBeenCalledTimes(4);
+    });
+
+    it('clearTables should clear fields and views for that base', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T',
+          fields: [{ id: 'f1', name: 'N', type: 'text' }],
+          views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+        }]))
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T',
+          fields: [{ id: 'f1', name: 'N', type: 'text' }],
+          views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+        }]));
+
+      await cache.fetchFields('key', 'app1', 'tbl1');
+      cache.clearTables('app1');
+      await cache.fetchViews('key', 'app1', 'tbl1');
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearFields should only clear fields for specific table', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockTablesResponse([{
+        id: 'tbl1', name: 'T',
+        fields: [{ id: 'f1', name: 'N', type: 'text' }],
+        views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+      }]));
+
+      await cache.fetchFields('key', 'app1', 'tbl1');
+
+      // Views should be cached
+      const views = await cache.fetchViews('key', 'app1', 'tbl1');
+      expect(views).toHaveLength(1);
+
+      // Clear fields only
+      cache.clearFields('app1', 'tbl1');
+
+      // Views should still be cached
+      const viewsAfter = await cache.fetchViews('key', 'app1', 'tbl1');
+      expect(viewsAfter).toHaveLength(1);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearViews should only clear views for specific table', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T',
+          fields: [{ id: 'f1', name: 'N', type: 'text' }],
+          views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+        }]))
+        .mockResolvedValueOnce(mockTablesResponse([{
+          id: 'tbl1', name: 'T',
+          fields: [{ id: 'f1', name: 'N', type: 'text' }],
+          views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+        }]));
+
+      await cache.fetchViews('key', 'app1', 'tbl1');
+      cache.clearViews('app1', 'tbl1');
+
+      // Fields should still be cached, views need refetch
+      await cache.fetchViews('key', 'app1', 'tbl1');
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getField', () => {
+    it('should find field by name from cache', async () => {
+      mockRequestUrl.mockResolvedValueOnce(mockTablesResponse([{
+        id: 'tbl1', name: 'T',
+        fields: [
+          { id: 'f1', name: 'Name', type: 'singleLineText' },
+          { id: 'f2', name: 'Count', type: 'number' },
+        ],
+        views: [],
+      }]));
+
+      await cache.fetchFields('key', 'app1', 'tbl1');
+      const field = cache.getField('app1-tbl1', 'Count');
+      expect(field?.type).toBe('number');
+    });
+
+    it('should return undefined for unknown field', () => {
+      const field = cache.getField('app1-tbl1', 'Unknown');
+      expect(field).toBeUndefined();
+    });
+  });
+});

--- a/tests/services/field-cache.test.ts
+++ b/tests/services/field-cache.test.ts
@@ -251,12 +251,12 @@ describe('FieldCache', () => {
       }]));
 
       await cache.fetchFields('key', 'app1', 'tbl1');
-      const field = cache.getField('app1-tbl1', 'Count');
+      const field = cache.getField(cache.getCacheKey('app1', 'tbl1'), 'Count');
       expect(field?.type).toBe('number');
     });
 
     it('should return undefined for unknown field', () => {
-      const field = cache.getField('app1-tbl1', 'Unknown');
+      const field = cache.getField(cache.getCacheKey('app1', 'tbl1'), 'Unknown');
       expect(field).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary
- 미커버 모듈 4개(SyncOrchestrator, AirtableClient, FileWatcher, FieldCache)에 대한 테스트 56건 추가
- Obsidian mock 인프라 확장 (createMockApp, createMockTFile, createMockTFolder)
- 267 → 323 tests

## Changes
### Mock Infrastructure (`tests/__mocks__/obsidian.mock.ts`)
- `createMockApp()`: vault 연산(read/create/modify/getAbstractFileByPath), workspace, event system
- `createMockTFile()` / `createMockTFolder()`: `instanceof` 체크를 통과하는 mock 인스턴스
- `requestUrl`, `MarkdownView` export 추가

### New Test Files
| File | Tests | Coverage |
|:---|:---|:---|
| `airtable-client.test.ts` | 19 | 설정 검증, fetchNotes 페이지네이션, fetchRecord 404, batchUpdate 청킹/에러 |
| `field-cache.test.ts` | 14 | 캐시 hit/miss, 공유 메타데이터(fields+views 단일 호출), 계층적 무효화 |
| `file-watcher.test.ts` | 13 | 디바운스 타이밍, syncing 플래그, 폴더 외 무시, debug 모드 배수 |
| `sync-orchestrator.test.ts` | 10 | from/to/bidirectional 모드, StatusBar 라이프사이클, 에러 전파 |

## Test plan
- [x] `npm run build` — 빌드 통과
- [x] `npx vitest run` — 323 tests passed (56 new)
- [x] `bash tests/e2e/start-e2e.sh --cleanup` — E2E 13/13 passed

Closes #39