### PR TITLE
feat: multi-base/table configuration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test": "vitest",
 		"test:run": "vitest run",
 		"test:e2e": "node tests/e2e/run-e2e.mjs --cleanup",
+		"test:e2e:settings": "node tests/e2e/run-settings-e2e.mjs",
 		"test:e2e:full": "bash tests/e2e/start-e2e.sh --cleanup"
 	},
 	"keywords": [

--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -9,7 +9,7 @@
 
 import type { App } from "obsidian";
 import { Notice } from "obsidian";
-import type { AutoNoteImporterSettings, SyncMode, SyncScope, ConfigEntry, Credential, SharedServices } from '../types';
+import type { LegacySettings, SyncMode, SyncScope, ConfigEntry, Credential, SharedServices } from '../types';
 import { AirtableClient, RateLimiter } from '../services';
 import { SyncQueue, ConflictResolver, SyncOrchestrator } from '../core';
 import type { StatusBarController, StatusBarHandle } from './sync-orchestrator';
@@ -17,18 +17,18 @@ import { FileWatcher } from '../file-operations';
 
 /**
  * Merges a ConfigEntry with credential and debug info to produce
- * an object structurally compatible with AutoNoteImporterSettings.
+ * an object structurally compatible with LegacySettings.
  */
 function buildSettingsFromConfig(
   config: ConfigEntry,
   credential: Credential,
   debugMode: boolean,
-): AutoNoteImporterSettings {
+): LegacySettings {
   return {
     ...config,
     apiKey: credential.apiKey,
     debugMode,
-  } as AutoNoteImporterSettings;
+  } as LegacySettings;
 }
 
 /**
@@ -39,7 +39,7 @@ export class ConfigInstance {
 
   private app: App;
   private shared: SharedServices;
-  private settings: AutoNoteImporterSettings;
+  private settings: LegacySettings;
 
   private rateLimiter: RateLimiter;
   private airtableClient: AirtableClient;

--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -1,0 +1,205 @@
+/**
+ * ConfigInstance owns the full service stack for one config entry.
+ *
+ * Creates and manages: DatabaseClient, FileWatcher, SyncOrchestrator,
+ * SyncQueue, ConflictResolver, and a per-config sync scheduler.
+ *
+ * @handbook 9.2-service-initialization-order
+ */
+
+import type { App } from "obsidian";
+import { Notice } from "obsidian";
+import type { AutoNoteImporterSettings, SyncMode, SyncScope, ConfigEntry, Credential, SharedServices } from '../types';
+import { AirtableClient, RateLimiter } from '../services';
+import { SyncQueue, ConflictResolver, SyncOrchestrator } from '../core';
+import type { StatusBarController, StatusBarHandle } from './sync-orchestrator';
+import { FileWatcher } from '../file-operations';
+
+/**
+ * Merges a ConfigEntry with credential and debug info to produce
+ * an object structurally compatible with AutoNoteImporterSettings.
+ */
+function buildSettingsFromConfig(
+  config: ConfigEntry,
+  credential: Credential,
+  debugMode: boolean,
+): AutoNoteImporterSettings {
+  return {
+    ...config,
+    apiKey: credential.apiKey,
+    debugMode,
+  } as AutoNoteImporterSettings;
+}
+
+/**
+ * Manages the full service stack for a single configuration entry.
+ */
+export class ConfigInstance {
+  readonly configId: string;
+
+  private app: App;
+  private shared: SharedServices;
+  private settings: AutoNoteImporterSettings;
+
+  private rateLimiter: RateLimiter;
+  private airtableClient: AirtableClient;
+  private conflictResolver: ConflictResolver;
+  private fileWatcher: FileWatcher;
+  private syncOrchestrator: SyncOrchestrator;
+  private syncQueue: SyncQueue;
+
+  private schedulerIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(app: App, config: ConfigEntry, credential: Credential, shared: SharedServices) {
+    this.configId = config.id;
+    this.app = app;
+    this.shared = shared;
+    this.settings = buildSettingsFromConfig(config, credential, shared.getDebugMode());
+
+    // 1. Get or create RateLimiter (shared per credential)
+    this.rateLimiter = this.getOrCreateRateLimiter(credential.id);
+
+    // 2. Create AirtableClient
+    this.airtableClient = new AirtableClient(this.settings, this.rateLimiter);
+
+    // 3. Create ConflictResolver
+    this.conflictResolver = new ConflictResolver(this.settings, this.airtableClient);
+
+    // 4. Create FileWatcher (callback captures syncQueue via closure — safe because
+    //    setup() is called after syncQueue is assigned, and callbacks fire asynchronously)
+    this.fileWatcher = new FileWatcher(
+      this.app,
+      this.settings,
+      async (files) => {
+        const mode: SyncMode = this.settings.autoSyncFormulas ? 'bidirectional' : 'to-airtable';
+        await this.syncQueue.enqueue(mode, 'modified', files.map(f => f.path));
+      }
+    );
+
+    // 5. Create SyncOrchestrator
+    const statusBar: StatusBarController = {
+      createItem: (): StatusBarHandle => {
+        const el = this.shared.statusBarFactory();
+        return {
+          setText(text: string) { el.textContent = text; },
+          remove() { el.remove(); },
+        };
+      },
+    };
+
+    this.syncOrchestrator = new SyncOrchestrator(
+      this.app,
+      this.settings,
+      this.airtableClient,
+      this.shared.fieldCache,
+      this.shared.frontmatterParser,
+      this.fileWatcher,
+      this.conflictResolver,
+      statusBar,
+    );
+
+    // 6. Create SyncQueue
+    this.syncQueue = new SyncQueue(
+      ({ mode, scope, filePaths }) => this.syncOrchestrator.processSyncRequest(mode, scope, filePaths),
+      (error) => {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        new Notice(`Auto Note Importer: Sync failed: ${message}`);
+      }
+    );
+
+    // 7. Setup file watcher and scheduler if enabled
+    if (config.enabled) {
+      this.fileWatcher.setup();
+      this.startScheduler(config);
+    }
+  }
+
+  /**
+   * Returns whether the periodic sync scheduler is currently active.
+   */
+  isSchedulerActive(): boolean {
+    return this.schedulerIntervalId !== null;
+  }
+
+  /**
+   * Enqueues a sync request for this config's queue.
+   */
+  enqueueSyncRequest(mode: SyncMode, scope: SyncScope, filePaths?: string[]): void {
+    this.syncQueue.enqueue(mode, scope, filePaths);
+  }
+
+  /**
+   * Updates all services with new config and credential.
+   */
+  updateSettings(config: ConfigEntry, credential: Credential): void {
+    this.settings = buildSettingsFromConfig(config, credential, this.shared.getDebugMode());
+
+    // Update RateLimiter if credential changed
+    const newRateLimiter = this.getOrCreateRateLimiter(credential.id);
+    if (newRateLimiter !== this.rateLimiter) {
+      this.rateLimiter = newRateLimiter;
+    }
+    this.rateLimiter.setDebugMode(this.shared.getDebugMode());
+
+    // Propagate settings to all services
+    this.airtableClient.updateSettings(this.settings);
+    this.conflictResolver.updateSettings(this.settings);
+    this.syncOrchestrator.updateSettings(this.settings);
+
+    // Reconfigure file watcher
+    this.fileWatcher.teardown();
+    this.fileWatcher.updateSettings(this.settings);
+    if (config.enabled) {
+      this.fileWatcher.setup();
+    }
+
+    // Restart scheduler
+    this.stopScheduler();
+    if (config.enabled) {
+      this.startScheduler(config);
+    }
+  }
+
+  /**
+   * Tears down all services and clears the scheduler.
+   */
+  destroy(): void {
+    this.stopScheduler();
+    this.fileWatcher.teardown();
+  }
+
+  /**
+   * Gets or creates a shared RateLimiter for the given credential.
+   */
+  private getOrCreateRateLimiter(credentialId: string): RateLimiter {
+    let limiter = this.shared.rateLimiters.get(credentialId);
+    if (!limiter) {
+      limiter = new RateLimiter();
+      limiter.setDebugMode(this.shared.getDebugMode());
+      this.shared.rateLimiters.set(credentialId, limiter);
+    }
+    return limiter;
+  }
+
+  /**
+   * Starts the periodic sync scheduler if interval > 0.
+   */
+  private startScheduler(config: ConfigEntry): void {
+    if (config.syncInterval > 0) {
+      this.schedulerIntervalId = setInterval(
+        () => this.syncQueue.enqueue('from-airtable', 'all'),
+        config.syncInterval * 60 * 1000,
+      );
+    }
+  }
+
+  /**
+   * Stops the periodic sync scheduler.
+   */
+  private stopScheduler(): void {
+    if (this.schedulerIntervalId !== null) {
+      clearInterval(this.schedulerIntervalId);
+      this.schedulerIntervalId = null;
+    }
+  }
+}

--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -36,6 +36,7 @@ function buildSettingsFromConfig(
  */
 export class ConfigInstance {
   readonly configId: string;
+  credentialId: string;
 
   private app: App;
   private shared: SharedServices;
@@ -52,6 +53,7 @@ export class ConfigInstance {
 
   constructor(app: App, config: ConfigEntry, credential: Credential, shared: SharedServices) {
     this.configId = config.id;
+    this.credentialId = credential.id;
     this.app = app;
     this.shared = shared;
     this.settings = buildSettingsFromConfig(config, credential, shared.getDebugMode());
@@ -132,6 +134,7 @@ export class ConfigInstance {
    * Updates all services with new config and credential.
    */
   updateSettings(config: ConfigEntry, credential: Credential): void {
+    this.credentialId = credential.id;
     this.settings = buildSettingsFromConfig(config, credential, this.shared.getDebugMode());
 
     // Update RateLimiter if credential changed

--- a/src/core/config-manager.ts
+++ b/src/core/config-manager.ts
@@ -1,0 +1,104 @@
+/**
+ * ConfigManager orchestrates multiple ConfigInstances.
+ *
+ * Handles lifecycle of per-config service stacks: creation, update,
+ * enable/disable transitions, and teardown.
+ */
+
+import type { App } from "obsidian";
+import type { ConfigEntry, Credential, SharedServices } from '../types';
+import { ConfigInstance } from './config-instance';
+
+/**
+ * Manages multiple ConfigInstance objects keyed by config ID.
+ */
+export class ConfigManager {
+  private app: App;
+  private shared: SharedServices;
+  private instances = new Map<string, ConfigInstance>();
+
+  constructor(app: App, shared: SharedServices) {
+    this.app = app;
+    this.shared = shared;
+  }
+
+  /**
+   * Creates ConfigInstance for each enabled config.
+   * Skips disabled configs.
+   */
+  initialize(configs: ConfigEntry[], credentials: Credential[]): void {
+    const credentialMap = new Map(credentials.map(c => [c.id, c]));
+
+    for (const config of configs) {
+      if (!config.enabled) continue;
+
+      const credential = credentialMap.get(config.credentialId);
+      if (!credential) continue;
+
+      this.addConfig(config, credential);
+    }
+  }
+
+  /**
+   * Creates a new ConfigInstance and adds it to the map.
+   */
+  addConfig(config: ConfigEntry, credential: Credential): ConfigInstance {
+    const instance = new ConfigInstance(this.app, config, credential, this.shared);
+    this.instances.set(config.id, instance);
+    return instance;
+  }
+
+  /**
+   * Destroys and removes a ConfigInstance.
+   */
+  removeConfig(configId: string): void {
+    const instance = this.instances.get(configId);
+    if (instance) {
+      instance.destroy();
+      this.instances.delete(configId);
+    }
+  }
+
+  /**
+   * Returns a ConfigInstance by ID, or undefined if not found.
+   */
+  getInstance(configId: string): ConfigInstance | undefined {
+    return this.instances.get(configId);
+  }
+
+  /**
+   * Returns all active (instantiated) ConfigInstances.
+   */
+  getAllEnabled(): ConfigInstance[] {
+    return Array.from(this.instances.values());
+  }
+
+  /**
+   * Updates a config entry, handling enable/disable transitions.
+   *
+   * - If instance exists and config still enabled: update settings
+   * - If instance exists but config now disabled: remove instance
+   * - If no instance but config now enabled: add instance
+   */
+  updateConfig(configId: string, config: ConfigEntry, credential: Credential): void {
+    const instance = this.instances.get(configId);
+
+    if (instance && config.enabled) {
+      instance.updateSettings(config, credential);
+    } else if (instance && !config.enabled) {
+      this.removeConfig(configId);
+    } else if (!instance && config.enabled) {
+      this.addConfig(config, credential);
+    }
+  }
+
+  /**
+   * Destroys all instances and clears the map.
+   */
+  destroy(): void {
+    for (const instance of this.instances.values()) {
+      instance.destroy();
+    }
+    this.instances.clear();
+  }
+}

--- a/src/core/config-manager.ts
+++ b/src/core/config-manager.ts
@@ -56,6 +56,18 @@ export class ConfigManager {
     if (instance) {
       instance.destroy();
       this.instances.delete(configId);
+      this.pruneOrphanedRateLimiters();
+    }
+  }
+
+  private pruneOrphanedRateLimiters(): void {
+    const usedCredentialIds = new Set(
+      Array.from(this.instances.values()).map(i => i.credentialId),
+    );
+    for (const credId of this.shared.rateLimiters.keys()) {
+      if (!usedCredentialIds.has(credId)) {
+        this.shared.rateLimiters.delete(credId);
+      }
     }
   }
 

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -6,19 +6,18 @@
 
 import { Notice } from "obsidian";
 import { areValuesEqual } from '../utils';
-import { AirtableClient } from '../services';
-import type { AutoNoteImporterSettings, ConflictInfo, SyncResult } from '../types';
+import type { AutoNoteImporterSettings, ConflictInfo, SyncResult, DatabaseClient } from '../types';
 
 /**
  * Handles conflict detection and resolution between Obsidian and Airtable.
  */
 export class ConflictResolver {
   private settings: AutoNoteImporterSettings;
-  private airtableClient: AirtableClient;
+  private client: DatabaseClient;
 
-  constructor(settings: AutoNoteImporterSettings, airtableClient: AirtableClient) {
+  constructor(settings: AutoNoteImporterSettings, client: DatabaseClient) {
     this.settings = settings;
-    this.airtableClient = airtableClient;
+    this.client = client;
   }
 
   /**
@@ -36,7 +35,7 @@ export class ConflictResolver {
     obsidianFields: Record<string, unknown>,
     filePath: string
   ): Promise<ConflictInfo[]> {
-    const record = await this.airtableClient.fetchRecord(recordId);
+    const record = await this.client.fetchRecord(recordId);
 
     if (!record) {
       return [];
@@ -71,7 +70,7 @@ export class ConflictResolver {
   ): Promise<SyncResult> {
     switch (this.settings.conflictResolution) {
       case 'obsidian-wins':
-        return this.airtableClient.updateRecord(recordId, fieldsToSync);
+        return this.client.updateRecord(recordId, fieldsToSync);
 
       case 'airtable-wins':
         return this.resolveAirtableWins(conflicts, fieldsToSync, recordId);
@@ -109,7 +108,7 @@ export class ConflictResolver {
     }
 
     if (Object.keys(nonConflictedFields).length > 0) {
-      return this.airtableClient.updateRecord(recordId, nonConflictedFields);
+      return this.client.updateRecord(recordId, nonConflictedFields);
     }
 
     return {

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -6,16 +6,16 @@
 
 import { Notice } from "obsidian";
 import { areValuesEqual } from '../utils';
-import type { AutoNoteImporterSettings, ConflictInfo, SyncResult, DatabaseClient } from '../types';
+import type { LegacySettings, ConflictInfo, SyncResult, DatabaseClient } from '../types';
 
 /**
  * Handles conflict detection and resolution between Obsidian and Airtable.
  */
 export class ConflictResolver {
-  private settings: AutoNoteImporterSettings;
+  private settings: LegacySettings;
   private client: DatabaseClient;
 
-  constructor(settings: AutoNoteImporterSettings, client: DatabaseClient) {
+  constructor(settings: LegacySettings, client: DatabaseClient) {
     this.settings = settings;
     this.client = client;
   }
@@ -23,7 +23,7 @@ export class ConflictResolver {
   /**
    * Updates the settings reference.
    */
-  updateSettings(settings: AutoNoteImporterSettings): void {
+  updateSettings(settings: LegacySettings): void {
     this.settings = settings;
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,3 +5,6 @@ export { ConflictResolver } from './conflict-resolver';
 
 export { SyncOrchestrator } from './sync-orchestrator';
 export type { StatusBarController, StatusBarHandle } from './sync-orchestrator';
+
+export { ConfigInstance } from './config-instance';
+export { ConfigManager } from './config-manager';

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -9,7 +9,7 @@
  */
 
 import { App, TFile, TFolder, normalizePath, Notice, MarkdownView } from "obsidian";
-import type { AutoNoteImporterSettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult, DatabaseClient } from '../types';
+import type { LegacySettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult, DatabaseClient } from '../types';
 import { AIRTABLE_BATCH_SIZE, DEBUG_DELAY_MULTIPLIER } from '../constants';
 import { FieldCache } from '../services';
 import { ConflictResolver } from './conflict-resolver';
@@ -28,7 +28,7 @@ export interface StatusBarController {
 
 export class SyncOrchestrator {
   private app: App;
-  private settings: AutoNoteImporterSettings;
+  private settings: LegacySettings;
   private client: DatabaseClient;
   private fieldCache: FieldCache;
   private frontmatterParser: FrontmatterParser;
@@ -38,7 +38,7 @@ export class SyncOrchestrator {
 
   constructor(
     app: App,
-    settings: AutoNoteImporterSettings,
+    settings: LegacySettings,
     client: DatabaseClient,
     fieldCache: FieldCache,
     frontmatterParser: FrontmatterParser,
@@ -56,7 +56,7 @@ export class SyncOrchestrator {
     this.statusBar = statusBar;
   }
 
-  updateSettings(settings: AutoNoteImporterSettings): void {
+  updateSettings(settings: LegacySettings): void {
     this.settings = settings;
   }
 

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -9,9 +9,9 @@
  */
 
 import { App, TFile, TFolder, normalizePath, Notice, MarkdownView } from "obsidian";
-import type { AutoNoteImporterSettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult } from '../types';
+import type { AutoNoteImporterSettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult, DatabaseClient } from '../types';
 import { AIRTABLE_BATCH_SIZE, DEBUG_DELAY_MULTIPLIER } from '../constants';
-import { AirtableClient, FieldCache } from '../services';
+import { FieldCache } from '../services';
 import { ConflictResolver } from './conflict-resolver';
 import { FrontmatterParser, FileWatcher } from '../file-operations';
 import { parseTemplate, buildMarkdownContent, generateBasesContent, resolveBasesFilePath, collectFieldNames } from '../builders';
@@ -29,7 +29,7 @@ export interface StatusBarController {
 export class SyncOrchestrator {
   private app: App;
   private settings: AutoNoteImporterSettings;
-  private airtableClient: AirtableClient;
+  private client: DatabaseClient;
   private fieldCache: FieldCache;
   private frontmatterParser: FrontmatterParser;
   private fileWatcher: FileWatcher;
@@ -39,7 +39,7 @@ export class SyncOrchestrator {
   constructor(
     app: App,
     settings: AutoNoteImporterSettings,
-    airtableClient: AirtableClient,
+    client: DatabaseClient,
     fieldCache: FieldCache,
     frontmatterParser: FrontmatterParser,
     fileWatcher: FileWatcher,
@@ -48,7 +48,7 @@ export class SyncOrchestrator {
   ) {
     this.app = app;
     this.settings = settings;
-    this.airtableClient = airtableClient;
+    this.client = client;
     this.fieldCache = fieldCache;
     this.frontmatterParser = frontmatterParser;
     this.fileWatcher = fileWatcher;
@@ -189,7 +189,7 @@ export class SyncOrchestrator {
 
     this.fileWatcher.setSyncing(true);
     try {
-      const remoteNote = await this.airtableClient.fetchRecord(recordId);
+      const remoteNote = await this.client.fetchRecord(recordId);
       if (!remoteNote) {
         new Notice("Auto Note Importer: Record not found in Airtable");
         return;
@@ -215,7 +215,7 @@ export class SyncOrchestrator {
 
     this.fileWatcher.setSyncing(true);
     try {
-      const remoteNotes = await this.airtableClient.fetchNotes();
+      const remoteNotes = await this.client.fetchNotes();
 
       let existingPrimaryFields: Set<string> | null = null;
       if (!this.settings.allowOverwrite) {
@@ -417,7 +417,7 @@ export class SyncOrchestrator {
       const batch = batchUpdates.slice(i, i + AIRTABLE_BATCH_SIZE);
 
       try {
-        const results = await this.airtableClient.batchUpdate(batch);
+        const results = await this.client.batchUpdate(batch);
         const failures: string[] = [];
         for (const result of results) {
           if (result.success) {

--- a/src/file-operations/file-watcher.ts
+++ b/src/file-operations/file-watcher.ts
@@ -7,7 +7,7 @@
 import type { App, EventRef } from "obsidian";
 import { TFile, normalizePath, Notice } from "obsidian";
 import { DEBUG_DELAY_MULTIPLIER } from '../constants';
-import type { AutoNoteImporterSettings } from '../types';
+import type { LegacySettings } from '../types';
 
 /**
  * Callback type for when files are ready to sync.
@@ -19,7 +19,7 @@ export type FilesReadyCallback = (files: TFile[]) => Promise<void>;
  */
 export class FileWatcher {
   private app: App;
-  private settings: AutoNoteImporterSettings;
+  private settings: LegacySettings;
   private pendingFiles: Set<string> = new Set();
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private onFilesReady: FilesReadyCallback;
@@ -29,7 +29,7 @@ export class FileWatcher {
 
   constructor(
     app: App,
-    settings: AutoNoteImporterSettings,
+    settings: LegacySettings,
     onFilesReady: FilesReadyCallback
   ) {
     this.app = app;
@@ -40,7 +40,7 @@ export class FileWatcher {
   /**
    * Updates the settings reference.
    */
-  updateSettings(settings: AutoNoteImporterSettings): void {
+  updateSettings(settings: LegacySettings): void {
     this.settings = settings;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 /**
  * Auto Note Importer - Main Plugin Entry Point
  *
- * Orchestrates Airtable <-> Obsidian sync via services, core logic, and file operations.
+ * Orchestrates Airtable <-> Obsidian sync via ConfigManager and per-config service stacks.
  *
  * @handbook 4.2-sync-architecture
  * @handbook 9.2-service-initialization-order
@@ -9,170 +9,185 @@
  * @handbook 9.4-conditional-command-visibility
  */
 
-import { Plugin, Notice } from "obsidian";
-import type { AutoNoteImporterSettings, SyncMode, SyncScope } from './types';
+import { Plugin } from "obsidian";
+import type { AutoNoteImporterSettings, ConfigEntry, SharedServices } from './types';
 import { DEFAULT_SETTINGS } from './types';
-import { AirtableClient, FieldCache, RateLimiter } from './services';
-import { SyncQueue, ConflictResolver, SyncOrchestrator } from './core';
-import { FrontmatterParser, FileWatcher } from './file-operations';
+import { FieldCache } from './services';
+import { ConfigManager } from './core';
+import { FrontmatterParser } from './file-operations';
 import { AutoNoteImporterSettingTab } from './ui';
+import { migrateSettings } from './utils/migration';
 
 /**
  * Main plugin class for Auto Note Importer.
  */
 export default class AutoNoteImporterPlugin extends Plugin {
   settings!: AutoNoteImporterSettings;
-  private intervalId: number | null = null;
   private settingTab!: AutoNoteImporterSettingTab;
 
-  // Services (initialized in onload → initializeServices)
-  private airtableClient!: AirtableClient;
+  private configManager!: ConfigManager;
   private fieldCache!: FieldCache;
-  private rateLimiter!: RateLimiter;
-
-  // Core
-  private syncQueue!: SyncQueue;
-  private conflictResolver!: ConflictResolver;
-  private syncOrchestrator!: SyncOrchestrator;
-
-  // File Operations
-  private frontmatterParser!: FrontmatterParser;
-  private fileWatcher!: FileWatcher;
 
   async onload() {
     await this.loadSettings();
     this.initializeServices();
     this.registerCommands();
-    this.startScheduler();
   }
 
   /**
-   * Initializes all service instances.
+   * Initializes ConfigManager and shared services.
    */
   private initializeServices(): void {
-    this.rateLimiter = new RateLimiter();
-    this.rateLimiter.setDebugMode(this.settings.debugMode);
     this.fieldCache = new FieldCache();
-    this.airtableClient = new AirtableClient(this.settings, this.rateLimiter);
 
-    this.frontmatterParser = new FrontmatterParser(this.app);
-    this.conflictResolver = new ConflictResolver(this.settings, this.airtableClient);
+    const shared: SharedServices = {
+      rateLimiters: new Map(),
+      fieldCache: this.fieldCache,
+      frontmatterParser: new FrontmatterParser(this.app),
+      statusBarFactory: () => this.addStatusBarItem(),
+      getDebugMode: () => this.settings.debugMode,
+    };
 
-    // Initialization order: FileWatcher → SyncOrchestrator → SyncQueue
-    // FileWatcher callback captures this.syncQueue via closure. This is safe because
-    // setup() is called after syncQueue is assigned, and callbacks fire asynchronously (debounced).
-    this.fileWatcher = new FileWatcher(
-      this.app,
-      this.settings,
-      async (files) => {
-        const mode: SyncMode = this.settings.autoSyncFormulas ? 'bidirectional' : 'to-airtable';
-        await this.syncQueue.enqueue(mode, 'modified', files.map(f => f.path));
-      }
-    );
-
-    this.syncOrchestrator = new SyncOrchestrator(
-      this.app,
-      this.settings,
-      this.airtableClient,
-      this.fieldCache,
-      this.frontmatterParser,
-      this.fileWatcher,
-      this.conflictResolver,
-      { createItem: () => this.addStatusBarItem() }
-    );
-
-    this.syncQueue = new SyncQueue(
-      ({ mode, scope, filePaths }) => this.syncOrchestrator.processSyncRequest(mode, scope, filePaths),
-      (error) => {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        new Notice(`Auto Note Importer: Sync failed: ${message}`);
-      }
-    );
-
-    this.fileWatcher.setup();
+    this.configManager = new ConfigManager(this.app, shared);
+    this.configManager.initialize(this.settings.configs, this.settings.credentials);
 
     this.settingTab = new AutoNoteImporterSettingTab(this.app, this, this.fieldCache);
     this.addSettingTab(this.settingTab);
   }
 
   /**
-   * Registers all plugin commands.
-   * Commands requiring bidirectional sync use checkCallback to hide when disabled.
+   * Registers per-config commands for all configurations.
    */
   private registerCommands(): void {
-    this.addCommand({
-      id: "sync-current-from-airtable",
-      name: "Sync current note from Airtable",
-      callback: () => this.syncQueue.enqueue('from-airtable', 'current')
-    });
-
-    this.addCommand({
-      id: "sync-all-from-airtable",
-      name: "Sync all notes from Airtable",
-      callback: () => this.syncQueue.enqueue('from-airtable', 'all')
-    });
-
-    this.addBidirectionalCommand("sync-current-to-airtable", "Sync current note to Airtable", 'to-airtable', 'current');
-    this.addBidirectionalCommand("sync-modified-to-airtable", "Sync modified notes to Airtable", 'to-airtable', 'modified');
-    this.addBidirectionalCommand("sync-all-to-airtable", "Sync all notes to Airtable", 'to-airtable', 'all');
-    this.addBidirectionalCommand("bidirectional-sync-current", "Bidirectional sync current note (with formulas)", 'bidirectional', 'current');
-    this.addBidirectionalCommand("bidirectional-sync-modified", "Bidirectional sync modified notes (with formulas)", 'bidirectional', 'modified');
-    this.addBidirectionalCommand("bidirectional-sync-all", "Bidirectional sync all notes (with formulas)", 'bidirectional', 'all');
-  }
-
-  private addBidirectionalCommand(id: string, name: string, mode: SyncMode, scope: SyncScope): void {
-    this.addCommand({
-      id,
-      name,
-      checkCallback: (checking) => {
-        if (!this.settings.bidirectionalSync) return false;
-        if (!checking) this.syncQueue.enqueue(mode, scope);
-        return true;
-      }
-    });
+    for (const config of this.settings.configs) {
+      this.registerCommandsForConfig(config);
+    }
   }
 
   /**
-   * Starts the automatic sync scheduler.
+   * Registers sync commands for a single config entry.
+   * Uses checkCallback with dynamic lookup to avoid capturing stale references.
    */
-  startScheduler(): void {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-    }
+  private registerCommandsForConfig(config: ConfigEntry): void {
+    const configId = config.id;
+    const suffix = ` \u2014 ${config.name}`;
 
-    if (this.settings.syncInterval > 0) {
-      this.intervalId = window.setInterval(
-        () => this.syncQueue.enqueue('from-airtable', 'all'),
-        this.settings.syncInterval * 60 * 1000
-      );
-    }
+    // From Airtable commands
+    this.addCommand({
+      id: `sync-from-airtable-${configId}`,
+      name: `Sync current note from Airtable${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('from-airtable', 'current');
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: `sync-all-from-airtable-${configId}`,
+      name: `Sync all notes from Airtable${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('from-airtable', 'all');
+        return true;
+      },
+    });
+
+    // To Airtable commands (gated by bidirectionalSync)
+    this.addCommand({
+      id: `sync-current-to-airtable-${configId}`,
+      name: `Sync current note to Airtable${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'current');
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: `sync-modified-to-airtable-${configId}`,
+      name: `Sync modified notes to Airtable${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'modified');
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: `sync-all-to-airtable-${configId}`,
+      name: `Sync all notes to Airtable${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'all');
+        return true;
+      },
+    });
+
+    // Bidirectional commands
+    this.addCommand({
+      id: `bidirectional-sync-current-${configId}`,
+      name: `Bidirectional sync current note${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'current');
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: `bidirectional-sync-modified-${configId}`,
+      name: `Bidirectional sync modified notes${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'modified');
+        return true;
+      },
+    });
+
+    this.addCommand({
+      id: `bidirectional-sync-all-${configId}`,
+      name: `Bidirectional sync all notes${suffix}`,
+      checkCallback: (checking) => {
+        const cfg = this.settings.configs.find(c => c.id === configId);
+        if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'all');
+        return true;
+      },
+    });
   }
 
   async loadSettings(): Promise<void> {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const data = await this.loadData();
+    const migrated = migrateSettings(data);
+
+    if (migrated) {
+      this.settings = migrated;
+      await this.saveData(this.settings);
+    } else {
+      this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+    }
   }
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
 
-    // Update service settings
-    this.rateLimiter?.setDebugMode(this.settings.debugMode);
-    this.airtableClient?.updateSettings(this.settings);
-    this.conflictResolver?.updateSettings(this.settings);
-    this.syncOrchestrator?.updateSettings(this.settings);
-
-    // Reconfigure file watcher (applies watchForChanges setting without reload)
-    if (this.fileWatcher) {
-      this.fileWatcher.teardown();
-      this.fileWatcher.updateSettings(this.settings);
-      this.fileWatcher.setup();
+    for (const config of this.settings.configs) {
+      const credential = this.settings.credentials.find(c => c.id === config.credentialId);
+      if (credential) {
+        this.configManager.updateConfig(config.id, config, credential);
+      }
     }
   }
 
   onunload(): void {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-    }
-    this.fileWatcher?.teardown();
+    this.configManager?.destroy();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,8 @@ export default class AutoNoteImporterPlugin extends Plugin {
   settings!: AutoNoteImporterSettings;
   private settingTab!: AutoNoteImporterSettingTab;
 
-  private configManager!: ConfigManager;
-  private fieldCache!: FieldCache;
+  configManager!: ConfigManager;
+  fieldCache!: FieldCache;
 
   async onload() {
     await this.loadSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@
  * @handbook 9.4-conditional-command-visibility
  */
 
-import { Plugin } from "obsidian";
+import { Plugin, normalizePath } from "obsidian";
 import type { AutoNoteImporterSettings, ConfigEntry, SharedServices } from './types';
 import { DEFAULT_SETTINGS } from './types';
 import { FieldCache } from './services';
@@ -65,6 +65,68 @@ export default class AutoNoteImporterPlugin extends Plugin {
   }
 
   /**
+   * Unregisters all commands for a given config, then re-registers
+   * commands for all current configs. Called when configs change
+   * (add/delete/rename/enable/disable).
+   */
+  private reregisterAllCommands(): void {
+    // Collect all config IDs that currently have commands registered
+    const commandPrefix = this.manifest.id;
+    const commands = (this.app as any).commands?.commands;
+    if (commands) {
+      const registeredIds = Object.keys(commands).filter(
+        id => id.startsWith(`${commandPrefix}:`) && id !== commandPrefix,
+      );
+      for (const fullId of registeredIds) {
+        delete commands[fullId];
+      }
+    }
+
+    // Re-register for all current configs
+    for (const config of this.settings.configs) {
+      this.registerCommandsForConfig(config);
+    }
+  }
+
+  /**
+   * Unregisters all commands for a specific config ID.
+   */
+  private unregisterCommandsForConfig(configId: string): void {
+    const commandPrefix = this.manifest.id;
+    const commandIds = [
+      `sync-from-airtable-${configId}`,
+      `sync-all-from-airtable-${configId}`,
+      `sync-current-to-airtable-${configId}`,
+      `sync-modified-to-airtable-${configId}`,
+      `sync-all-to-airtable-${configId}`,
+      `bidirectional-sync-current-${configId}`,
+      `bidirectional-sync-modified-${configId}`,
+      `bidirectional-sync-all-${configId}`,
+    ];
+    const commands = (this.app as any).commands?.commands;
+    if (!commands) return;
+    for (const id of commandIds) {
+      const fullId = `${commandPrefix}:${id}`;
+      if (fullId in commands) {
+        delete commands[fullId];
+      }
+    }
+  }
+
+  /**
+   * Validates whether the active file belongs to the given config's folder.
+   * Returns false (hiding the command) if no file is active or the file
+   * is outside the config's folder.
+   */
+  private isActiveFileInConfigFolder(cfg: ConfigEntry): boolean {
+    const activeFile = this.app.workspace.getActiveFile();
+    if (!activeFile) return false;
+    const folderPath = normalizePath(cfg.folderPath);
+    if (folderPath && !activeFile.path.startsWith(folderPath + '/')) return false;
+    return true;
+  }
+
+  /**
    * Registers sync commands for a single config entry.
    * Uses checkCallback with dynamic lookup to avoid capturing stale references.
    */
@@ -79,6 +141,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled) return false;
+        if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('from-airtable', 'current');
         return true;
       },
@@ -102,6 +165,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'current');
         return true;
       },
@@ -136,6 +200,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
+        if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'current');
         return true;
       },
@@ -185,6 +250,8 @@ export default class AutoNoteImporterPlugin extends Plugin {
         this.configManager.updateConfig(config.id, config, credential);
       }
     }
+
+    this.reregisterAllCommands();
   }
 
   onunload(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
   configManager!: ConfigManager;
   fieldCache!: FieldCache;
+  private commandFingerprint = '';
 
   async onload() {
     await this.loadSettings();
@@ -62,6 +63,13 @@ export default class AutoNoteImporterPlugin extends Plugin {
     for (const config of this.settings.configs) {
       this.registerCommandsForConfig(config);
     }
+    this.commandFingerprint = this.getCommandFingerprint();
+  }
+
+  private getCommandFingerprint(): string {
+    return this.settings.configs
+      .map(c => `${c.id}:${c.name}:${c.enabled}:${c.bidirectionalSync}`)
+      .join('|');
   }
 
   /**
@@ -85,31 +93,6 @@ export default class AutoNoteImporterPlugin extends Plugin {
     // Re-register for all current configs
     for (const config of this.settings.configs) {
       this.registerCommandsForConfig(config);
-    }
-  }
-
-  /**
-   * Unregisters all commands for a specific config ID.
-   */
-  private unregisterCommandsForConfig(configId: string): void {
-    const commandPrefix = this.manifest.id;
-    const commandIds = [
-      `sync-from-airtable-${configId}`,
-      `sync-all-from-airtable-${configId}`,
-      `sync-current-to-airtable-${configId}`,
-      `sync-modified-to-airtable-${configId}`,
-      `sync-all-to-airtable-${configId}`,
-      `bidirectional-sync-current-${configId}`,
-      `bidirectional-sync-modified-${configId}`,
-      `bidirectional-sync-all-${configId}`,
-    ];
-    const commands = (this.app as any).commands?.commands;
-    if (!commands) return;
-    for (const id of commandIds) {
-      const fullId = `${commandPrefix}:${id}`;
-      if (fullId in commands) {
-        delete commands[fullId];
-      }
     }
   }
 
@@ -244,14 +227,28 @@ export default class AutoNoteImporterPlugin extends Plugin {
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
 
+    // Remove instances for deleted configs or configs with missing credentials
+    const currentIds = new Set(this.settings.configs.map(c => c.id));
+    for (const instance of this.configManager.getAllEnabled()) {
+      if (!currentIds.has(instance.configId)) {
+        this.configManager.removeConfig(instance.configId);
+      }
+    }
+
     for (const config of this.settings.configs) {
       const credential = this.settings.credentials.find(c => c.id === config.credentialId);
       if (credential) {
         this.configManager.updateConfig(config.id, config, credential);
+      } else {
+        this.configManager.removeConfig(config.id);
       }
     }
 
-    this.reregisterAllCommands();
+    const newFingerprint = this.getCommandFingerprint();
+    if (this.commandFingerprint !== newFingerprint) {
+      this.commandFingerprint = newFingerprint;
+      this.reregisterAllCommands();
+    }
   }
 
   onunload(): void {

--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -7,13 +7,13 @@
 
 import { requestUrl } from "obsidian";
 import { AIRTABLE_API_BASE_URL, AIRTABLE_BATCH_SIZE } from '../constants';
-import type { AutoNoteImporterSettings, RemoteNote, SyncResult, BatchUpdate } from '../types';
+import type { AutoNoteImporterSettings, RemoteNote, SyncResult, BatchUpdate, DatabaseClient } from '../types';
 import { RateLimiter } from './rate-limiter';
 
 /**
  * Client for interacting with the Airtable API.
  */
-export class AirtableClient {
+export class AirtableClient implements DatabaseClient {
   private settings: AutoNoteImporterSettings;
   private rateLimiter: RateLimiter;
 

--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -7,17 +7,17 @@
 
 import { requestUrl } from "obsidian";
 import { AIRTABLE_API_BASE_URL, AIRTABLE_BATCH_SIZE } from '../constants';
-import type { AutoNoteImporterSettings, RemoteNote, SyncResult, BatchUpdate, DatabaseClient } from '../types';
+import type { LegacySettings, RemoteNote, SyncResult, BatchUpdate, DatabaseClient } from '../types';
 import { RateLimiter } from './rate-limiter';
 
 /**
  * Client for interacting with the Airtable API.
  */
 export class AirtableClient implements DatabaseClient {
-  private settings: AutoNoteImporterSettings;
+  private settings: LegacySettings;
   private rateLimiter: RateLimiter;
 
-  constructor(settings: AutoNoteImporterSettings, rateLimiter?: RateLimiter) {
+  constructor(settings: LegacySettings, rateLimiter?: RateLimiter) {
     this.settings = settings;
     this.rateLimiter = rateLimiter || new RateLimiter();
   }
@@ -25,7 +25,7 @@ export class AirtableClient implements DatabaseClient {
   /**
    * Updates the settings reference.
    */
-  updateSettings(settings: AutoNoteImporterSettings): void {
+  updateSettings(settings: LegacySettings): void {
     this.settings = settings;
   }
 

--- a/src/services/field-cache.ts
+++ b/src/services/field-cache.ts
@@ -16,17 +16,6 @@ export class FieldCache {
   private cachedTables: Map<string, AirtableTable[]> = new Map();
   private cachedFields: Map<string, AirtableField[]> = new Map();
   private cachedViews: Map<string, AirtableView[]> = new Map();
-  private lastApiKey = "";
-
-  /**
-   * Clears cache if the API key has changed.
-   */
-  private clearCacheIfApiKeyChanged(apiKey: string): void {
-    if (this.lastApiKey !== apiKey) {
-      this.clearBases();
-      this.lastApiKey = apiKey;
-    }
-  }
 
   /**
    * Clears cached bases (and dependent tables/fields).
@@ -70,8 +59,6 @@ export class FieldCache {
    * Fetches available bases from Airtable.
    */
   async fetchBases(apiKey: string): Promise<AirtableBase[]> {
-    this.clearCacheIfApiKeyChanged(apiKey);
-
     if (this.cachedBases) {
       return this.cachedBases;
     }
@@ -99,8 +86,6 @@ export class FieldCache {
    * Fetches tables for a specific base.
    */
   async fetchTables(apiKey: string, baseId: string): Promise<AirtableTable[]> {
-    this.clearCacheIfApiKeyChanged(apiKey);
-
     const cachedTables = this.cachedTables.get(baseId);
     if (cachedTables) return cachedTables;
 
@@ -175,8 +160,6 @@ export class FieldCache {
    * Fetches fields for a specific table.
    */
   async fetchFields(apiKey: string, baseId: string, tableId: string): Promise<AirtableField[]> {
-    this.clearCacheIfApiKeyChanged(apiKey);
-
     const cacheKey = this.getCacheKey(baseId, tableId);
     const cached = this.cachedFields.get(cacheKey);
     if (cached) return cached;
@@ -189,8 +172,6 @@ export class FieldCache {
    * Fetches views for a specific table.
    */
   async fetchViews(apiKey: string, baseId: string, tableId: string): Promise<AirtableView[]> {
-    this.clearCacheIfApiKeyChanged(apiKey);
-
     const cacheKey = this.getCacheKey(baseId, tableId);
     const cached = this.cachedViews.get(cacheKey);
     if (cached) return cached;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -1,0 +1,69 @@
+/**
+ * Configuration entry type definitions for multi-config support.
+ */
+
+import type { ConflictResolutionMode, BasesFileLocation } from './settings.types';
+import type { RateLimiter } from '../services/rate-limiter';
+import type { FieldCache } from '../services/field-cache';
+import type { FrontmatterParser } from '../file-operations/frontmatter-parser';
+
+export interface SharedServices {
+  rateLimiters: Map<string, RateLimiter>;
+  fieldCache: FieldCache;
+  frontmatterParser: FrontmatterParser;
+  statusBarFactory: () => HTMLElement;
+  getDebugMode: () => boolean;
+}
+
+export interface ConfigEntry {
+  id: string;
+  name: string;
+  enabled: boolean;
+  credentialId: string;
+
+  baseId: string;
+  tableId: string;
+  viewId: string;
+
+  folderPath: string;
+  templatePath: string;
+  filenameFieldName: string;
+  subfolderFieldName: string;
+
+  syncInterval: number;
+  allowOverwrite: boolean;
+  bidirectionalSync: boolean;
+  conflictResolution: ConflictResolutionMode;
+  watchForChanges: boolean;
+  fileWatchDebounce: number;
+  autoSyncFormulas: boolean;
+  formulaSyncDelay: number;
+
+  generateBasesFile: boolean;
+  basesFileLocation: BasesFileLocation;
+  basesCustomPath: string;
+  basesRegenerateOnSync: boolean;
+}
+
+export const DEFAULT_CONFIG_ENTRY: Omit<ConfigEntry, 'id' | 'name' | 'credentialId'> = {
+  enabled: true,
+  baseId: '',
+  tableId: '',
+  viewId: '',
+  folderPath: '',
+  templatePath: '',
+  filenameFieldName: '',
+  subfolderFieldName: '',
+  syncInterval: 0,
+  allowOverwrite: true,
+  bidirectionalSync: false,
+  conflictResolution: 'manual',
+  watchForChanges: false,
+  fileWatchDebounce: 2000,
+  autoSyncFormulas: false,
+  formulaSyncDelay: 3000,
+  generateBasesFile: false,
+  basesFileLocation: 'vault-root',
+  basesCustomPath: '',
+  basesRegenerateOnSync: false,
+};

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -61,7 +61,7 @@ export const DEFAULT_CONFIG_ENTRY: Omit<ConfigEntry, 'id' | 'name' | 'credential
   watchForChanges: false,
   fileWatchDebounce: 2000,
   autoSyncFormulas: false,
-  formulaSyncDelay: 3000,
+  formulaSyncDelay: 1500,
   generateBasesFile: false,
   basesFileLocation: 'vault-root',
   basesCustomPath: '',

--- a/src/types/credential.types.ts
+++ b/src/types/credential.types.ts
@@ -1,0 +1,12 @@
+/**
+ * Credential type definitions for external service authentication.
+ */
+
+export type CredentialType = 'airtable';
+
+export interface Credential {
+  id: string;
+  name: string;
+  type: CredentialType;
+  apiKey: string;
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,0 +1,12 @@
+/**
+ * Database client interface for abstracting external data sources.
+ */
+
+import type { RemoteNote, SyncResult, BatchUpdate } from './airtable.types';
+
+export interface DatabaseClient {
+  fetchNotes(): Promise<RemoteNote[]>;
+  fetchRecord(recordId: string): Promise<RemoteNote | null>;
+  updateRecord(recordId: string, fields: Record<string, unknown>): Promise<SyncResult>;
+  batchUpdate(updates: BatchUpdate[]): Promise<SyncResult[]>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,5 @@ export type {
   SyncRequest,
   NoteCreationResult,
 } from './sync.types';
+
+export type { DatabaseClient } from './database.types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,14 @@ export type {
 } from './sync.types';
 
 export type { DatabaseClient } from './database.types';
+
+export type {
+  SharedServices,
+  ConfigEntry,
+} from './config.types';
+export { DEFAULT_CONFIG_ENTRY } from './config.types';
+
+export type {
+  CredentialType,
+  Credential,
+} from './credential.types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,9 +2,10 @@ export type {
   ConflictResolutionMode,
   BasesFileLocation,
   SyncScope,
+  LegacySettings,
   AutoNoteImporterSettings,
 } from './settings.types';
-export { DEFAULT_SETTINGS } from './settings.types';
+export { DEFAULT_SETTINGS, DEFAULT_LEGACY_SETTINGS } from './settings.types';
 
 export type {
   AirtableField,

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -3,6 +3,9 @@
  * @handbook 9.3-settings-update-pattern
  */
 
+import type { Credential } from './credential.types';
+import type { ConfigEntry } from './config.types';
+
 /**
  * Conflict resolution modes for bidirectional sync.
  */
@@ -19,9 +22,11 @@ export type BasesFileLocation = 'vault-root' | 'synced-folder' | 'custom';
 export type SyncScope = 'current' | 'modified' | 'all';
 
 /**
- * Plugin settings interface.
+ * Legacy single-config settings interface.
+ * Used by services internally via ConfigInstance.buildSettingsFromConfig().
+ * @deprecated Use AutoNoteImporterSettings (v2 multi-config) for plugin-level settings.
  */
-export interface AutoNoteImporterSettings {
+export interface LegacySettings {
   apiKey: string;
   baseId: string;
   tableId: string;
@@ -46,19 +51,31 @@ export interface AutoNoteImporterSettings {
 }
 
 /**
- * Default values for the plugin settings.
+ * Plugin settings interface (v2 multi-config).
  */
-export const DEFAULT_SETTINGS: AutoNoteImporterSettings = {
-  apiKey: "",
-  baseId: "",
-  tableId: "",
-  viewId: "",
-  folderPath: "Crawling",
-  templatePath: "",
+export interface AutoNoteImporterSettings {
+  version: 2;
+  credentials: Credential[];
+  configs: ConfigEntry[];
+  activeConfigId: string;
+  debugMode: boolean;
+}
+
+/**
+ * Default values for the legacy per-config settings.
+ * Used by services and tests that construct LegacySettings objects.
+ */
+export const DEFAULT_LEGACY_SETTINGS: LegacySettings = {
+  apiKey: '',
+  baseId: '',
+  tableId: '',
+  viewId: '',
+  folderPath: 'Crawling',
+  templatePath: '',
   syncInterval: 0,
   allowOverwrite: false,
-  filenameFieldName: "title",
-  subfolderFieldName: "",
+  filenameFieldName: 'title',
+  subfolderFieldName: '',
   bidirectionalSync: false,
   conflictResolution: 'manual',
   watchForChanges: true,
@@ -69,5 +86,16 @@ export const DEFAULT_SETTINGS: AutoNoteImporterSettings = {
   basesFileLocation: 'vault-root',
   basesCustomPath: '',
   basesRegenerateOnSync: false,
+  debugMode: false,
+};
+
+/**
+ * Default values for the plugin settings.
+ */
+export const DEFAULT_SETTINGS: AutoNoteImporterSettings = {
+  version: 2,
+  credentials: [],
+  configs: [],
+  activeConfigId: '',
   debugMode: false,
 };

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,6 +1,10 @@
 /**
  * Settings tab UI for the Auto Note Importer plugin.
  * UI-only - delegates API calls to FieldCache.
+ *
+ * Temporary bridge: reads/writes through activeConfig and activeCredential
+ * helpers until Tasks 10-11 implement the full multi-config UI.
+ *
  * @handbook 5.1-ui-components
  */
 
@@ -8,7 +12,7 @@ import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import type { ExtraButtonComponent, Plugin } from "obsidian";
 import { FieldCache } from '../services';
 import { isFieldTypeSupported } from '../constants';
-import type { AutoNoteImporterSettings, ConflictResolutionMode, BasesFileLocation } from '../types';
+import type { AutoNoteImporterSettings, ConfigEntry, Credential, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { FolderSuggest, FileSuggest } from './suggest';
 
 /**
@@ -17,7 +21,6 @@ import { FolderSuggest, FileSuggest } from './suggest';
 export interface SettingsPlugin extends Plugin {
   settings: AutoNoteImporterSettings;
   saveSettings(): Promise<void>;
-  startScheduler(): void;
 }
 
 /**
@@ -32,6 +35,23 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     super(app, plugin);
     this.plugin = plugin;
     this.fieldCache = fieldCache;
+  }
+
+  /**
+   * Returns the active config entry, or undefined if none exists.
+   */
+  private get activeConfig(): ConfigEntry | undefined {
+    const { activeConfigId, configs } = this.plugin.settings;
+    return configs.find(c => c.id === activeConfigId) ?? configs[0];
+  }
+
+  /**
+   * Returns the credential for the active config, or undefined.
+   */
+  private get activeCredential(): Credential | undefined {
+    const config = this.activeConfig;
+    if (!config) return undefined;
+    return this.plugin.settings.credentials.find(c => c.id === config.credentialId);
   }
 
   private debounceDisplay(delay = 100): void {
@@ -65,6 +85,17 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
+    const config = this.activeConfig;
+    const credential = this.activeCredential;
+
+    if (!config || !credential) {
+      new Setting(containerEl)
+        .setName('No configuration')
+        .setDesc('Add a configuration to get started.');
+      this.renderDebugSettings(containerEl);
+      return;
+    }
+
     // API Key setting
     new Setting(containerEl)
       .setName("Airtable personal access token")
@@ -72,17 +103,17 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       .addText(text => {
         text
           .setPlaceholder("your-pat-token")
-          .setValue(this.plugin.settings.apiKey)
+          .setValue(credential.apiKey)
           .onChange(async (value) => {
-            this.plugin.settings.apiKey = value;
+            credential.apiKey = value;
             await this.plugin.saveSettings();
             this.debounceDisplay();
           });
         text.inputEl.type = 'password';
       });
 
-    if (this.plugin.settings.apiKey) {
-      this.renderBaseSelector(containerEl);
+    if (credential.apiKey) {
+      this.renderBaseSelector(containerEl, config, credential);
     }
 
     // Folder path setting
@@ -92,9 +123,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       .addText(text => {
         const input = text
           .setPlaceholder("Crawling")
-          .setValue(this.plugin.settings.folderPath)
+          .setValue(config.folderPath)
           .onChange(async (value) => {
-            this.plugin.settings.folderPath = value;
+            config.folderPath = value;
             await this.plugin.saveSettings();
           });
         new FolderSuggest(this.app, input.inputEl as HTMLInputElement);
@@ -107,56 +138,55 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       .addText(text => {
         const input = text
           .setPlaceholder("Templates/note-template.md")
-          .setValue(this.plugin.settings.templatePath)
+          .setValue(config.templatePath)
           .onChange(async (value) => {
-            this.plugin.settings.templatePath = value;
+            config.templatePath = value;
             await this.plugin.saveSettings();
           });
         new FileSuggest(this.app, input.inputEl as HTMLInputElement);
       });
 
     this.renderNumberSetting(containerEl, "Sync interval (minutes)", "How often to sync notes (in minutes).", "0",
-      this.plugin.settings.syncInterval, "Sync interval",
-      (num) => { this.plugin.settings.syncInterval = num; },
-      () => { this.plugin.startScheduler(); });
+      config.syncInterval, "Sync interval",
+      (num) => { config.syncInterval = num; });
 
     // Allow overwrite setting
     new Setting(containerEl)
       .setName("Allow overwrite existing notes")
       .setDesc("If enabled, existing notes will be overwritten when syncing.")
       .addToggle(toggle => toggle
-        .setValue(this.plugin.settings.allowOverwrite)
+        .setValue(config.allowOverwrite)
         .onChange(async (value) => {
-          this.plugin.settings.allowOverwrite = value;
+          config.allowOverwrite = value;
           await this.plugin.saveSettings();
         }));
 
     // Bases database settings
-    this.renderBasesSettings(containerEl);
+    this.renderBasesSettings(containerEl, config);
 
     // Bidirectional sync settings
-    this.renderBidirectionalSyncSettings(containerEl);
+    this.renderBidirectionalSyncSettings(containerEl, config);
 
     // Debug settings
     this.renderDebugSettings(containerEl);
   }
 
-  private renderBaseSelector(containerEl: HTMLElement): void {
+  private renderBaseSelector(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
     new Setting(containerEl)
       .setName("Select base")
       .setDesc("Choose the Airtable base you want to import notes from.")
       .addDropdown(async dropdown => {
         try {
           dropdown.addOption("", "-- Select base. --");
-          const bases = await this.fieldCache.fetchBases(this.plugin.settings.apiKey);
+          const bases = await this.fieldCache.fetchBases(credential.apiKey);
           for (const base of bases) {
             dropdown.addOption(base.id, base.name);
           }
-          dropdown.setValue(this.plugin.settings.baseId);
+          dropdown.setValue(config.baseId);
           dropdown.onChange(async (value) => {
-            this.plugin.settings.baseId = value;
-            this.plugin.settings.tableId = "";
-            this.plugin.settings.viewId = "";
+            config.baseId = value;
+            config.tableId = "";
+            config.viewId = "";
             await this.plugin.saveSettings();
             this.debounceDisplay();
           });
@@ -169,12 +199,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         this.fieldCache.clearBases();
       }));
 
-    if (this.plugin.settings.baseId) {
-      this.renderTableSelector(containerEl);
+    if (config.baseId) {
+      this.renderTableSelector(containerEl, config, credential);
     }
   }
 
-  private renderTableSelector(containerEl: HTMLElement): void {
+  private renderTableSelector(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
     new Setting(containerEl)
       .setName("Select table")
       .setDesc("Choose the specific table within the selected base.")
@@ -182,16 +212,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         try {
           dropdown.addOption("", "-- Select table --");
           const tables = await this.fieldCache.fetchTables(
-            this.plugin.settings.apiKey,
-            this.plugin.settings.baseId
+            credential.apiKey,
+            config.baseId
           );
           for (const table of tables) {
             dropdown.addOption(table.id, table.name);
           }
-          dropdown.setValue(this.plugin.settings.tableId);
+          dropdown.setValue(config.tableId);
           dropdown.onChange(async (value) => {
-            this.plugin.settings.tableId = value;
-            this.plugin.settings.viewId = "";
+            config.tableId = value;
+            config.viewId = "";
             await this.plugin.saveSettings();
             this.debounceDisplay();
           });
@@ -201,16 +231,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         }
       })
       .addExtraButton(button => this.configureRefreshButton(button, "Refresh table list", () => {
-        this.fieldCache.clearTables(this.plugin.settings.baseId);
+        this.fieldCache.clearTables(config.baseId);
       }));
 
-    if (this.plugin.settings.tableId) {
-      this.renderViewSelector(containerEl);
-      this.renderFieldSelectors(containerEl);
+    if (config.tableId) {
+      this.renderViewSelector(containerEl, config, credential);
+      this.renderFieldSelectors(containerEl, config, credential);
     }
   }
 
-  private renderViewSelector(containerEl: HTMLElement): void {
+  private renderViewSelector(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
     new Setting(containerEl)
       .setName("Select view (optional)")
       .setDesc("Filter synced records by an Airtable view. Leave empty to sync all records.")
@@ -218,16 +248,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         try {
           dropdown.addOption("", "-- All records (no view filter) --");
           const views = await this.fieldCache.fetchViews(
-            this.plugin.settings.apiKey,
-            this.plugin.settings.baseId,
-            this.plugin.settings.tableId
+            credential.apiKey,
+            config.baseId,
+            config.tableId
           );
           for (const view of views) {
             dropdown.addOption(view.id, `${view.name} (${view.type})`);
           }
-          dropdown.setValue(this.plugin.settings.viewId);
+          dropdown.setValue(config.viewId);
           dropdown.onChange(async (value) => {
-            this.plugin.settings.viewId = value;
+            config.viewId = value;
             await this.plugin.saveSettings();
           });
         } catch (error) {
@@ -236,16 +266,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         }
       })
       .addExtraButton(button => this.configureRefreshButton(button, "Refresh view list", () => {
-        this.fieldCache.clearViews(this.plugin.settings.baseId, this.plugin.settings.tableId);
+        this.fieldCache.clearViews(config.baseId, config.tableId);
       }));
   }
 
-  private renderFieldSelectors(containerEl: HTMLElement): void {
+  private renderFieldSelectors(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
     this.renderFieldDropdown(containerEl, "Filename field", "Select the field to use for the note's filename.", "-- Select field --",
-      this.plugin.settings.filenameFieldName, (value) => { this.plugin.settings.filenameFieldName = value; });
+      config.filenameFieldName, (value) => { config.filenameFieldName = value; }, config, credential);
 
     this.renderFieldDropdown(containerEl, "Subfolder field", "Select the field to use for subfolder organization.", "-- No subfolder --",
-      this.plugin.settings.subfolderFieldName, (value) => { this.plugin.settings.subfolderFieldName = value; });
+      config.subfolderFieldName, (value) => { config.subfolderFieldName = value; }, config, credential);
   }
 
   private renderFieldDropdown(
@@ -254,7 +284,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     desc: string,
     placeholder: string,
     currentValue: string,
-    onSelect: (value: string) => void
+    onSelect: (value: string) => void,
+    config: ConfigEntry,
+    credential: Credential
   ): void {
     new Setting(containerEl)
       .setName(name)
@@ -263,9 +295,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         try {
           dropdown.addOption("", placeholder);
           const fields = await this.fieldCache.fetchFields(
-            this.plugin.settings.apiKey,
-            this.plugin.settings.baseId,
-            this.plugin.settings.tableId
+            credential.apiKey,
+            config.baseId,
+            config.tableId
           );
 
           const supportedFields = fields.filter(field => isFieldTypeSupported(field.type));
@@ -290,25 +322,25 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         }
       })
       .addExtraButton(button => this.configureRefreshButton(button, "Refresh field list", () => {
-        this.fieldCache.clearFields(this.plugin.settings.baseId, this.plugin.settings.tableId);
+        this.fieldCache.clearFields(config.baseId, config.tableId);
       }));
   }
 
-  private renderBasesSettings(containerEl: HTMLElement): void {
+  private renderBasesSettings(containerEl: HTMLElement, config: ConfigEntry): void {
     new Setting(containerEl).setName('Bases database').setHeading();
 
     new Setting(containerEl)
       .setName('Auto-generate Bases database file')
       .setDesc('Create a .base file after sync for table/card view in Obsidian Bases.')
       .addToggle(toggle => toggle
-        .setValue(this.plugin.settings.generateBasesFile)
+        .setValue(config.generateBasesFile)
         .onChange(async (value) => {
-          this.plugin.settings.generateBasesFile = value;
+          config.generateBasesFile = value;
           await this.plugin.saveSettings();
           this.debounceDisplay();
         }));
 
-    if (this.plugin.settings.generateBasesFile) {
+    if (config.generateBasesFile) {
       new Setting(containerEl)
         .setName('Database file location')
         .setDesc('Where to create the .base file.')
@@ -316,23 +348,23 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .addOption('vault-root', 'Vault root')
           .addOption('synced-folder', 'Inside synced folder')
           .addOption('custom', 'Custom path')
-          .setValue(this.plugin.settings.basesFileLocation)
+          .setValue(config.basesFileLocation)
           .onChange(async (value) => {
-            this.plugin.settings.basesFileLocation = value as BasesFileLocation;
+            config.basesFileLocation = value as BasesFileLocation;
             await this.plugin.saveSettings();
             this.debounceDisplay();
           }));
 
-      if (this.plugin.settings.basesFileLocation === 'custom') {
+      if (config.basesFileLocation === 'custom') {
         new Setting(containerEl)
           .setName('Custom path')
           .setDesc('Folder path for the .base file. Leave empty to use vault root.')
           .addText(text => {
             const input = text
               .setPlaceholder('Bases')
-              .setValue(this.plugin.settings.basesCustomPath)
+              .setValue(config.basesCustomPath)
               .onChange(async (value) => {
-                this.plugin.settings.basesCustomPath = value;
+                config.basesCustomPath = value;
                 await this.plugin.saveSettings();
               });
             new FolderSuggest(this.app, input.inputEl as HTMLInputElement);
@@ -343,29 +375,29 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setName('Regenerate on each sync')
         .setDesc('Recreate .base file on every sync. Disable to preserve manual edits.')
         .addToggle(toggle => toggle
-          .setValue(this.plugin.settings.basesRegenerateOnSync)
+          .setValue(config.basesRegenerateOnSync)
           .onChange(async (value) => {
-            this.plugin.settings.basesRegenerateOnSync = value;
+            config.basesRegenerateOnSync = value;
             await this.plugin.saveSettings();
           }));
     }
   }
 
-  private renderBidirectionalSyncSettings(containerEl: HTMLElement): void {
+  private renderBidirectionalSyncSettings(containerEl: HTMLElement, config: ConfigEntry): void {
     new Setting(containerEl).setName('Bidirectional sync').setHeading();
 
     new Setting(containerEl)
       .setName("Enable bidirectional sync")
       .setDesc("When enabled, changes made in Obsidian will be synced back to Airtable.")
       .addToggle(toggle => toggle
-        .setValue(this.plugin.settings.bidirectionalSync)
+        .setValue(config.bidirectionalSync)
         .onChange(async (value) => {
-          this.plugin.settings.bidirectionalSync = value;
+          config.bidirectionalSync = value;
           await this.plugin.saveSettings();
           this.debounceDisplay();
         }));
 
-    if (this.plugin.settings.bidirectionalSync) {
+    if (config.bidirectionalSync) {
       new Setting(containerEl)
         .setName("Conflict resolution")
         .setDesc("How to handle conflicts when the same field is modified in both places.")
@@ -373,9 +405,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .addOption('manual', 'Manual resolution (show conflicts)')
           .addOption('obsidian-wins', 'Obsidian wins (overwrite Airtable)')
           .addOption('airtable-wins', 'Airtable wins (overwrite Obsidian)')
-          .setValue(this.plugin.settings.conflictResolution)
+          .setValue(config.conflictResolution)
           .onChange(async (value) => {
-            this.plugin.settings.conflictResolution = value as ConflictResolutionMode;
+            config.conflictResolution = value as ConflictResolutionMode;
             await this.plugin.saveSettings();
           }));
 
@@ -383,36 +415,36 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setName("Watch for file changes")
         .setDesc("Automatically detect and sync changes made to notes in Obsidian.")
         .addToggle(toggle => toggle
-          .setValue(this.plugin.settings.watchForChanges)
+          .setValue(config.watchForChanges)
           .onChange(async (value) => {
-            this.plugin.settings.watchForChanges = value;
+            config.watchForChanges = value;
             await this.plugin.saveSettings();
             this.debounceDisplay();
           }));
 
-      if (this.plugin.settings.watchForChanges) {
+      if (config.watchForChanges) {
         this.renderNumberSetting(containerEl, "File watch debounce (milliseconds)",
           "How long to wait after a file change before triggering sync.", "2000",
-          this.plugin.settings.fileWatchDebounce, "Debounce time",
-          (num) => { this.plugin.settings.fileWatchDebounce = num; }, undefined, "500");
+          config.fileWatchDebounce, "Debounce time",
+          (num) => { config.fileWatchDebounce = num; }, undefined, "500");
       }
 
       new Setting(containerEl)
         .setName("Auto-sync formulas and relations")
         .setDesc("Automatically fetch computed formula and relation results after syncing.")
         .addToggle(toggle => toggle
-          .setValue(this.plugin.settings.autoSyncFormulas)
+          .setValue(config.autoSyncFormulas)
           .onChange(async (value) => {
-            this.plugin.settings.autoSyncFormulas = value;
+            config.autoSyncFormulas = value;
             await this.plugin.saveSettings();
             this.debounceDisplay();
           }));
 
-      if (this.plugin.settings.autoSyncFormulas) {
+      if (config.autoSyncFormulas) {
         this.renderNumberSetting(containerEl, "Formula sync delay (milliseconds)",
           "How long to wait for Airtable to compute formulas before fetching.", "1500",
-          this.plugin.settings.formulaSyncDelay, "Formula sync delay",
-          (num) => { this.plugin.settings.formulaSyncDelay = num; }, undefined, "100");
+          config.formulaSyncDelay, "Formula sync delay",
+          (num) => { config.formulaSyncDelay = num; }, undefined, "100");
       }
     }
   }

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -36,6 +36,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private editingCredentialId: string | null = null;
   private addingCredential = false;
   private expandedSections: Set<string> = new Set(['airtable-connection']);
+  private pendingDeleteConfigId: string | null = null;
+  private pendingDeleteCredentialId: string | null = null;
 
   constructor(app: App, plugin: SettingsPlugin, fieldCache: FieldCache) {
     super(app, plugin);
@@ -227,15 +229,24 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       this.display();
     });
 
-    const deleteBtn = actionsCell.createEl('button', { cls: 'ani-cred-action-btn' });
-    setIcon(deleteBtn, 'trash-2');
-    deleteBtn.title = 'Delete credential';
+    const isPendingDelete = this.pendingDeleteCredentialId === cred.id;
+    const deleteBtn = actionsCell.createEl('button', {
+      cls: `ani-cred-action-btn${isPendingDelete ? ' ani-cred-action-confirm' : ''}`,
+    });
+    setIcon(deleteBtn, isPendingDelete ? 'check' : 'trash-2');
+    deleteBtn.title = isPendingDelete ? 'Confirm delete' : 'Delete credential';
     deleteBtn.addEventListener('click', async () => {
-      const inUse = this.plugin.settings.configs.some(c => c.credentialId === cred.id);
-      if (inUse) {
-        new Notice('Auto Note Importer: Cannot delete a credential that is in use by a configuration.');
+      if (!isPendingDelete) {
+        const inUse = this.plugin.settings.configs.some(c => c.credentialId === cred.id);
+        if (inUse) {
+          new Notice('Auto Note Importer: Cannot delete a credential that is in use by a configuration.');
+          return;
+        }
+        this.pendingDeleteCredentialId = cred.id;
+        this.display();
         return;
       }
+      this.pendingDeleteCredentialId = null;
       this.plugin.settings.credentials = this.plugin.settings.credentials.filter(c => c.id !== cred.id);
       await this.plugin.saveSettings();
       this.display();
@@ -456,26 +467,45 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private renderDeleteConfigButton(containerEl: HTMLElement, config: ConfigEntry): void {
     new Setting(containerEl).setName('Danger zone').setHeading();
 
+    const isPending = this.pendingDeleteConfigId === config.id;
     const setting = new Setting(containerEl)
       .setName('Delete this configuration')
-      .setDesc('Permanently remove this sync configuration. This cannot be undone.')
-      .addButton(button => button
-        .setButtonText('Delete')
-        .setWarning()
-        .onClick(async () => {
-          const { configs } = this.plugin.settings;
-          if (configs.length <= 1) {
-            new Notice('Auto Note Importer: Cannot delete the last configuration.');
-            return;
-          }
-          const confirmed = confirm(`Delete configuration "${config.name}"? This cannot be undone.`);
-          if (!confirmed) return;
-          this.plugin.settings.configs = configs.filter(c => c.id !== config.id);
-          // Switch to first remaining config
-          this.plugin.settings.activeConfigId = this.plugin.settings.configs[0]?.id ?? '';
-          await this.plugin.saveSettings();
+      .setDesc(isPending
+        ? 'Click again to confirm deletion.'
+        : 'Permanently remove this sync configuration. This cannot be undone.')
+      .addButton(button => {
+        button
+          .setButtonText(isPending ? 'Confirm delete' : 'Delete')
+          .setWarning()
+          .onClick(async () => {
+            if (!isPending) {
+              this.pendingDeleteConfigId = config.id;
+              this.display();
+              return;
+            }
+            const { configs } = this.plugin.settings;
+            if (configs.length <= 1) {
+              new Notice('Auto Note Importer: Cannot delete the last configuration.');
+              return;
+            }
+            this.pendingDeleteConfigId = null;
+            this.plugin.settings.configs = configs.filter(c => c.id !== config.id);
+            this.plugin.settings.activeConfigId = this.plugin.settings.configs[0]?.id ?? '';
+            await this.plugin.saveSettings();
+            this.display();
+          });
+        if (isPending) {
+          button.buttonEl.addClass('mod-destructive');
+        }
+      });
+    if (isPending) {
+      setting.addButton(button => button
+        .setButtonText('Cancel')
+        .onClick(() => {
+          this.pendingDeleteConfigId = null;
           this.display();
         }));
+    }
     setting.settingEl.addClass('ani-delete-config');
   }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -94,6 +94,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Credentials section
     this.renderCredentialsSection(containerEl);
 
+    // Debug settings (global, above per-config tabs)
+    this.renderDebugSettings(containerEl);
+
     // Tab bar for config switching
     this.renderTabBar(containerEl);
 
@@ -106,40 +109,43 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .setName('No configuration')
           .setDesc('Add a configuration using the + tab above.');
       }
-      this.renderDebugSettings(containerEl);
       return;
     }
 
     // Config header: name, enabled toggle, credential selector
     this.renderConfigHeader(containerEl, config);
 
-    // Section 1: Airtable Connection (expanded by default)
+    // Summary card stack
+    const cardStack = containerEl.createDiv({ cls: 'ani-card-stack' });
+
     if (credential.apiKey) {
-      this.renderCollapsibleSection(containerEl, 'airtable-connection', 'Airtable Connection', (container) => {
-        this.renderBaseSelector(container, config, credential);
-      });
+      this.renderSummaryCard(cardStack, 'airtable-connection', '\u{1F4E1}', 'Airtable Connection',
+        this.getConnectionSummary(config),
+        config.baseId && config.tableId ? 'ok' : 'off',
+        config.baseId && config.tableId ? 'Connected' : 'Setup required',
+        (container) => { this.renderBaseSelector(container, config, credential); });
     }
 
-    // Section 2: File Settings
-    this.renderCollapsibleSection(containerEl, 'file-settings', 'File Settings', (container) => {
-      this.renderFileSettings(container, config);
-    });
+    this.renderSummaryCard(cardStack, 'file-settings', '\u{1F4C1}', 'File Settings',
+      this.getFileSummary(config),
+      config.folderPath ? 'ok' : 'off',
+      config.folderPath ? 'Configured' : 'Setup required',
+      (container) => { this.renderFileSettings(container, config); });
 
-    // Section 3: Bases Database
-    this.renderCollapsibleSection(containerEl, 'bases-database', 'Bases Database', (container) => {
-      this.renderBasesSettings(container, config);
-    });
+    this.renderSummaryCard(cardStack, 'bases-database', '\u{1F4BE}', 'Bases Database',
+      config.generateBasesFile ? 'Auto-generate enabled' : '',
+      config.generateBasesFile ? 'ok' : 'off',
+      config.generateBasesFile ? 'On' : 'Off',
+      (container) => { this.renderBasesSettings(container, config); });
 
-    // Section 4: Bidirectional Sync
-    this.renderCollapsibleSection(containerEl, 'bidirectional-sync', 'Bidirectional Sync', (container) => {
-      this.renderBidirectionalSyncSettings(container, config);
-    });
+    this.renderSummaryCard(cardStack, 'bidirectional-sync', '\u{1F504}', 'Bidirectional Sync',
+      this.getSyncSummary(config),
+      config.bidirectionalSync ? 'ok' : 'off',
+      config.bidirectionalSync ? 'On' : 'Off',
+      (container) => { this.renderBidirectionalSyncSettings(container, config); });
 
     // Delete config button
     this.renderDeleteConfigButton(containerEl, config);
-
-    // Debug settings
-    this.renderDebugSettings(containerEl);
   }
 
   // ─── Credentials Section ───────────────────────────────────────────
@@ -360,10 +366,14 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         this.display();
         return;
       }
+      const existingNames = new Set(configs.map(c => c.name));
+      let nameIdx = configs.length + 1;
+      while (existingNames.has(`Config ${nameIdx}`)) nameIdx++;
+
       const newConfig: ConfigEntry = {
         ...DEFAULT_CONFIG_ENTRY,
         id: generateId(),
-        name: `Config ${configs.length + 1}`,
+        name: `Config ${nameIdx}`,
         credentialId: this.plugin.settings.credentials[0].id,
       };
       this.plugin.settings.configs.push(newConfig);
@@ -379,13 +389,23 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     new Setting(containerEl).setName('Configuration').setHeading();
 
     // Config name
-    new Setting(containerEl)
+    const nameSetting = new Setting(containerEl)
       .setName('Configuration name')
       .setDesc('A display name for this sync configuration.')
       .addText(text => text
         .setPlaceholder('My Config')
         .setValue(config.name)
         .onChange(async (value) => {
+          const duplicate = this.plugin.settings.configs.some(
+            c => c.id !== config.id && c.name.trim() === value.trim(),
+          );
+          if (duplicate) {
+            nameSetting.descEl.textContent = 'This name is already used by another configuration.';
+            nameSetting.descEl.addClass('ani-field-error');
+            return;
+          }
+          nameSetting.descEl.textContent = 'A display name for this sync configuration.';
+          nameSetting.descEl.removeClass('ani-field-error');
           config.name = value;
           await this.plugin.saveSettings();
           // Update tab text without full re-render
@@ -446,6 +466,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             new Notice('Auto Note Importer: Cannot delete the last configuration.');
             return;
           }
+          const confirmed = confirm(`Delete configuration "${config.name}"? This cannot be undone.`);
+          if (!confirmed) return;
           this.plugin.settings.configs = configs.filter(c => c.id !== config.id);
           // Switch to first remaining config
           this.plugin.settings.activeConfigId = this.plugin.settings.configs[0]?.id ?? '';
@@ -455,22 +477,31 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     setting.settingEl.addClass('ani-delete-config');
   }
 
-  // ─── Collapsible Sections ─────────────────────────────────────────
+  // ─── Summary Cards ─────────────────────────────────────────────────
 
-  private renderCollapsibleSection(
+  private renderSummaryCard(
     containerEl: HTMLElement,
     sectionId: string,
+    icon: string,
     title: string,
+    summary: string,
+    badgeStatus: 'ok' | 'off',
+    badgeText: string,
     renderContent: (container: HTMLElement) => void,
   ): void {
     const isExpanded = this.expandedSections.has(sectionId);
-    const indicator = isExpanded ? '\u25BC' : '\u25B6';
+    const card = containerEl.createDiv({ cls: `ani-summary-card${isExpanded ? ' is-expanded' : ''}` });
 
-    const heading = new Setting(containerEl)
-      .setName(`${indicator} ${title}`)
-      .setHeading();
-    heading.settingEl.addClass('ani-section-heading');
-    heading.settingEl.addEventListener('click', () => {
+    const header = card.createDiv({ cls: 'ani-card-header' });
+    header.createSpan({ cls: 'ani-card-icon', text: icon });
+    header.createSpan({ cls: 'ani-card-title', text: title });
+    if (summary) {
+      header.createSpan({ cls: 'ani-card-summary', text: summary });
+    }
+    header.createSpan({ cls: `ani-card-badge ani-card-badge-${badgeStatus}`, text: badgeText });
+    header.createSpan({ cls: 'ani-card-chevron', text: '\u25B6' });
+
+    header.addEventListener('click', () => {
       if (this.expandedSections.has(sectionId)) {
         this.expandedSections.delete(sectionId);
       } else {
@@ -480,18 +511,45 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     });
 
     if (isExpanded) {
-      const content = containerEl.createDiv({ cls: 'ani-section-content' });
-      renderContent(content);
+      const body = card.createDiv({ cls: 'ani-card-body' });
+      renderContent(body);
     }
+  }
+
+  private getConnectionSummary(config: ConfigEntry): string {
+    if (!config.baseId || !config.tableId) return '';
+    const parts: string[] = [];
+    if (config.filenameFieldName) parts.push(config.filenameFieldName);
+    if (config.viewId) parts.push('View filtered');
+    return parts.join(' \u00B7 ');
+  }
+
+  private getFileSummary(config: ConfigEntry): string {
+    const parts: string[] = [];
+    if (config.folderPath) parts.push(config.folderPath + '/');
+    if (config.templatePath) {
+      parts.push(config.templatePath.split('/').pop() ?? config.templatePath);
+    }
+    if (config.syncInterval > 0) parts.push(config.syncInterval + 'min');
+    return parts.join(' \u00B7 ');
+  }
+
+  private getSyncSummary(config: ConfigEntry): string {
+    if (!config.bidirectionalSync) return '';
+    const parts: string[] = [];
+    parts.push(config.conflictResolution);
+    if (config.watchForChanges) parts.push('watching');
+    return parts.join(' \u00B7 ');
   }
 
   // ─── File Settings ──────────────────────────────────────────────────
 
   private renderFileSettings(containerEl: HTMLElement, config: ConfigEntry): void {
-    // Folder path setting (with overlap validation)
-    new Setting(containerEl)
+    // Folder path setting (with inline overlap validation)
+    const folderDesc = 'Example: folder1/folder2';
+    const folderSetting = new Setting(containerEl)
       .setName("New file location")
-      .setDesc("Example: folder1/folder2")
+      .setDesc(folderDesc)
       .addText(text => {
         const input = text
           .setPlaceholder("Crawling")
@@ -499,9 +557,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             const error = validateFolderPath(config.id, value, this.plugin.settings.configs);
             if (error) {
-              new Notice(`Auto Note Importer: ${error}`);
+              folderSetting.descEl.textContent = error;
+              folderSetting.descEl.addClass('ani-field-error');
               return;
             }
+            folderSetting.descEl.textContent = folderDesc;
+            folderSetting.descEl.removeClass('ani-field-error');
             config.folderPath = value;
             await this.plugin.saveSettings();
           });
@@ -851,9 +912,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private renderDebugSettings(containerEl: HTMLElement): void {
-    new Setting(containerEl).setName('Debug').setHeading();
+    const section = containerEl.createDiv({ cls: 'ani-debug-section' });
 
-    new Setting(containerEl)
+    new Setting(section).setName('Debug').setHeading();
+
+    new Setting(section)
       .setName("Debug mode (slow sync)")
       .setDesc("Slows down all sync operations by 5x for easier testing and observation.")
       .addToggle(toggle => toggle

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -8,7 +8,7 @@
  * @handbook 5.1-ui-components
  */
 
-import { App, PluginSettingTab, Setting, Notice } from "obsidian";
+import { App, PluginSettingTab, Setting, Notice, setIcon } from "obsidian";
 import type { ExtraButtonComponent, Plugin } from "obsidian";
 import { FieldCache } from '../services';
 import { isFieldTypeSupported } from '../constants';
@@ -33,7 +33,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   plugin: SettingsPlugin;
   private fieldCache: FieldCache;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  private credentialsExpanded = false;
   private editingCredentialId: string | null = null;
   private addingCredential = false;
 
@@ -91,7 +90,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
-    // Credentials section (collapsible)
+    // Credentials section
     this.renderCredentialsSection(containerEl);
 
     // Tab bar for config switching
@@ -184,38 +183,43 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   // ─── Credentials Section ───────────────────────────────────────────
 
   private renderCredentialsSection(containerEl: HTMLElement): void {
-    const indicator = this.credentialsExpanded ? '\u25BC' : '\u25B6';
-    const heading = new Setting(containerEl)
-      .setName(`${indicator} Credentials`)
-      .setHeading();
-    heading.settingEl.addClass('ani-credentials-heading');
-    heading.settingEl.addEventListener('click', () => {
-      this.credentialsExpanded = !this.credentialsExpanded;
-      this.display();
-    });
-
-    if (!this.credentialsExpanded) return;
+    const section = containerEl.createDiv({ cls: 'ani-credentials-section' });
+    section.createEl('h3', { text: 'Credentials' });
+    section.createEl('p', { cls: 'ani-credentials-desc', text: 'Configure your Airtable credentials.' });
 
     const { credentials } = this.plugin.settings;
 
-    for (const cred of credentials) {
-      if (this.editingCredentialId === cred.id) {
-        this.renderCredentialEditRow(containerEl, cred);
-      } else {
-        this.renderCredentialRow(containerEl, cred);
+    if (credentials.length > 0) {
+      const table = section.createEl('table', { cls: 'ani-credentials-table' });
+      const thead = table.createEl('thead');
+      const headerRow = thead.createEl('tr');
+      headerRow.createEl('th', { text: 'Name' });
+      headerRow.createEl('th', { text: 'Type' });
+      headerRow.createEl('th', { text: 'API Key' });
+      headerRow.createEl('th', { text: 'Actions' });
+
+      const tbody = table.createEl('tbody');
+      for (const cred of credentials) {
+        this.renderCredentialTableRow(tbody, cred);
       }
     }
 
+    // Edit form (inline below table)
+    if (this.editingCredentialId) {
+      const cred = credentials.find(c => c.id === this.editingCredentialId);
+      if (cred) this.renderCredentialEditRow(section, cred);
+    }
+
+    // Add form or button
     if (this.addingCredential) {
-      this.renderCredentialAddRow(containerEl);
+      this.renderCredentialAddRow(section);
     } else {
-      new Setting(containerEl)
-        .addButton(button => button
-          .setButtonText('+ Add credential')
-          .onClick(() => {
-            this.addingCredential = true;
-            this.display();
-          }));
+      const addContainer = section.createDiv({ cls: 'ani-credentials-add' });
+      const addBtn = addContainer.createEl('button', { text: '+ Add credential' });
+      addBtn.addEventListener('click', () => {
+        this.addingCredential = true;
+        this.display();
+      });
     }
   }
 
@@ -224,30 +228,45 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     return '\u2022\u2022\u2022\u2022' + apiKey.slice(-4);
   }
 
-  private renderCredentialRow(containerEl: HTMLElement, cred: Credential): void {
-    new Setting(containerEl)
-      .setName(cred.name)
-      .setDesc(this.maskApiKey(cred.apiKey))
-      .addExtraButton(button => button
-        .setIcon('pencil')
-        .setTooltip('Edit credential')
-        .onClick(() => {
-          this.editingCredentialId = cred.id;
-          this.display();
-        }))
-      .addExtraButton(button => button
-        .setIcon('trash')
-        .setTooltip('Delete credential')
-        .onClick(async () => {
-          const inUse = this.plugin.settings.configs.some(c => c.credentialId === cred.id);
-          if (inUse) {
-            new Notice('Auto Note Importer: Cannot delete a credential that is in use by a configuration.');
-            return;
-          }
-          this.plugin.settings.credentials = this.plugin.settings.credentials.filter(c => c.id !== cred.id);
-          await this.plugin.saveSettings();
-          this.display();
-        }));
+  private renderCredentialTableRow(tbody: HTMLElement, cred: Credential): void {
+    const row = tbody.createEl('tr');
+    row.createEl('td', { cls: 'ani-cred-name', text: cred.name });
+    row.createEl('td', { cls: 'ani-cred-type', text: 'Airtable' });
+
+    const keyCell = row.createEl('td');
+    if (cred.apiKey) {
+      keyCell.createSpan({ cls: 'ani-cred-key', text: this.maskApiKey(cred.apiKey) });
+    } else {
+      const setLink = keyCell.createSpan({ cls: 'ani-cred-key-set', text: 'Set API key' });
+      setLink.addEventListener('click', () => {
+        this.editingCredentialId = cred.id;
+        this.display();
+      });
+    }
+
+    const actionsCell = row.createEl('td', { cls: 'ani-cred-actions' });
+
+    const editBtn = actionsCell.createEl('button', { cls: 'ani-cred-action-btn' });
+    setIcon(editBtn, 'settings');
+    editBtn.title = 'Edit credential';
+    editBtn.addEventListener('click', () => {
+      this.editingCredentialId = cred.id;
+      this.display();
+    });
+
+    const deleteBtn = actionsCell.createEl('button', { cls: 'ani-cred-action-btn' });
+    setIcon(deleteBtn, 'trash-2');
+    deleteBtn.title = 'Delete credential';
+    deleteBtn.addEventListener('click', async () => {
+      const inUse = this.plugin.settings.configs.some(c => c.credentialId === cred.id);
+      if (inUse) {
+        new Notice('Auto Note Importer: Cannot delete a credential that is in use by a configuration.');
+        return;
+      }
+      this.plugin.settings.credentials = this.plugin.settings.credentials.filter(c => c.id !== cred.id);
+      await this.plugin.saveSettings();
+      this.display();
+    });
   }
 
   private renderCredentialEditRow(containerEl: HTMLElement, cred: Credential): void {
@@ -375,7 +394,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     addTab.addEventListener('click', async () => {
       if (this.plugin.settings.credentials.length === 0) {
         new Notice('Auto Note Importer: Add a credential first before creating a configuration.');
-        this.credentialsExpanded = true;
         this.addingCredential = true;
         this.display();
         return;

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -118,31 +118,36 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Summary card stack
     const cardStack = containerEl.createDiv({ cls: 'ani-card-stack' });
 
+    const connected = !!(config.baseId && config.tableId);
     if (credential.apiKey) {
-      this.renderSummaryCard(cardStack, 'airtable-connection', '\u{1F4E1}', 'Airtable Connection',
-        this.getConnectionSummary(config),
-        config.baseId && config.tableId ? 'ok' : 'off',
-        config.baseId && config.tableId ? 'Connected' : 'Setup required',
-        (container) => { this.renderBaseSelector(container, config, credential); });
+      this.renderSummaryCard(cardStack, {
+        sectionId: 'airtable-connection', icon: '\u{1F4E1}', title: 'Airtable Connection',
+        summary: this.getConnectionSummary(config),
+        badge: connected ? { status: 'ok', text: 'Connected' } : { status: 'off', text: 'Setup required' },
+        renderContent: (c) => this.renderBaseSelector(c, config, credential),
+      });
     }
 
-    this.renderSummaryCard(cardStack, 'file-settings', '\u{1F4C1}', 'File Settings',
-      this.getFileSummary(config),
-      config.folderPath ? 'ok' : 'off',
-      config.folderPath ? 'Configured' : 'Setup required',
-      (container) => { this.renderFileSettings(container, config); });
+    this.renderSummaryCard(cardStack, {
+      sectionId: 'file-settings', icon: '\u{1F4C1}', title: 'File Settings',
+      summary: this.getFileSummary(config),
+      badge: config.folderPath ? { status: 'ok', text: 'Configured' } : { status: 'off', text: 'Setup required' },
+      renderContent: (c) => this.renderFileSettings(c, config),
+    });
 
-    this.renderSummaryCard(cardStack, 'bases-database', '\u{1F4BE}', 'Bases Database',
-      config.generateBasesFile ? 'Auto-generate enabled' : '',
-      config.generateBasesFile ? 'ok' : 'off',
-      config.generateBasesFile ? 'On' : 'Off',
-      (container) => { this.renderBasesSettings(container, config); });
+    this.renderSummaryCard(cardStack, {
+      sectionId: 'bases-database', icon: '\u{1F4BE}', title: 'Bases Database',
+      summary: config.generateBasesFile ? 'Auto-generate enabled' : '',
+      badge: config.generateBasesFile ? { status: 'ok', text: 'On' } : { status: 'off', text: 'Off' },
+      renderContent: (c) => this.renderBasesSettings(c, config),
+    });
 
-    this.renderSummaryCard(cardStack, 'bidirectional-sync', '\u{1F504}', 'Bidirectional Sync',
-      this.getSyncSummary(config),
-      config.bidirectionalSync ? 'ok' : 'off',
-      config.bidirectionalSync ? 'On' : 'Off',
-      (container) => { this.renderBidirectionalSyncSettings(container, config); });
+    this.renderSummaryCard(cardStack, {
+      sectionId: 'bidirectional-sync', icon: '\u{1F504}', title: 'Bidirectional Sync',
+      summary: this.getSyncSummary(config),
+      badge: config.bidirectionalSync ? { status: 'ok', text: 'On' } : { status: 'off', text: 'Off' },
+      renderContent: (c) => this.renderBidirectionalSyncSettings(c, config),
+    });
 
     // Delete config button
     this.renderDeleteConfigButton(containerEl, config);
@@ -347,9 +352,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       const tab = tabBar.createDiv({
         cls: `ani-config-tab${config.id === activeId ? ' active' : ''}`,
         text: config.name || 'Untitled',
+        attr: { 'data-config-id': config.id },
       });
-      tab.addEventListener('click', () => {
+      tab.addEventListener('click', async () => {
         this.plugin.settings.activeConfigId = config.id;
+        await this.plugin.saveSettings();
         this.display();
       });
     }
@@ -400,20 +407,15 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             c => c.id !== config.id && c.name.trim() === value.trim(),
           );
           if (duplicate) {
-            nameSetting.descEl.textContent = 'This name is already used by another configuration.';
-            nameSetting.descEl.addClass('ani-field-error');
+            this.showFieldError(nameSetting, 'This name is already used by another configuration.');
             return;
           }
-          nameSetting.descEl.textContent = 'A display name for this sync configuration.';
-          nameSetting.descEl.removeClass('ani-field-error');
+          this.showFieldError(nameSetting, null, 'A display name for this sync configuration.');
           config.name = value;
           await this.plugin.saveSettings();
           // Update tab text without full re-render
-          const tabs = this.containerEl.querySelectorAll('.ani-config-tab:not(.ani-add-tab)');
-          const activeIdx = this.plugin.settings.configs.findIndex(c => c.id === config.id);
-          if (tabs[activeIdx]) {
-            tabs[activeIdx].textContent = value || 'Untitled';
-          }
+          const tab = this.containerEl.querySelector(`.ani-config-tab[data-config-id="${config.id}"]`);
+          if (tab) tab.textContent = value || 'Untitled';
         }));
 
     // Enabled toggle
@@ -481,14 +483,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
   private renderSummaryCard(
     containerEl: HTMLElement,
-    sectionId: string,
-    icon: string,
-    title: string,
-    summary: string,
-    badgeStatus: 'ok' | 'off',
-    badgeText: string,
-    renderContent: (container: HTMLElement) => void,
+    opts: {
+      sectionId: string;
+      icon: string;
+      title: string;
+      summary: string;
+      badge: { status: 'ok' | 'off'; text: string };
+      renderContent: (container: HTMLElement) => void;
+    },
   ): void {
+    const { sectionId, icon, title, summary, badge, renderContent } = opts;
     const isExpanded = this.expandedSections.has(sectionId);
     const card = containerEl.createDiv({ cls: `ani-summary-card${isExpanded ? ' is-expanded' : ''}` });
 
@@ -498,7 +502,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     if (summary) {
       header.createSpan({ cls: 'ani-card-summary', text: summary });
     }
-    header.createSpan({ cls: `ani-card-badge ani-card-badge-${badgeStatus}`, text: badgeText });
+    header.createSpan({ cls: `ani-card-badge ani-card-badge-${badge.status}`, text: badge.text });
     header.createSpan({ cls: 'ani-card-chevron', text: '\u25B6' });
 
     header.addEventListener('click', () => {
@@ -513,6 +517,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     if (isExpanded) {
       const body = card.createDiv({ cls: 'ani-card-body' });
       renderContent(body);
+    }
+  }
+
+  private showFieldError(setting: Setting, error: string | null, defaultDesc?: string): void {
+    if (error) {
+      setting.descEl.textContent = error;
+      setting.descEl.addClass('ani-field-error');
+    } else {
+      setting.descEl.textContent = defaultDesc ?? '';
+      setting.descEl.removeClass('ani-field-error');
     }
   }
 
@@ -557,12 +571,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             const error = validateFolderPath(config.id, value, this.plugin.settings.configs);
             if (error) {
-              folderSetting.descEl.textContent = error;
-              folderSetting.descEl.addClass('ani-field-error');
+              this.showFieldError(folderSetting, error);
               return;
             }
-            folderSetting.descEl.textContent = folderDesc;
-            folderSetting.descEl.removeClass('ani-field-error');
+            this.showFieldError(folderSetting, null, folderDesc);
             config.folderPath = value;
             await this.plugin.saveSettings();
           });

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -2,7 +2,8 @@
  * Settings tab UI for the Auto Note Importer plugin.
  * UI-only - delegates API calls to FieldCache.
  *
- * Multi-config UI with credential management and per-config settings rendering.
+ * Multi-config UI with credential management, tab-based config switching,
+ * and per-config settings rendering.
  *
  * @handbook 5.1-ui-components
  */
@@ -12,8 +13,10 @@ import type { ExtraButtonComponent, Plugin } from "obsidian";
 import { FieldCache } from '../services';
 import { isFieldTypeSupported } from '../constants';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, ConflictResolutionMode, BasesFileLocation } from '../types';
+import { DEFAULT_CONFIG_ENTRY } from '../types';
 import { FolderSuggest, FileSuggest } from './suggest';
 import { generateId } from '../utils/object-utils';
+import { validateFolderPath } from '../utils/validation';
 
 /**
  * Interface for the plugin that the settings tab needs.
@@ -91,23 +94,31 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Credentials section (collapsible)
     this.renderCredentialsSection(containerEl);
 
+    // Tab bar for config switching
+    this.renderTabBar(containerEl);
+
     const config = this.activeConfig;
     const credential = this.activeCredential;
 
     if (!config || !credential) {
-      new Setting(containerEl)
-        .setName('No configuration')
-        .setDesc('Add a configuration to get started.');
+      if (this.plugin.settings.configs.length === 0) {
+        new Setting(containerEl)
+          .setName('No configuration')
+          .setDesc('Add a configuration using the + tab above.');
+      }
       this.renderDebugSettings(containerEl);
       return;
     }
+
+    // Config header: name, enabled toggle, credential selector
+    this.renderConfigHeader(containerEl, config);
 
     // Airtable connection settings (base, table, view, fields)
     if (credential.apiKey) {
       this.renderBaseSelector(containerEl, config, credential);
     }
 
-    // Folder path setting
+    // Folder path setting (with overlap validation)
     new Setting(containerEl)
       .setName("New file location")
       .setDesc("Example: folder1/folder2")
@@ -116,6 +127,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .setPlaceholder("Crawling")
           .setValue(config.folderPath)
           .onChange(async (value) => {
+            const error = validateFolderPath(config.id, value, this.plugin.settings.configs);
+            if (error) {
+              new Notice(`Auto Note Importer: ${error}`);
+              return;
+            }
             config.folderPath = value;
             await this.plugin.saveSettings();
           });
@@ -157,6 +173,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
     // Bidirectional sync settings
     this.renderBidirectionalSyncSettings(containerEl, config);
+
+    // Delete config button
+    this.renderDeleteConfigButton(containerEl, config);
 
     // Debug settings
     this.renderDebugSettings(containerEl);
@@ -328,6 +347,132 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           this.addingCredential = false;
           this.display();
         }));
+  }
+
+  // ─── Tab Bar ───────────────────────────────────────────────────────
+
+  private renderTabBar(containerEl: HTMLElement): void {
+    const tabBar = containerEl.createDiv({ cls: 'ani-config-tab-bar' });
+    const { configs } = this.plugin.settings;
+    const activeId = this.activeConfig?.id;
+
+    for (const config of configs) {
+      const tab = tabBar.createDiv({
+        cls: `ani-config-tab${config.id === activeId ? ' active' : ''}`,
+        text: config.name || 'Untitled',
+      });
+      tab.addEventListener('click', () => {
+        this.plugin.settings.activeConfigId = config.id;
+        this.display();
+      });
+    }
+
+    // Add tab
+    const addTab = tabBar.createDiv({
+      cls: 'ani-config-tab ani-add-tab',
+      text: '+',
+    });
+    addTab.addEventListener('click', async () => {
+      if (this.plugin.settings.credentials.length === 0) {
+        new Notice('Auto Note Importer: Add a credential first before creating a configuration.');
+        this.credentialsExpanded = true;
+        this.addingCredential = true;
+        this.display();
+        return;
+      }
+      const newConfig: ConfigEntry = {
+        ...DEFAULT_CONFIG_ENTRY,
+        id: generateId(),
+        name: `Config ${configs.length + 1}`,
+        credentialId: this.plugin.settings.credentials[0].id,
+      };
+      this.plugin.settings.configs.push(newConfig);
+      this.plugin.settings.activeConfigId = newConfig.id;
+      await this.plugin.saveSettings();
+      this.display();
+    });
+  }
+
+  // ─── Config Header ─────────────────────────────────────────────────
+
+  private renderConfigHeader(containerEl: HTMLElement, config: ConfigEntry): void {
+    new Setting(containerEl).setName('Configuration').setHeading();
+
+    // Config name
+    new Setting(containerEl)
+      .setName('Configuration name')
+      .setDesc('A display name for this sync configuration.')
+      .addText(text => text
+        .setPlaceholder('My Config')
+        .setValue(config.name)
+        .onChange(async (value) => {
+          config.name = value;
+          await this.plugin.saveSettings();
+          // Update tab text without full re-render
+          const tabs = this.containerEl.querySelectorAll('.ani-config-tab:not(.ani-add-tab)');
+          const activeIdx = this.plugin.settings.configs.findIndex(c => c.id === config.id);
+          if (tabs[activeIdx]) {
+            tabs[activeIdx].textContent = value || 'Untitled';
+          }
+        }));
+
+    // Enabled toggle
+    new Setting(containerEl)
+      .setName('Enabled')
+      .setDesc('When disabled, this configuration will not sync.')
+      .addToggle(toggle => toggle
+        .setValue(config.enabled)
+        .onChange(async (value) => {
+          config.enabled = value;
+          await this.plugin.saveSettings();
+        }));
+
+    // Credential selector
+    new Setting(containerEl)
+      .setName('Credential')
+      .setDesc('Select the Airtable credential to use for this configuration.')
+      .addDropdown(dropdown => {
+        const { credentials } = this.plugin.settings;
+        if (credentials.length === 0) {
+          dropdown.addOption('', '-- No credentials --');
+        } else {
+          for (const cred of credentials) {
+            dropdown.addOption(cred.id, cred.name);
+          }
+        }
+        dropdown.setValue(config.credentialId);
+        dropdown.onChange(async (value) => {
+          config.credentialId = value;
+          await this.plugin.saveSettings();
+          this.debounceDisplay();
+        });
+      });
+  }
+
+  // ─── Delete Config ─────────────────────────────────────────────────
+
+  private renderDeleteConfigButton(containerEl: HTMLElement, config: ConfigEntry): void {
+    new Setting(containerEl).setName('Danger zone').setHeading();
+
+    const setting = new Setting(containerEl)
+      .setName('Delete this configuration')
+      .setDesc('Permanently remove this sync configuration. This cannot be undone.')
+      .addButton(button => button
+        .setButtonText('Delete')
+        .setWarning()
+        .onClick(async () => {
+          const { configs } = this.plugin.settings;
+          if (configs.length <= 1) {
+            new Notice('Auto Note Importer: Cannot delete the last configuration.');
+            return;
+          }
+          this.plugin.settings.configs = configs.filter(c => c.id !== config.id);
+          // Switch to first remaining config
+          this.plugin.settings.activeConfigId = this.plugin.settings.configs[0]?.id ?? '';
+          await this.plugin.saveSettings();
+          this.display();
+        }));
+    setting.settingEl.addClass('ani-delete-config');
   }
 
   // ─── Existing Render Methods ───────────────────────────────────────

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -2,8 +2,7 @@
  * Settings tab UI for the Auto Note Importer plugin.
  * UI-only - delegates API calls to FieldCache.
  *
- * Temporary bridge: reads/writes through activeConfig and activeCredential
- * helpers until Tasks 10-11 implement the full multi-config UI.
+ * Multi-config UI with credential management and per-config settings rendering.
  *
  * @handbook 5.1-ui-components
  */
@@ -14,6 +13,7 @@ import { FieldCache } from '../services';
 import { isFieldTypeSupported } from '../constants';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { FolderSuggest, FileSuggest } from './suggest';
+import { generateId } from '../utils/object-utils';
 
 /**
  * Interface for the plugin that the settings tab needs.
@@ -30,6 +30,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   plugin: SettingsPlugin;
   private fieldCache: FieldCache;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private credentialsExpanded = false;
+  private editingCredentialId: string | null = null;
+  private addingCredential = false;
 
   constructor(app: App, plugin: SettingsPlugin, fieldCache: FieldCache) {
     super(app, plugin);
@@ -85,6 +88,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
+    // Credentials section (collapsible)
+    this.renderCredentialsSection(containerEl);
+
     const config = this.activeConfig;
     const credential = this.activeCredential;
 
@@ -96,22 +102,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       return;
     }
 
-    // API Key setting
-    new Setting(containerEl)
-      .setName("Airtable personal access token")
-      .setDesc("Enter your Airtable personal access token.")
-      .addText(text => {
-        text
-          .setPlaceholder("your-pat-token")
-          .setValue(credential.apiKey)
-          .onChange(async (value) => {
-            credential.apiKey = value;
-            await this.plugin.saveSettings();
-            this.debounceDisplay();
-          });
-        text.inputEl.type = 'password';
-      });
-
+    // Airtable connection settings (base, table, view, fields)
     if (credential.apiKey) {
       this.renderBaseSelector(containerEl, config, credential);
     }
@@ -170,6 +161,176 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Debug settings
     this.renderDebugSettings(containerEl);
   }
+
+  // ─── Credentials Section ───────────────────────────────────────────
+
+  private renderCredentialsSection(containerEl: HTMLElement): void {
+    const indicator = this.credentialsExpanded ? '\u25BC' : '\u25B6';
+    const heading = new Setting(containerEl)
+      .setName(`${indicator} Credentials`)
+      .setHeading();
+    heading.settingEl.addClass('ani-credentials-heading');
+    heading.settingEl.addEventListener('click', () => {
+      this.credentialsExpanded = !this.credentialsExpanded;
+      this.display();
+    });
+
+    if (!this.credentialsExpanded) return;
+
+    const { credentials } = this.plugin.settings;
+
+    for (const cred of credentials) {
+      if (this.editingCredentialId === cred.id) {
+        this.renderCredentialEditRow(containerEl, cred);
+      } else {
+        this.renderCredentialRow(containerEl, cred);
+      }
+    }
+
+    if (this.addingCredential) {
+      this.renderCredentialAddRow(containerEl);
+    } else {
+      new Setting(containerEl)
+        .addButton(button => button
+          .setButtonText('+ Add credential')
+          .onClick(() => {
+            this.addingCredential = true;
+            this.display();
+          }));
+    }
+  }
+
+  private maskApiKey(apiKey: string): string {
+    if (apiKey.length <= 4) return apiKey ? '****' : '';
+    return '\u2022\u2022\u2022\u2022' + apiKey.slice(-4);
+  }
+
+  private renderCredentialRow(containerEl: HTMLElement, cred: Credential): void {
+    new Setting(containerEl)
+      .setName(cred.name)
+      .setDesc(this.maskApiKey(cred.apiKey))
+      .addExtraButton(button => button
+        .setIcon('pencil')
+        .setTooltip('Edit credential')
+        .onClick(() => {
+          this.editingCredentialId = cred.id;
+          this.display();
+        }))
+      .addExtraButton(button => button
+        .setIcon('trash')
+        .setTooltip('Delete credential')
+        .onClick(async () => {
+          const inUse = this.plugin.settings.configs.some(c => c.credentialId === cred.id);
+          if (inUse) {
+            new Notice('Auto Note Importer: Cannot delete a credential that is in use by a configuration.');
+            return;
+          }
+          this.plugin.settings.credentials = this.plugin.settings.credentials.filter(c => c.id !== cred.id);
+          await this.plugin.saveSettings();
+          this.display();
+        }));
+  }
+
+  private renderCredentialEditRow(containerEl: HTMLElement, cred: Credential): void {
+    let nameValue = cred.name;
+    let keyValue = cred.apiKey;
+
+    const nameSetting = new Setting(containerEl)
+      .setName('Name')
+      .addText(text => text
+        .setValue(cred.name)
+        .setPlaceholder('Credential name')
+        .onChange(value => { nameValue = value; }));
+    nameSetting.settingEl.addClass('ani-credential-edit');
+
+    const keySetting = new Setting(containerEl)
+      .setName('API Key')
+      .addText(text => {
+        text
+          .setValue(cred.apiKey)
+          .setPlaceholder('pat-xxx...')
+          .onChange(value => { keyValue = value; });
+        text.inputEl.type = 'password';
+      });
+    keySetting.settingEl.addClass('ani-credential-edit');
+
+    new Setting(containerEl)
+      .addButton(button => button
+        .setButtonText('Save')
+        .setCta()
+        .onClick(async () => {
+          if (!nameValue.trim()) {
+            new Notice('Auto Note Importer: Credential name cannot be empty.');
+            return;
+          }
+          cred.name = nameValue.trim();
+          cred.apiKey = keyValue;
+          await this.plugin.saveSettings();
+          this.editingCredentialId = null;
+          this.display();
+        }))
+      .addButton(button => button
+        .setButtonText('Cancel')
+        .onClick(() => {
+          this.editingCredentialId = null;
+          this.display();
+        }));
+  }
+
+  private renderCredentialAddRow(containerEl: HTMLElement): void {
+    let nameValue = '';
+    let keyValue = '';
+
+    const nameSetting = new Setting(containerEl)
+      .setName('Name')
+      .addText(text => text
+        .setPlaceholder('e.g. Personal Airtable')
+        .onChange(value => { nameValue = value; }));
+    nameSetting.settingEl.addClass('ani-credential-edit');
+
+    const keySetting = new Setting(containerEl)
+      .setName('API Key')
+      .addText(text => {
+        text
+          .setPlaceholder('pat-xxx...')
+          .onChange(value => { keyValue = value; });
+        text.inputEl.type = 'password';
+      });
+    keySetting.settingEl.addClass('ani-credential-edit');
+
+    new Setting(containerEl)
+      .addButton(button => button
+        .setButtonText('Save')
+        .setCta()
+        .onClick(async () => {
+          if (!nameValue.trim()) {
+            new Notice('Auto Note Importer: Credential name cannot be empty.');
+            return;
+          }
+          if (!keyValue.trim()) {
+            new Notice('Auto Note Importer: API key cannot be empty.');
+            return;
+          }
+          const newCred: Credential = {
+            id: generateId(),
+            name: nameValue.trim(),
+            type: 'airtable',
+            apiKey: keyValue.trim(),
+          };
+          this.plugin.settings.credentials.push(newCred);
+          await this.plugin.saveSettings();
+          this.addingCredential = false;
+          this.display();
+        }))
+      .addButton(button => button
+        .setButtonText('Cancel')
+        .onClick(() => {
+          this.addingCredential = false;
+          this.display();
+        }));
+  }
+
+  // ─── Existing Render Methods ───────────────────────────────────────
 
   private renderBaseSelector(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
     new Setting(containerEl)

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -35,6 +35,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private editingCredentialId: string | null = null;
   private addingCredential = false;
+  private expandedSections: Set<string> = new Set(['airtable-connection']);
 
   constructor(app: App, plugin: SettingsPlugin, fieldCache: FieldCache) {
     super(app, plugin);
@@ -112,66 +113,27 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Config header: name, enabled toggle, credential selector
     this.renderConfigHeader(containerEl, config);
 
-    // Airtable connection settings (base, table, view, fields)
+    // Section 1: Airtable Connection (expanded by default)
     if (credential.apiKey) {
-      this.renderBaseSelector(containerEl, config, credential);
+      this.renderCollapsibleSection(containerEl, 'airtable-connection', 'Airtable Connection', (container) => {
+        this.renderBaseSelector(container, config, credential);
+      });
     }
 
-    // Folder path setting (with overlap validation)
-    new Setting(containerEl)
-      .setName("New file location")
-      .setDesc("Example: folder1/folder2")
-      .addText(text => {
-        const input = text
-          .setPlaceholder("Crawling")
-          .setValue(config.folderPath)
-          .onChange(async (value) => {
-            const error = validateFolderPath(config.id, value, this.plugin.settings.configs);
-            if (error) {
-              new Notice(`Auto Note Importer: ${error}`);
-              return;
-            }
-            config.folderPath = value;
-            await this.plugin.saveSettings();
-          });
-        new FolderSuggest(this.app, input.inputEl as HTMLInputElement);
-      });
+    // Section 2: File Settings
+    this.renderCollapsibleSection(containerEl, 'file-settings', 'File Settings', (container) => {
+      this.renderFileSettings(container, config);
+    });
 
-    // Template path setting
-    new Setting(containerEl)
-      .setName("Template file")
-      .setDesc("Example: templates/template-file.md")
-      .addText(text => {
-        const input = text
-          .setPlaceholder("Templates/note-template.md")
-          .setValue(config.templatePath)
-          .onChange(async (value) => {
-            config.templatePath = value;
-            await this.plugin.saveSettings();
-          });
-        new FileSuggest(this.app, input.inputEl as HTMLInputElement);
-      });
+    // Section 3: Bases Database
+    this.renderCollapsibleSection(containerEl, 'bases-database', 'Bases Database', (container) => {
+      this.renderBasesSettings(container, config);
+    });
 
-    this.renderNumberSetting(containerEl, "Sync interval (minutes)", "How often to sync notes (in minutes).", "0",
-      config.syncInterval, "Sync interval",
-      (num) => { config.syncInterval = num; });
-
-    // Allow overwrite setting
-    new Setting(containerEl)
-      .setName("Allow overwrite existing notes")
-      .setDesc("If enabled, existing notes will be overwritten when syncing.")
-      .addToggle(toggle => toggle
-        .setValue(config.allowOverwrite)
-        .onChange(async (value) => {
-          config.allowOverwrite = value;
-          await this.plugin.saveSettings();
-        }));
-
-    // Bases database settings
-    this.renderBasesSettings(containerEl, config);
-
-    // Bidirectional sync settings
-    this.renderBidirectionalSyncSettings(containerEl, config);
+    // Section 4: Bidirectional Sync
+    this.renderCollapsibleSection(containerEl, 'bidirectional-sync', 'Bidirectional Sync', (container) => {
+      this.renderBidirectionalSyncSettings(container, config);
+    });
 
     // Delete config button
     this.renderDeleteConfigButton(containerEl, config);
@@ -493,6 +455,90 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     setting.settingEl.addClass('ani-delete-config');
   }
 
+  // ─── Collapsible Sections ─────────────────────────────────────────
+
+  private renderCollapsibleSection(
+    containerEl: HTMLElement,
+    sectionId: string,
+    title: string,
+    renderContent: (container: HTMLElement) => void,
+  ): void {
+    const isExpanded = this.expandedSections.has(sectionId);
+    const indicator = isExpanded ? '\u25BC' : '\u25B6';
+
+    const heading = new Setting(containerEl)
+      .setName(`${indicator} ${title}`)
+      .setHeading();
+    heading.settingEl.addClass('ani-section-heading');
+    heading.settingEl.addEventListener('click', () => {
+      if (this.expandedSections.has(sectionId)) {
+        this.expandedSections.delete(sectionId);
+      } else {
+        this.expandedSections.add(sectionId);
+      }
+      this.display();
+    });
+
+    if (isExpanded) {
+      const content = containerEl.createDiv({ cls: 'ani-section-content' });
+      renderContent(content);
+    }
+  }
+
+  // ─── File Settings ──────────────────────────────────────────────────
+
+  private renderFileSettings(containerEl: HTMLElement, config: ConfigEntry): void {
+    // Folder path setting (with overlap validation)
+    new Setting(containerEl)
+      .setName("New file location")
+      .setDesc("Example: folder1/folder2")
+      .addText(text => {
+        const input = text
+          .setPlaceholder("Crawling")
+          .setValue(config.folderPath)
+          .onChange(async (value) => {
+            const error = validateFolderPath(config.id, value, this.plugin.settings.configs);
+            if (error) {
+              new Notice(`Auto Note Importer: ${error}`);
+              return;
+            }
+            config.folderPath = value;
+            await this.plugin.saveSettings();
+          });
+        new FolderSuggest(this.app, input.inputEl as HTMLInputElement);
+      });
+
+    // Template path setting
+    new Setting(containerEl)
+      .setName("Template file")
+      .setDesc("Example: templates/template-file.md")
+      .addText(text => {
+        const input = text
+          .setPlaceholder("Templates/note-template.md")
+          .setValue(config.templatePath)
+          .onChange(async (value) => {
+            config.templatePath = value;
+            await this.plugin.saveSettings();
+          });
+        new FileSuggest(this.app, input.inputEl as HTMLInputElement);
+      });
+
+    this.renderNumberSetting(containerEl, "Sync interval (minutes)", "How often to sync notes (in minutes).", "0",
+      config.syncInterval, "Sync interval",
+      (num) => { config.syncInterval = num; });
+
+    // Allow overwrite setting
+    new Setting(containerEl)
+      .setName("Allow overwrite existing notes")
+      .setDesc("If enabled, existing notes will be overwritten when syncing.")
+      .addToggle(toggle => toggle
+        .setValue(config.allowOverwrite)
+        .onChange(async (value) => {
+          config.allowOverwrite = value;
+          await this.plugin.saveSettings();
+        }));
+  }
+
   // ─── Existing Render Methods ───────────────────────────────────────
 
   private renderBaseSelector(containerEl: HTMLElement, config: ConfigEntry, credential: Credential): void {
@@ -651,8 +697,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private renderBasesSettings(containerEl: HTMLElement, config: ConfigEntry): void {
-    new Setting(containerEl).setName('Bases database').setHeading();
-
     new Setting(containerEl)
       .setName('Auto-generate Bases database file')
       .setDesc('Create a .base file after sync for table/card view in Obsidian Bases.')
@@ -708,8 +752,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private renderBidirectionalSyncSettings(containerEl: HTMLElement, config: ConfigEntry): void {
-    new Setting(containerEl).setName('Bidirectional sync').setHeading();
-
     new Setting(containerEl)
       .setName("Enable bidirectional sync")
       .setDesc("When enabled, changes made in Obsidian will be synced back to Airtable.")

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -1,0 +1,92 @@
+/**
+ * Settings migration utility for upgrading legacy single-config settings to v2 multi-config format.
+ */
+
+import type { Credential } from '../types/credential.types';
+import type { ConfigEntry } from '../types/config.types';
+import { generateId } from './object-utils';
+
+/**
+ * The v2 multi-config settings structure returned after migration.
+ */
+export interface MultiConfigSettings {
+  version: 2;
+  credentials: Credential[];
+  configs: ConfigEntry[];
+  activeConfigId: string;
+  debugMode: boolean;
+}
+
+/**
+ * Migrates legacy single-config settings data to the v2 multi-config format.
+ *
+ * - Returns null for null/undefined input (fresh install, no migration needed).
+ * - Returns null if data is already v2 format (migration already done).
+ * - Otherwise converts legacy settings into a single credential + config entry.
+ *
+ * @param data - Raw settings data loaded from plugin storage (unknown type)
+ * @returns Migrated v2 settings, or null if migration is not applicable
+ */
+export function migrateSettings(data: unknown): MultiConfigSettings | null {
+  if (data == null) {
+    return null;
+  }
+
+  if (typeof data !== 'object') {
+    return null;
+  }
+
+  const record = data as Record<string, unknown>;
+
+  if (record['version'] === 2) {
+    return null;
+  }
+
+  const credentialId = generateId();
+  const configId = generateId();
+
+  const credential: Credential = {
+    id: credentialId,
+    name: 'Airtable',
+    type: 'airtable',
+    apiKey: typeof record['apiKey'] === 'string' ? record['apiKey'] : '',
+  };
+
+  const config: ConfigEntry = {
+    id: configId,
+    name: 'Default',
+    enabled: true,
+    credentialId,
+    baseId: typeof record['baseId'] === 'string' ? record['baseId'] : '',
+    tableId: typeof record['tableId'] === 'string' ? record['tableId'] : '',
+    viewId: typeof record['viewId'] === 'string' ? record['viewId'] : '',
+    folderPath: typeof record['folderPath'] === 'string' ? record['folderPath'] : '',
+    templatePath: typeof record['templatePath'] === 'string' ? record['templatePath'] : '',
+    filenameFieldName: typeof record['filenameFieldName'] === 'string' ? record['filenameFieldName'] : '',
+    subfolderFieldName: typeof record['subfolderFieldName'] === 'string' ? record['subfolderFieldName'] : '',
+    syncInterval: typeof record['syncInterval'] === 'number' ? record['syncInterval'] : 0,
+    allowOverwrite: typeof record['allowOverwrite'] === 'boolean' ? record['allowOverwrite'] : true,
+    bidirectionalSync: typeof record['bidirectionalSync'] === 'boolean' ? record['bidirectionalSync'] : false,
+    conflictResolution: (record['conflictResolution'] === 'obsidian-wins' || record['conflictResolution'] === 'airtable-wins')
+      ? record['conflictResolution']
+      : 'manual',
+    watchForChanges: typeof record['watchForChanges'] === 'boolean' ? record['watchForChanges'] : false,
+    fileWatchDebounce: typeof record['fileWatchDebounce'] === 'number' ? record['fileWatchDebounce'] : 2000,
+    autoSyncFormulas: typeof record['autoSyncFormulas'] === 'boolean' ? record['autoSyncFormulas'] : false,
+    formulaSyncDelay: typeof record['formulaSyncDelay'] === 'number' ? record['formulaSyncDelay'] : 3000,
+    generateBasesFile: typeof record['generateBasesFile'] === 'boolean' ? record['generateBasesFile'] : false,
+    basesFileLocation: (record['basesFileLocation'] === 'synced-folder' || record['basesFileLocation'] === 'custom')
+      ? record['basesFileLocation']
+      : 'vault-root',
+    basesCustomPath: typeof record['basesCustomPath'] === 'string' ? record['basesCustomPath'] : '',
+    basesRegenerateOnSync: typeof record['basesRegenerateOnSync'] === 'boolean' ? record['basesRegenerateOnSync'] : false,
+  };
+
+  return {
+    version: 2,
+    credentials: [credential],
+    configs: [config],
+    activeConfigId: configId,
+    debugMode: typeof record['debugMode'] === 'boolean' ? record['debugMode'] : false,
+  };
+}

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -63,7 +63,7 @@ export function migrateSettings(data: unknown): AutoNoteImporterSettings | null 
     watchForChanges: typeof record['watchForChanges'] === 'boolean' ? record['watchForChanges'] : false,
     fileWatchDebounce: typeof record['fileWatchDebounce'] === 'number' ? record['fileWatchDebounce'] : 2000,
     autoSyncFormulas: typeof record['autoSyncFormulas'] === 'boolean' ? record['autoSyncFormulas'] : false,
-    formulaSyncDelay: typeof record['formulaSyncDelay'] === 'number' ? record['formulaSyncDelay'] : 3000,
+    formulaSyncDelay: typeof record['formulaSyncDelay'] === 'number' ? record['formulaSyncDelay'] : 1500,
     generateBasesFile: typeof record['generateBasesFile'] === 'boolean' ? record['generateBasesFile'] : false,
     basesFileLocation: (record['basesFileLocation'] === 'synced-folder' || record['basesFileLocation'] === 'custom')
       ? record['basesFileLocation']

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -4,18 +4,8 @@
 
 import type { Credential } from '../types/credential.types';
 import type { ConfigEntry } from '../types/config.types';
+import type { AutoNoteImporterSettings } from '../types/settings.types';
 import { generateId } from './object-utils';
-
-/**
- * The v2 multi-config settings structure returned after migration.
- */
-export interface MultiConfigSettings {
-  version: 2;
-  credentials: Credential[];
-  configs: ConfigEntry[];
-  activeConfigId: string;
-  debugMode: boolean;
-}
 
 /**
  * Migrates legacy single-config settings data to the v2 multi-config format.
@@ -27,7 +17,7 @@ export interface MultiConfigSettings {
  * @param data - Raw settings data loaded from plugin storage (unknown type)
  * @returns Migrated v2 settings, or null if migration is not applicable
  */
-export function migrateSettings(data: unknown): MultiConfigSettings | null {
+export function migrateSettings(data: unknown): AutoNoteImporterSettings | null {
   if (data == null) {
     return null;
   }

--- a/src/utils/object-utils.ts
+++ b/src/utils/object-utils.ts
@@ -68,5 +68,5 @@ export function areValuesEqual(value1: unknown, value2: unknown): boolean {
  * @returns A unique string identifier
  */
 export function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  return crypto.randomUUID();
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,41 @@
+/**
+ * Validation utilities for plugin configuration.
+ */
+
+import { normalizePath } from 'obsidian';
+import type { ConfigEntry } from '../types/config.types';
+
+/**
+ * Validates that a folder path does not overlap with any other config's folder path.
+ *
+ * Overlap is defined as:
+ * - Identical paths
+ * - One path is an ancestor of the other (parent-child or child-parent relationship)
+ *
+ * Disabled configs are still checked to prevent future conflicts when re-enabled.
+ *
+ * @param configId - The ID of the config being validated (excluded from comparison)
+ * @param folderPath - The folder path to validate
+ * @param configs - All existing config entries
+ * @returns An error message string if there is a conflict, or null if valid
+ */
+export function validateFolderPath(
+  configId: string,
+  folderPath: string,
+  configs: ConfigEntry[],
+): string | null {
+  const normalized = normalizePath(folderPath);
+  for (const config of configs) {
+    if (config.id === configId) continue;
+    const other = normalizePath(config.folderPath);
+    if (!other) continue;
+    if (
+      normalized === other ||
+      normalized.startsWith(other + '/') ||
+      other.startsWith(normalized + '/')
+    ) {
+      return `Folder conflicts with "${config.name}" configuration`;
+    }
+  }
+  return null;
+}

--- a/styles.css
+++ b/styles.css
@@ -148,20 +148,115 @@
   color: var(--text-accent);
 }
 
-/* ─── Collapsible Sections ────────────────────────────────────────── */
+/* ─── Debug Section Spacing ────────────────────────────────────────── */
 
-.ani-section-heading {
+.ani-debug-section {
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+/* ─── Summary Cards ───────────────────────────────────────────────── */
+
+.ani-card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.ani-summary-card {
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  overflow: hidden;
+  transition: border-color 150ms;
+}
+
+.ani-summary-card:hover {
+  border-color: var(--background-modifier-border-hover);
+}
+
+.ani-summary-card.is-expanded {
+  border-color: var(--interactive-accent);
+}
+
+.ani-card-header {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 8px;
   cursor: pointer;
   user-select: none;
 }
 
-.ani-section-heading:hover {
+.ani-card-header:hover {
   background: var(--background-modifier-hover);
-  border-radius: 4px;
 }
 
-.ani-section-content {
-  padding-left: 4px;
+.ani-card-icon {
+  font-size: 13px;
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+}
+
+.ani-card-title {
+  font-size: var(--font-ui-small);
+  font-weight: 500;
+  color: var(--text-normal);
+  flex: 1;
+}
+
+.ani-card-summary {
+  font-size: var(--font-smallest);
+  color: var(--text-faint);
+  margin-right: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.ani-card-badge {
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 8px;
+  font-weight: 500;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.ani-card-badge-ok {
+  background: rgba(0, 200, 83, 0.1);
+  color: #4ade80;
+}
+
+.ani-card-badge-off {
+  background: rgba(128, 128, 128, 0.1);
+  color: var(--text-faint);
+}
+
+.ani-card-chevron {
+  font-size: 9px;
+  color: var(--text-faint);
+  flex-shrink: 0;
+  transition: transform 200ms;
+}
+
+.ani-summary-card.is-expanded .ani-card-chevron {
+  transform: rotate(90deg);
+}
+
+.ani-card-body {
+  padding: 4px 12px 10px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+/* ─── Inline Field Errors ─────────────────────────────────────────── */
+
+.ani-field-error {
+  color: var(--text-error) !important;
 }
 
 /* ─── Delete Config ───────────────────────────────────────────────── */

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,22 @@
   color: var(--text-accent);
 }
 
+/* ─── Collapsible Sections ────────────────────────────────────────── */
+
+.ani-section-heading {
+  cursor: pointer;
+  user-select: none;
+}
+
+.ani-section-heading:hover {
+  background: var(--background-modifier-hover);
+  border-radius: 4px;
+}
+
+.ani-section-content {
+  padding-left: 4px;
+}
+
 /* ─── Delete Config ───────────────────────────────────────────────── */
 
 .ani-delete-config .setting-item-control .mod-warning {

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,20 @@
 /*
+ * Auto Note Importer plugin styles.
+ */
 
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
+/* ─── Credentials Section ─────────────────────────────────────────── */
 
-If your plugin does not need CSS, delete this file.
+.ani-credentials-heading {
+  cursor: pointer;
+  user-select: none;
+}
 
-*/
+.ani-credentials-heading:hover {
+  background: var(--background-modifier-hover);
+  border-radius: 4px;
+}
+
+.ani-credential-edit {
+  padding-left: 12px;
+  border-left: 2px solid var(--interactive-accent);
+}

--- a/styles.css
+++ b/styles.css
@@ -2,18 +2,106 @@
  * Auto Note Importer plugin styles.
  */
 
-/* ─── Credentials Section ─────────────────────────────────────────── */
+/* ─── Credentials Table ──────────────────────────────────────────── */
 
-.ani-credentials-heading {
+.ani-credentials-section {
+  margin-bottom: 24px;
+}
+
+.ani-credentials-section h3 {
+  margin: 0 0 4px;
+  font-size: var(--h3-size);
+  font-weight: var(--h3-weight);
+  color: var(--h3-color);
+}
+
+.ani-credentials-section .ani-credentials-desc {
+  font-size: var(--font-smallest);
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.ani-credentials-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-ui-small);
+  margin-bottom: 8px;
+}
+
+.ani-credentials-table th {
+  text-align: left;
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: var(--font-smallest);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.ani-credentials-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  vertical-align: middle;
+}
+
+.ani-credentials-table tr:last-child td {
+  border-bottom: none;
+}
+
+.ani-credentials-table .ani-cred-name {
+  color: var(--text-accent);
+  font-weight: 500;
+}
+
+.ani-credentials-table .ani-cred-type {
+  color: var(--text-normal);
+}
+
+.ani-credentials-table .ani-cred-key {
+  color: var(--text-muted);
+}
+
+.ani-credentials-table .ani-cred-key-set {
+  color: var(--text-accent);
   cursor: pointer;
-  user-select: none;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 150ms;
 }
 
-.ani-credentials-heading:hover {
-  background: var(--background-modifier-hover);
+.ani-credentials-table .ani-cred-key-set:hover {
+  text-decoration-color: var(--text-accent);
+}
+
+.ani-credentials-table .ani-cred-actions {
+  text-align: right;
+}
+
+.ani-credentials-table .ani-cred-action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 4px;
   border-radius: 4px;
+  transition: color 150ms, background 150ms;
 }
 
+.ani-credentials-table .ani-cred-action-btn:hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+}
+
+.ani-credentials-add {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.ani-credentials-add button {
+  font-size: var(--font-ui-small);
+}
+
+/* Credential edit form (inline) */
 .ani-credential-edit {
   padding-left: 12px;
   border-left: 2px solid var(--interactive-accent);
@@ -24,30 +112,40 @@
 .ani-config-tab-bar {
   display: flex;
   gap: 0;
-  border-bottom: 2px solid var(--interactive-accent);
-  margin-bottom: 16px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  margin-bottom: 20px;
+  padding: 0;
 }
 
 .ani-config-tab {
-  padding: 6px 14px;
+  padding: 8px 16px;
   cursor: pointer;
-  border-radius: 6px 6px 0 0;
-  font-size: 13px;
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  transition: color 150ms, border-color 150ms;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.ani-config-tab:hover {
+  color: var(--text-normal);
 }
 
 .ani-config-tab.active {
-  background: var(--interactive-accent);
-  color: var(--text-on-accent);
+  color: var(--text-accent);
+  border-bottom-color: var(--text-accent);
   font-weight: 600;
-}
-
-.ani-config-tab:not(.active):hover {
-  background: var(--background-modifier-hover);
 }
 
 .ani-add-tab {
-  color: var(--text-muted);
-  font-weight: 600;
+  color: var(--text-faint);
+  font-size: var(--font-ui-medium);
+  padding: 6px 14px;
+}
+
+.ani-add-tab:hover {
+  color: var(--text-accent);
 }
 
 /* ─── Delete Config ───────────────────────────────────────────────── */

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,10 @@
   background: var(--background-modifier-hover);
 }
 
+.ani-credentials-table .ani-cred-action-confirm {
+  color: var(--text-error);
+}
+
 .ani-credentials-add {
   display: flex;
   justify-content: flex-end;

--- a/styles.css
+++ b/styles.css
@@ -18,3 +18,44 @@
   padding-left: 12px;
   border-left: 2px solid var(--interactive-accent);
 }
+
+/* ─── Config Tab Bar ──────────────────────────────────────────────── */
+
+.ani-config-tab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--interactive-accent);
+  margin-bottom: 16px;
+}
+
+.ani-config-tab {
+  padding: 6px 14px;
+  cursor: pointer;
+  border-radius: 6px 6px 0 0;
+  font-size: 13px;
+}
+
+.ani-config-tab.active {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  font-weight: 600;
+}
+
+.ani-config-tab:not(.active):hover {
+  background: var(--background-modifier-hover);
+}
+
+.ani-add-tab {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+/* ─── Delete Config ───────────────────────────────────────────────── */
+
+.ani-delete-config .setting-item-control .mod-warning {
+  opacity: 0.8;
+}
+
+.ani-delete-config .setting-item-control .mod-warning:hover {
+  opacity: 1;
+}

--- a/tests/__mocks__/database-client.mock.ts
+++ b/tests/__mocks__/database-client.mock.ts
@@ -1,0 +1,23 @@
+/**
+ * DatabaseClient mock for testing.
+ */
+
+import { vi } from 'vitest';
+import type { DatabaseClient, SyncResult } from '../../src/types';
+
+export type MockDatabaseClient = {
+  [K in keyof DatabaseClient]: ReturnType<typeof vi.fn>;
+};
+
+export function createMockDatabaseClient(): MockDatabaseClient {
+  return {
+    fetchNotes: vi.fn().mockResolvedValue([]),
+    fetchRecord: vi.fn().mockResolvedValue(null),
+    updateRecord: vi.fn().mockResolvedValue({
+      success: true,
+      recordId: 'rec123',
+      updatedFields: {}
+    } as SyncResult),
+    batchUpdate: vi.fn().mockResolvedValue([]),
+  };
+}

--- a/tests/core/config-instance.test.ts
+++ b/tests/core/config-instance.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for ConfigInstance.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { App } from 'obsidian';
+import { createMockApp } from 'obsidian';
+import type { ConfigEntry, Credential, SharedServices } from '../../src/types';
+import { DEFAULT_CONFIG_ENTRY } from '../../src/types';
+import { ConfigInstance } from '../../src/core/config-instance';
+import { AirtableClient } from '../../src/services/airtable-client';
+import { RateLimiter } from '../../src/services/rate-limiter';
+import { FileWatcher } from '../../src/file-operations/file-watcher';
+import { SyncOrchestrator } from '../../src/core/sync-orchestrator';
+import { SyncQueue } from '../../src/core/sync-queue';
+import { ConflictResolver } from '../../src/core/conflict-resolver';
+import { FieldCache } from '../../src/services/field-cache';
+import { FrontmatterParser } from '../../src/file-operations/frontmatter-parser';
+
+// Mock all service constructors
+vi.mock('../../src/services/airtable-client');
+vi.mock('../../src/file-operations/file-watcher');
+vi.mock('../../src/core/sync-orchestrator');
+vi.mock('../../src/core/sync-queue');
+vi.mock('../../src/core/conflict-resolver');
+
+function createConfig(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return {
+    ...DEFAULT_CONFIG_ENTRY,
+    id: 'cfg-1',
+    name: 'Test Config',
+    credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+function createCredential(overrides: Partial<Credential> = {}): Credential {
+  return {
+    id: 'cred-1',
+    name: 'Test Credential',
+    type: 'airtable',
+    apiKey: 'pat-test-key',
+    ...overrides,
+  };
+}
+
+function createSharedServices(overrides: Partial<SharedServices> = {}): SharedServices {
+  return {
+    rateLimiters: new Map(),
+    fieldCache: new FieldCache(),
+    frontmatterParser: new FrontmatterParser({} as App),
+    statusBarFactory: vi.fn(() => {
+      const el = document.createElement('div');
+      el.textContent = '';
+      return el;
+    }),
+    getDebugMode: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+describe('ConfigInstance', () => {
+  let mockApp: ReturnType<typeof createMockApp>;
+  let shared: SharedServices;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockApp = createMockApp();
+    shared = createSharedServices();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('constructor — service creation', () => {
+    it('should create all services on construction', () => {
+      const config = createConfig();
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      expect(instance.configId).toBe('cfg-1');
+      expect(AirtableClient).toHaveBeenCalledTimes(1);
+      expect(ConflictResolver).toHaveBeenCalledTimes(1);
+      expect(FileWatcher).toHaveBeenCalledTimes(1);
+      expect(SyncOrchestrator).toHaveBeenCalledTimes(1);
+      expect(SyncQueue).toHaveBeenCalledTimes(1);
+
+      instance.destroy();
+    });
+
+    it('should call fileWatcher.setup() when config is enabled', () => {
+      const config = createConfig({ enabled: true });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      const fileWatcherInstance = vi.mocked(FileWatcher).mock.instances[0];
+      expect(fileWatcherInstance.setup).toHaveBeenCalledTimes(1);
+
+      instance.destroy();
+    });
+
+    it('should NOT call fileWatcher.setup() when config is disabled', () => {
+      const config = createConfig({ enabled: false });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      const fileWatcherInstance = vi.mocked(FileWatcher).mock.instances[0];
+      expect(fileWatcherInstance.setup).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it('should pass merged settings with apiKey and debugMode to AirtableClient', () => {
+      const config = createConfig({ baseId: 'appXYZ', tableId: 'tblABC' });
+      const credential = createCredential({ apiKey: 'pat-my-key' });
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      const settingsArg = vi.mocked(AirtableClient).mock.calls[0][0];
+      expect(settingsArg.apiKey).toBe('pat-my-key');
+      expect(settingsArg.debugMode).toBe(false);
+      expect(settingsArg.baseId).toBe('appXYZ');
+      expect(settingsArg.tableId).toBe('tblABC');
+
+      instance.destroy();
+    });
+  });
+
+  describe('scheduler', () => {
+    it('should start scheduler when syncInterval > 0 and enabled', () => {
+      const config = createConfig({ enabled: true, syncInterval: 5 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      expect(instance.isSchedulerActive()).toBe(true);
+
+      instance.destroy();
+    });
+
+    it('should NOT start scheduler when syncInterval is 0', () => {
+      const config = createConfig({ enabled: true, syncInterval: 0 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      expect(instance.isSchedulerActive()).toBe(false);
+
+      instance.destroy();
+    });
+
+    it('should NOT start scheduler when config is disabled', () => {
+      const config = createConfig({ enabled: false, syncInterval: 5 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      expect(instance.isSchedulerActive()).toBe(false);
+
+      instance.destroy();
+    });
+
+    it('should enqueue from-airtable sync on scheduler tick', () => {
+      const config = createConfig({ enabled: true, syncInterval: 1 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      const syncQueueInstance = vi.mocked(SyncQueue).mock.instances[0];
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('from-airtable', 'all');
+
+      instance.destroy();
+    });
+  });
+
+  describe('RateLimiter sharing', () => {
+    it('should create new RateLimiter for new credential', () => {
+      const config = createConfig();
+      const credential = createCredential({ id: 'cred-new' });
+
+      expect(shared.rateLimiters.size).toBe(0);
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      expect(shared.rateLimiters.has('cred-new')).toBe(true);
+      expect(shared.rateLimiters.size).toBe(1);
+
+      instance.destroy();
+    });
+
+    it('should reuse existing RateLimiter for same credential', () => {
+      const existingLimiter = new RateLimiter();
+      shared.rateLimiters.set('cred-1', existingLimiter);
+
+      const config = createConfig({ credentialId: 'cred-1' });
+      const credential = createCredential({ id: 'cred-1' });
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      // Should still be 1 entry — the existing one was reused
+      expect(shared.rateLimiters.size).toBe(1);
+      // AirtableClient should receive the existing limiter
+      const rateLimiterArg = vi.mocked(AirtableClient).mock.calls[0][1];
+      expect(rateLimiterArg).toBe(existingLimiter);
+
+      instance.destroy();
+    });
+
+    it('should share RateLimiter between two configs with same credential', () => {
+      const config1 = createConfig({ id: 'cfg-1', credentialId: 'cred-shared' });
+      const config2 = createConfig({ id: 'cfg-2', credentialId: 'cred-shared' });
+      const credential = createCredential({ id: 'cred-shared' });
+
+      const instance1 = new ConfigInstance(mockApp as unknown as App, config1, credential, shared);
+      const instance2 = new ConfigInstance(mockApp as unknown as App, config2, credential, shared);
+
+      expect(shared.rateLimiters.size).toBe(1);
+
+      const limiter1 = vi.mocked(AirtableClient).mock.calls[0][1];
+      const limiter2 = vi.mocked(AirtableClient).mock.calls[1][1];
+      expect(limiter1).toBe(limiter2);
+
+      instance1.destroy();
+      instance2.destroy();
+    });
+  });
+
+  describe('destroy', () => {
+    it('should stop scheduler on destroy', () => {
+      const config = createConfig({ enabled: true, syncInterval: 5 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      expect(instance.isSchedulerActive()).toBe(true);
+
+      instance.destroy();
+      expect(instance.isSchedulerActive()).toBe(false);
+    });
+
+    it('should teardown fileWatcher on destroy', () => {
+      const config = createConfig({ enabled: true });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      const fileWatcherInstance = vi.mocked(FileWatcher).mock.instances[0];
+
+      instance.destroy();
+
+      expect(fileWatcherInstance.teardown).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should propagate updated settings to all services', () => {
+      const config = createConfig({ enabled: true });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+
+      const airtableInstance = vi.mocked(AirtableClient).mock.instances[0];
+      const conflictInstance = vi.mocked(ConflictResolver).mock.instances[0];
+      const orchestratorInstance = vi.mocked(SyncOrchestrator).mock.instances[0];
+      const fileWatcherInstance = vi.mocked(FileWatcher).mock.instances[0];
+
+      const updatedConfig = createConfig({ enabled: true, folderPath: 'NewFolder' });
+      const updatedCredential = createCredential({ apiKey: 'pat-updated' });
+
+      instance.updateSettings(updatedConfig, updatedCredential);
+
+      expect(airtableInstance.updateSettings).toHaveBeenCalled();
+      expect(conflictInstance.updateSettings).toHaveBeenCalled();
+      expect(orchestratorInstance.updateSettings).toHaveBeenCalled();
+      expect(fileWatcherInstance.teardown).toHaveBeenCalled();
+      expect(fileWatcherInstance.updateSettings).toHaveBeenCalled();
+      expect(fileWatcherInstance.setup).toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it('should restart scheduler on settings update', () => {
+      const config = createConfig({ enabled: true, syncInterval: 5 });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      expect(instance.isSchedulerActive()).toBe(true);
+
+      const updatedConfig = createConfig({ enabled: true, syncInterval: 0 });
+      instance.updateSettings(updatedConfig, credential);
+      expect(instance.isSchedulerActive()).toBe(false);
+
+      const reenabledConfig = createConfig({ enabled: true, syncInterval: 10 });
+      instance.updateSettings(reenabledConfig, credential);
+      expect(instance.isSchedulerActive()).toBe(true);
+
+      instance.destroy();
+    });
+  });
+
+  describe('enqueueSyncRequest', () => {
+    it('should delegate to syncQueue.enqueue', () => {
+      const config = createConfig({ enabled: true });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      const syncQueueInstance = vi.mocked(SyncQueue).mock.instances[0];
+
+      instance.enqueueSyncRequest('from-airtable', 'all');
+
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('from-airtable', 'all', undefined);
+
+      instance.destroy();
+    });
+
+    it('should pass filePaths when provided', () => {
+      const config = createConfig({ enabled: true });
+      const credential = createCredential();
+
+      const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
+      const syncQueueInstance = vi.mocked(SyncQueue).mock.instances[0];
+
+      instance.enqueueSyncRequest('to-airtable', 'modified', ['file1.md', 'file2.md']);
+
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('to-airtable', 'modified', ['file1.md', 'file2.md']);
+
+      instance.destroy();
+    });
+  });
+});

--- a/tests/core/config-manager.test.ts
+++ b/tests/core/config-manager.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for ConfigManager.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { App } from 'obsidian';
+import { createMockApp } from 'obsidian';
+import type { ConfigEntry, Credential, SharedServices } from '../../src/types';
+import { DEFAULT_CONFIG_ENTRY } from '../../src/types';
+import { ConfigManager } from '../../src/core/config-manager';
+import { ConfigInstance } from '../../src/core/config-instance';
+import { FieldCache } from '../../src/services/field-cache';
+import { FrontmatterParser } from '../../src/file-operations/frontmatter-parser';
+
+vi.mock('../../src/core/config-instance');
+
+function createConfig(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
+  return {
+    ...DEFAULT_CONFIG_ENTRY,
+    id: 'cfg-1',
+    name: 'Test Config',
+    credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+function createCredential(overrides: Partial<Credential> = {}): Credential {
+  return {
+    id: 'cred-1',
+    name: 'Test Credential',
+    type: 'airtable',
+    apiKey: 'pat-test-key',
+    ...overrides,
+  };
+}
+
+function createSharedServices(): SharedServices {
+  return {
+    rateLimiters: new Map(),
+    fieldCache: new FieldCache(),
+    frontmatterParser: new FrontmatterParser({} as App),
+    statusBarFactory: vi.fn(() => document.createElement('div')),
+    getDebugMode: vi.fn(() => false),
+  };
+}
+
+describe('ConfigManager', () => {
+  let mockApp: ReturnType<typeof createMockApp>;
+  let shared: SharedServices;
+  let manager: ConfigManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApp = createMockApp();
+    shared = createSharedServices();
+    manager = new ConfigManager(mockApp as unknown as App, shared);
+  });
+
+  describe('initialize', () => {
+    it('should create instances for enabled configs', () => {
+      const configs = [
+        createConfig({ id: 'cfg-1', enabled: true, credentialId: 'cred-1' }),
+        createConfig({ id: 'cfg-2', enabled: true, credentialId: 'cred-1' }),
+      ];
+      const credentials = [createCredential({ id: 'cred-1' })];
+
+      manager.initialize(configs, credentials);
+
+      expect(ConfigInstance).toHaveBeenCalledTimes(2);
+      expect(manager.getAllEnabled()).toHaveLength(2);
+    });
+
+    it('should skip disabled configs', () => {
+      const configs = [
+        createConfig({ id: 'cfg-1', enabled: true, credentialId: 'cred-1' }),
+        createConfig({ id: 'cfg-2', enabled: false, credentialId: 'cred-1' }),
+        createConfig({ id: 'cfg-3', enabled: true, credentialId: 'cred-1' }),
+      ];
+      const credentials = [createCredential({ id: 'cred-1' })];
+
+      manager.initialize(configs, credentials);
+
+      expect(ConfigInstance).toHaveBeenCalledTimes(2);
+      expect(manager.getAllEnabled()).toHaveLength(2);
+    });
+
+    it('should skip configs with missing credentials', () => {
+      const configs = [
+        createConfig({ id: 'cfg-1', enabled: true, credentialId: 'cred-missing' }),
+      ];
+      const credentials = [createCredential({ id: 'cred-1' })];
+
+      manager.initialize(configs, credentials);
+
+      expect(ConfigInstance).toHaveBeenCalledTimes(0);
+      expect(manager.getAllEnabled()).toHaveLength(0);
+    });
+  });
+
+  describe('addConfig', () => {
+    it('should create a new ConfigInstance and return it', () => {
+      const config = createConfig();
+      const credential = createCredential();
+
+      const instance = manager.addConfig(config, credential);
+
+      expect(ConfigInstance).toHaveBeenCalledTimes(1);
+      expect(instance).toBeDefined();
+      expect(manager.getInstance('cfg-1')).toBe(instance);
+    });
+  });
+
+  describe('removeConfig', () => {
+    it('should call destroy on the instance and remove it', () => {
+      const config = createConfig({ id: 'cfg-1' });
+      const credential = createCredential();
+
+      manager.addConfig(config, credential);
+      const instance = vi.mocked(ConfigInstance).mock.instances[0];
+
+      manager.removeConfig('cfg-1');
+
+      expect(instance.destroy).toHaveBeenCalledTimes(1);
+      expect(manager.getInstance('cfg-1')).toBeUndefined();
+    });
+
+    it('should do nothing for non-existent config', () => {
+      // Should not throw
+      manager.removeConfig('non-existent');
+      expect(manager.getAllEnabled()).toHaveLength(0);
+    });
+  });
+
+  describe('getInstance', () => {
+    it('should return instance by ID', () => {
+      const config = createConfig({ id: 'cfg-1' });
+      const credential = createCredential();
+
+      const instance = manager.addConfig(config, credential);
+
+      expect(manager.getInstance('cfg-1')).toBe(instance);
+    });
+
+    it('should return undefined for unknown ID', () => {
+      expect(manager.getInstance('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('getAllEnabled', () => {
+    it('should return all active instances', () => {
+      const credential = createCredential();
+      manager.addConfig(createConfig({ id: 'cfg-1' }), credential);
+      manager.addConfig(createConfig({ id: 'cfg-2' }), credential);
+
+      const all = manager.getAllEnabled();
+
+      expect(all).toHaveLength(2);
+    });
+
+    it('should return empty array when no instances exist', () => {
+      expect(manager.getAllEnabled()).toHaveLength(0);
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('should call updateSettings when instance exists and config is enabled', () => {
+      const config = createConfig({ id: 'cfg-1', enabled: true });
+      const credential = createCredential();
+
+      manager.addConfig(config, credential);
+      const instance = vi.mocked(ConfigInstance).mock.instances[0];
+
+      const updatedConfig = createConfig({ id: 'cfg-1', enabled: true, folderPath: 'Updated' });
+      manager.updateConfig('cfg-1', updatedConfig, credential);
+
+      expect(instance.updateSettings).toHaveBeenCalledWith(updatedConfig, credential);
+    });
+
+    it('should remove instance when config is disabled', () => {
+      const config = createConfig({ id: 'cfg-1', enabled: true });
+      const credential = createCredential();
+
+      manager.addConfig(config, credential);
+      const instance = vi.mocked(ConfigInstance).mock.instances[0];
+
+      const disabledConfig = createConfig({ id: 'cfg-1', enabled: false });
+      manager.updateConfig('cfg-1', disabledConfig, credential);
+
+      expect(instance.destroy).toHaveBeenCalledTimes(1);
+      expect(manager.getInstance('cfg-1')).toBeUndefined();
+    });
+
+    it('should add instance when previously disabled config is enabled', () => {
+      const config = createConfig({ id: 'cfg-1', enabled: true });
+      const credential = createCredential();
+
+      // No instance exists for cfg-1
+      expect(manager.getInstance('cfg-1')).toBeUndefined();
+
+      manager.updateConfig('cfg-1', config, credential);
+
+      expect(ConfigInstance).toHaveBeenCalledTimes(1);
+      expect(manager.getInstance('cfg-1')).toBeDefined();
+    });
+
+    it('should do nothing when no instance and config is disabled', () => {
+      const disabledConfig = createConfig({ id: 'cfg-1', enabled: false });
+      const credential = createCredential();
+
+      manager.updateConfig('cfg-1', disabledConfig, credential);
+
+      expect(ConfigInstance).not.toHaveBeenCalled();
+      expect(manager.getInstance('cfg-1')).toBeUndefined();
+    });
+  });
+
+  describe('destroy', () => {
+    it('should destroy all instances and clear the map', () => {
+      const credential = createCredential();
+      manager.addConfig(createConfig({ id: 'cfg-1' }), credential);
+      manager.addConfig(createConfig({ id: 'cfg-2' }), credential);
+
+      const instances = vi.mocked(ConfigInstance).mock.instances;
+      expect(instances).toHaveLength(2);
+
+      manager.destroy();
+
+      expect(instances[0].destroy).toHaveBeenCalled();
+      expect(instances[1].destroy).toHaveBeenCalled();
+      expect(manager.getAllEnabled()).toHaveLength(0);
+    });
+
+    it('should handle empty manager gracefully', () => {
+      // Should not throw
+      manager.destroy();
+      expect(manager.getAllEnabled()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/core/conflict-resolver.test.ts
+++ b/tests/core/conflict-resolver.test.ts
@@ -11,29 +11,21 @@ vi.mock('obsidian', () => ({
 
 import { ConflictResolver } from '../../src/core/conflict-resolver';
 import { createMockDatabaseClient, MockDatabaseClient } from '../__mocks__/database-client.mock';
-import type { AutoNoteImporterSettings, ConflictInfo, DatabaseClient } from '../../src/types';
+import type { LegacySettings, ConflictInfo, DatabaseClient } from '../../src/types';
+import { DEFAULT_LEGACY_SETTINGS } from '../../src/types';
 
 describe('ConflictResolver', () => {
   let mockClient: MockDatabaseClient;
   let resolver: ConflictResolver;
 
-  const createSettings = (conflictResolution: 'obsidian-wins' | 'airtable-wins' | 'manual'): AutoNoteImporterSettings => ({
+  const createSettings = (conflictResolution: 'obsidian-wins' | 'airtable-wins' | 'manual'): LegacySettings => ({
+    ...DEFAULT_LEGACY_SETTINGS,
     apiKey: 'key',
     baseId: 'base123',
     tableId: 'tbl123',
     folderPath: 'notes',
-    templatePath: '',
-    syncInterval: 0,
-    allowOverwrite: false,
-    filenameFieldName: '',
-    subfolderFieldName: '',
     bidirectionalSync: true,
     conflictResolution,
-    watchForChanges: false,
-    fileWatchDebounce: 2000,
-    autoSyncFormulas: false,
-    formulaSyncDelay: 1500,
-    debugMode: false,
   });
 
   beforeEach(() => {

--- a/tests/core/conflict-resolver.test.ts
+++ b/tests/core/conflict-resolver.test.ts
@@ -10,12 +10,11 @@ vi.mock('obsidian', () => ({
 }));
 
 import { ConflictResolver } from '../../src/core/conflict-resolver';
-import type { AirtableClient } from '../../src/services/airtable-client';
-import { createMockAirtableClient, MockAirtableClient } from '../__mocks__/airtable-client.mock';
-import type { AutoNoteImporterSettings, ConflictInfo } from '../../src/types';
+import { createMockDatabaseClient, MockDatabaseClient } from '../__mocks__/database-client.mock';
+import type { AutoNoteImporterSettings, ConflictInfo, DatabaseClient } from '../../src/types';
 
 describe('ConflictResolver', () => {
-  let mockAirtableClient: MockAirtableClient;
+  let mockClient: MockDatabaseClient;
   let resolver: ConflictResolver;
 
   const createSettings = (conflictResolution: 'obsidian-wins' | 'airtable-wins' | 'manual'): AutoNoteImporterSettings => ({
@@ -39,27 +38,27 @@ describe('ConflictResolver', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAirtableClient = createMockAirtableClient();
+    mockClient = createMockDatabaseClient();
   });
 
   describe('shouldSkipConflictDetection', () => {
     it('should return true for obsidian-wins mode (CR-2.1)', () => {
       const settings = createSettings('obsidian-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(true);
     });
 
     it('should return false for airtable-wins mode (CR-2.2)', () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(false);
     });
 
     it('should return false for manual mode', () => {
       const settings = createSettings('manual');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(false);
     });
@@ -68,9 +67,9 @@ describe('ConflictResolver', () => {
   describe('detectConflicts', () => {
     it('should return empty array when record not found', async () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
-      mockAirtableClient.fetchRecord.mockResolvedValue(null);
+      mockClient.fetchRecord.mockResolvedValue(null);
 
       const conflicts = await resolver.detectConflicts(
         'rec123',
@@ -83,9 +82,9 @@ describe('ConflictResolver', () => {
 
     it('should detect conflicting field values', async () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
-      mockAirtableClient.fetchRecord.mockResolvedValue({
+      mockClient.fetchRecord.mockResolvedValue({
         id: 'rec123',
         fields: {
           field1: 'airtable-value',
@@ -114,9 +113,9 @@ describe('ConflictResolver', () => {
 
     it('should not detect conflict when values are equal', async () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
-      mockAirtableClient.fetchRecord.mockResolvedValue({
+      mockClient.fetchRecord.mockResolvedValue({
         id: 'rec123',
         fields: { field1: 'same-value' }
       });
@@ -132,9 +131,9 @@ describe('ConflictResolver', () => {
 
     it('should not detect conflict for new fields in obsidian', async () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
-      mockAirtableClient.fetchRecord.mockResolvedValue({
+      mockClient.fetchRecord.mockResolvedValue({
         id: 'rec123',
         fields: {}
       });
@@ -150,9 +149,9 @@ describe('ConflictResolver', () => {
 
     it('should propagate fetch errors to caller', async () => {
       const settings = createSettings('airtable-wins');
-      resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
-      mockAirtableClient.fetchRecord.mockRejectedValue(new Error('Network error'));
+      mockClient.fetchRecord.mockRejectedValue(new Error('Network error'));
 
       await expect(
         resolver.detectConflicts('rec123', { field1: 'value' }, 'notes/test.md')
@@ -172,7 +171,7 @@ describe('ConflictResolver', () => {
     describe('obsidian-wins mode (CR-1.1)', () => {
       it('should sync all fields, overwriting Airtable', async () => {
         const settings = createSettings('obsidian-wins');
-        resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+        resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
         const conflicts = [createConflict('field1')];
         const fieldsToSync = {
@@ -180,7 +179,7 @@ describe('ConflictResolver', () => {
           field2: 'other-value'
         };
 
-        mockAirtableClient.updateRecord.mockResolvedValue({
+        mockClient.updateRecord.mockResolvedValue({
           success: true,
           recordId: 'rec123',
           updatedFields: fieldsToSync
@@ -188,7 +187,7 @@ describe('ConflictResolver', () => {
 
         const result = await resolver.resolve(conflicts, fieldsToSync, 'rec123');
 
-        expect(mockAirtableClient.updateRecord).toHaveBeenCalledWith('rec123', fieldsToSync);
+        expect(mockClient.updateRecord).toHaveBeenCalledWith('rec123', fieldsToSync);
         expect(result.success).toBe(true);
       });
     });
@@ -196,7 +195,7 @@ describe('ConflictResolver', () => {
     describe('airtable-wins mode (CR-1.2)', () => {
       it('should skip conflicted fields and sync non-conflicted fields only', async () => {
         const settings = createSettings('airtable-wins');
-        resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+        resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
         const conflicts = [createConflict('field1')];
         const fieldsToSync = {
@@ -204,7 +203,7 @@ describe('ConflictResolver', () => {
           field2: 'non-conflicted-value'
         };
 
-        mockAirtableClient.updateRecord.mockResolvedValue({
+        mockClient.updateRecord.mockResolvedValue({
           success: true,
           recordId: 'rec123',
           updatedFields: { field2: 'non-conflicted-value' }
@@ -212,7 +211,7 @@ describe('ConflictResolver', () => {
 
         const result = await resolver.resolve(conflicts, fieldsToSync, 'rec123');
 
-        expect(mockAirtableClient.updateRecord).toHaveBeenCalledWith('rec123', {
+        expect(mockClient.updateRecord).toHaveBeenCalledWith('rec123', {
           field2: 'non-conflicted-value'
         });
         expect(result.success).toBe(true);
@@ -220,14 +219,14 @@ describe('ConflictResolver', () => {
 
       it('should return success without calling updateRecord if all fields conflicted', async () => {
         const settings = createSettings('airtable-wins');
-        resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+        resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
         const conflicts = [createConflict('field1')];
         const fieldsToSync = { field1: 'obsidian-value' };
 
         const result = await resolver.resolve(conflicts, fieldsToSync, 'rec123');
 
-        expect(mockAirtableClient.updateRecord).not.toHaveBeenCalled();
+        expect(mockClient.updateRecord).not.toHaveBeenCalled();
         expect(result.success).toBe(true);
         expect(result.updatedFields).toEqual({});
       });
@@ -236,14 +235,14 @@ describe('ConflictResolver', () => {
     describe('manual mode (CR-1.3)', () => {
       it('should not sync and return error', async () => {
         const settings = createSettings('manual');
-        resolver = new ConflictResolver(settings, mockAirtableClient as unknown as AirtableClient);
+        resolver = new ConflictResolver(settings, mockClient as unknown as DatabaseClient);
 
         const conflicts = [createConflict('field1')];
         const fieldsToSync = { field1: 'obsidian-value' };
 
         const result = await resolver.resolve(conflicts, fieldsToSync, 'rec123');
 
-        expect(mockAirtableClient.updateRecord).not.toHaveBeenCalled();
+        expect(mockClient.updateRecord).not.toHaveBeenCalled();
         expect(result.success).toBe(false);
         expect(result.error).toContain('Conflicts detected');
       });
@@ -253,7 +252,7 @@ describe('ConflictResolver', () => {
   describe('updateSettings', () => {
     it('should update internal settings reference', () => {
       const initialSettings = createSettings('obsidian-wins');
-      resolver = new ConflictResolver(initialSettings, mockAirtableClient as unknown as AirtableClient);
+      resolver = new ConflictResolver(initialSettings, mockClient as unknown as DatabaseClient);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(true);
 

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -9,7 +9,7 @@ import type { AutoNoteImporterSettings } from '../../src/types';
 import { DEFAULT_SETTINGS } from '../../src/types';
 // Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
 import { createMockApp, createMockTFile, createMockTFolder } from 'obsidian';
-import { createMockAirtableClient } from '../__mocks__/airtable-client.mock';
+import { createMockDatabaseClient } from '../__mocks__/database-client.mock';
 import { FieldCache } from '../../src/services/field-cache';
 import { FrontmatterParser } from '../../src/file-operations/frontmatter-parser';
 import { FileWatcher } from '../../src/file-operations/file-watcher';
@@ -41,7 +41,7 @@ function createMockStatusBar(): StatusBarController & { lastItem: StatusBarHandl
 
 describe('SyncOrchestrator', () => {
   let mockApp: ReturnType<typeof createMockApp>;
-  let mockClient: ReturnType<typeof createMockAirtableClient>;
+  let mockClient: ReturnType<typeof createMockDatabaseClient>;
   let fieldCache: FieldCache;
   let frontmatterParser: FrontmatterParser;
   let fileWatcher: FileWatcher;
@@ -55,7 +55,7 @@ describe('SyncOrchestrator', () => {
 
     settings = createSettings();
     mockApp = createMockApp();
-    mockClient = createMockAirtableClient();
+    mockClient = createMockDatabaseClient();
     fieldCache = new FieldCache();
     frontmatterParser = new FrontmatterParser(mockApp as unknown as App);
     fileWatcher = new FileWatcher(mockApp as unknown as App, settings, vi.fn());

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -5,8 +5,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SyncOrchestrator } from '../../src/core/sync-orchestrator';
 import type { StatusBarHandle, StatusBarController } from '../../src/core/sync-orchestrator';
-import type { AutoNoteImporterSettings } from '../../src/types';
-import { DEFAULT_SETTINGS } from '../../src/types';
+import type { LegacySettings } from '../../src/types';
+import { DEFAULT_LEGACY_SETTINGS } from '../../src/types';
 // Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
 import { createMockApp, createMockTFile, createMockTFolder } from 'obsidian';
 import { createMockDatabaseClient } from '../__mocks__/database-client.mock';
@@ -16,9 +16,9 @@ import { FileWatcher } from '../../src/file-operations/file-watcher';
 import { ConflictResolver } from '../../src/core/conflict-resolver';
 import type { App } from 'obsidian';
 
-function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+function createSettings(overrides: Partial<LegacySettings> = {}): LegacySettings {
   return {
-    ...DEFAULT_SETTINGS,
+    ...DEFAULT_LEGACY_SETTINGS,
     apiKey: 'pat-test',
     baseId: 'appTest',
     tableId: 'tblTest',
@@ -48,7 +48,7 @@ describe('SyncOrchestrator', () => {
   let conflictResolver: ConflictResolver;
   let statusBar: ReturnType<typeof createMockStatusBar>;
   let orchestrator: SyncOrchestrator;
-  let settings: AutoNoteImporterSettings;
+  let settings: LegacySettings;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/e2e/cdp-helpers.mjs
+++ b/tests/e2e/cdp-helpers.mjs
@@ -1,0 +1,48 @@
+/**
+ * Shared CDP (Chrome DevTools Protocol) helpers for E2E tests.
+ *
+ * Usage:
+ *   import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+ */
+
+const CDP_PORT = process.env.CDP_PORT || 9222;
+
+export async function findPageTarget() {
+  const override = process.env.CDP_TARGET_ID;
+  if (override) return override;
+
+  const resp = await fetch(`http://localhost:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const page = targets.find(t => t.type === 'page' && t.url.includes('obsidian'));
+  if (!page) throw new Error('No Obsidian page target found. Is Obsidian running with --remote-debugging-port?');
+  return page.id;
+}
+
+export function evalInObsidian(targetId, expression, timeout = 20000) {
+  const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${targetId}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout (${timeout}ms)`)), timeout);
+    const ws = new WebSocket(wsUrl);
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({
+        id: 1,
+        method: 'Runtime.evaluate',
+        params: { expression, awaitPromise: true, returnByValue: true }
+      }));
+    });
+    ws.addEventListener('message', (e) => {
+      const result = JSON.parse(e.data);
+      if (result.id === 1) {
+        clearTimeout(timer);
+        if (result.result?.exceptionDetails) {
+          resolve({ __error: result.result.exceptionDetails.exception?.description || 'Unknown error' });
+        } else {
+          try { resolve(JSON.parse(result.result.result.value)); }
+          catch { resolve(result.result.result.value); }
+        }
+        ws.close();
+      }
+    });
+    ws.addEventListener('error', (err) => { clearTimeout(timer); ws.close(); reject(err); });
+  });
+}

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -8,6 +8,8 @@
  *      /Applications/Obsidian.app/Contents/MacOS/Obsidian --remote-debugging-port=9222
  *   2. A vault with the plugin installed and configured (Airtable PAT, base, table)
  *   3. The Airtable table must have: Name (text), Count (number), Status (select), Cal (formula: Count*2)
+ *   4. For multi-config tests: a second table 'E2E-MultiConfig' (tblZO35AeSdSmI3rr)
+ *      with fields: Name (text), Value (number), Tag (singleSelect)
  *
  * Usage:
  *   node tests/e2e/run-e2e.mjs                          # auto-detect CDP target
@@ -21,9 +23,13 @@
 
 const CDP_PORT = process.env.CDP_PORT || 9222;
 const PLUGIN_ID = 'auto-note-importer';
+const MULTI_CONFIG_TABLE_ID = 'tblZO35AeSdSmI3rr';
+const MULTI_CONFIG_FOLDER = 'E2E-Multi';
+const MULTI_CONFIG_ID = 'e2e-cfg-2';
 
 // Test records created during setup — deleted during cleanup
 let testRecordIds = [];
+let multiConfigRecordIds = [];
 
 // ---------------------------------------------------------------------------
 // CDP helpers
@@ -101,25 +107,48 @@ const HELPERS = `
     await waitForCache(file, 'Count', newCount);
   }
 
-  function setMode(mode, autoFormula) {
-    const p = app.plugins.plugins['${PLUGIN_ID}'];
-    p.settings.conflictResolution = mode;
-    if (autoFormula !== undefined) p.settings.autoSyncFormulas = autoFormula;
-    p.conflictResolver.updateSettings(p.settings);
+  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
+
+  function getConfig(idx = 0) {
+    const p = getPlugin();
+    return p.settings.configs[idx];
   }
 
-  async function fetchRecord(recordId) {
-    const p = app.plugins.plugins['${PLUGIN_ID}'];
-    const base = p.settings.baseId;
-    const table = p.settings.tableId;
+  function getCredential(config) {
+    const p = getPlugin();
+    const cfg = config || getConfig();
+    return p.settings.credentials.find(c => c.id === cfg.credentialId);
+  }
+
+  function getInstance(config) {
+    const p = getPlugin();
+    const cfg = config || getConfig();
+    return p.configManager.getInstance(cfg.id);
+  }
+
+  function setMode(mode, autoFormula, config) {
+    const cfg = config || getConfig();
+    const cred = getCredential(cfg);
+    cfg.conflictResolution = mode;
+    if (autoFormula !== undefined) cfg.autoSyncFormulas = autoFormula;
+    getInstance(cfg).updateSettings(cfg, cred);
+  }
+
+  async function fetchRecord(recordId, config) {
+    const cfg = config || getConfig();
+    const cred = getCredential(cfg);
     const resp = await fetch(
-      'https://api.airtable.com/v0/' + base + '/' + table + '/' + recordId,
-      { headers: { 'Authorization': 'Bearer ' + p.settings.apiKey } }
+      'https://api.airtable.com/v0/' + cfg.baseId + '/' + cfg.tableId + '/' + recordId,
+      { headers: { 'Authorization': 'Bearer ' + cred.apiKey } }
     );
     return (await resp.json()).fields;
   }
 
-  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
+  async function enqueueSync(mode, scope, config) {
+    const cfg = config || getConfig();
+    const inst = getInstance(cfg);
+    await inst.enqueueSyncRequest(mode, scope);
+  }
 `;
 
 // ---------------------------------------------------------------------------
@@ -149,12 +178,12 @@ async function setup() {
 
   log('=== Setup: Create test records ===');
   const r = await run(`(async () => {
-    const p = app.plugins.plugins['${PLUGIN_ID}'];
-    const base = p.settings.baseId;
-    const table = p.settings.tableId;
-    const resp = await fetch('https://api.airtable.com/v0/' + base + '/' + table, {
+    ${HELPERS}
+    const cfg = getConfig();
+    const cred = getCredential();
+    const resp = await fetch('https://api.airtable.com/v0/' + cfg.baseId + '/' + cfg.tableId, {
       method: 'POST',
-      headers: { 'Authorization': 'Bearer ' + p.settings.apiKey, 'Content-Type': 'application/json' },
+      headers: { 'Authorization': 'Bearer ' + cred.apiKey, 'Content-Type': 'application/json' },
       body: JSON.stringify({ records: [
         { fields: { Name: 'E2E-Pull-Test', Count: 100, Status: 'Todo' } },
         { fields: { Name: 'E2E-Push-Test', Count: 200, Status: 'In progress' } },
@@ -169,41 +198,15 @@ async function setup() {
   log(`Created ${r.length} test records: ${testRecordIds.join(', ')}`);
 }
 
-async function resetAll() {
-  await run(`(async () => {
-    ${HELPERS}
-    const p = getPlugin();
-    const base = p.settings.baseId;
-    const table = p.settings.tableId;
-    await fetch('https://api.airtable.com/v0/' + base + '/' + table, {
-      method: 'PATCH',
-      headers: { 'Authorization': 'Bearer ' + p.settings.apiKey, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ records: [
-        { id: '${() => testRecordIds[0]}', fields: { Name: 'E2E-Pull-Test', Count: 100, Status: 'Todo' } },
-        { id: '${() => testRecordIds[1]}', fields: { Name: 'E2E-Push-Test', Count: 200, Status: 'In progress' } },
-        { id: '${() => testRecordIds[2]}', fields: { Name: 'E2E-Bidir-Test', Count: 300, Status: 'Done' } }
-      ]})
-    });
-    setMode('manual', false);
-    await getPlugin().syncQueue.enqueue('from-airtable', 'all');
-    await new Promise(r => setTimeout(r, 5000));
-    return '"reset"';
-  })()`.replaceAll("${() => testRecordIds[0]}", testRecordIds[0])
-      .replaceAll("${() => testRecordIds[1]}", testRecordIds[1])
-      .replaceAll("${() => testRecordIds[2]}", testRecordIds[2]),
-  20000);
-}
-
 function resetExpr() {
   // Build a reset expression using current testRecordIds
   return `(async () => {
     ${HELPERS}
-    const p = getPlugin();
-    const base = p.settings.baseId;
-    const table = p.settings.tableId;
-    await fetch('https://api.airtable.com/v0/' + base + '/' + table, {
+    const cfg = getConfig();
+    const cred = getCredential();
+    await fetch('https://api.airtable.com/v0/' + cfg.baseId + '/' + cfg.tableId, {
       method: 'PATCH',
-      headers: { 'Authorization': 'Bearer ' + p.settings.apiKey, 'Content-Type': 'application/json' },
+      headers: { 'Authorization': 'Bearer ' + cred.apiKey, 'Content-Type': 'application/json' },
       body: JSON.stringify({ records: [
         { id: '${testRecordIds[0]}', fields: { Name: 'E2E-Pull-Test', Count: 100, Status: 'Todo' } },
         { id: '${testRecordIds[1]}', fields: { Name: 'E2E-Push-Test', Count: 200, Status: 'In progress' } },
@@ -211,7 +214,7 @@ function resetExpr() {
       ]})
     });
     setMode('manual', false);
-    await getPlugin().syncQueue.enqueue('from-airtable', 'all');
+    await enqueueSync('from-airtable', 'all');
     await new Promise(r => setTimeout(r, 5000));
     return '"reset"';
   })()`;
@@ -224,21 +227,21 @@ async function doReset() {
 async function cleanup() {
   log('\n=== Cleanup: Delete test records ===');
   await run(`(async () => {
-    const p = app.plugins.plugins['${PLUGIN_ID}'];
-    const base = p.settings.baseId;
-    const table = p.settings.tableId;
+    ${HELPERS}
+    const cfg = getConfig();
+    const cred = getCredential();
     const ids = ${JSON.stringify(testRecordIds)};
 
     // Delete from Airtable
     const params = ids.map(id => 'records[]=' + id).join('&');
-    await fetch('https://api.airtable.com/v0/' + base + '/' + table + '?' + params, {
+    await fetch('https://api.airtable.com/v0/' + cfg.baseId + '/' + cfg.tableId + '?' + params, {
       method: 'DELETE',
-      headers: { 'Authorization': 'Bearer ' + p.settings.apiKey }
+      headers: { 'Authorization': 'Bearer ' + cred.apiKey }
     });
 
     // Delete local files
     for (const name of ['E2E-Pull-Test.md', 'E2E-Push-Test.md', 'E2E-Bidir-Test.md']) {
-      const file = app.vault.getAbstractFileByPath(p.settings.folderPath + '/' + name);
+      const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/' + name);
       if (file) await app.vault.delete(file);
     }
 
@@ -248,6 +251,44 @@ async function cleanup() {
     return '"cleaned"';
   })()`, 15000);
   log('Test records and files cleaned up');
+}
+
+async function cleanupMultiConfig() {
+  log('\n=== Cleanup: Multi-config test data ===');
+  await run(`(async () => {
+    ${HELPERS}
+    const p = getPlugin();
+    const cred = getCredential();
+    const mcIds = ${JSON.stringify(multiConfigRecordIds)};
+
+    // Delete records from second table
+    if (mcIds.length > 0) {
+      const params = mcIds.map(id => 'records[]=' + id).join('&');
+      await fetch('https://api.airtable.com/v0/' + getConfig().baseId + '/${MULTI_CONFIG_TABLE_ID}?' + params, {
+        method: 'DELETE',
+        headers: { 'Authorization': 'Bearer ' + cred.apiKey }
+      });
+    }
+
+    // Delete files in E2E-Multi/ folder
+    const mcFiles = app.vault.getFiles().filter(f => f.path.startsWith('${MULTI_CONFIG_FOLDER}/'));
+    for (const f of mcFiles) await app.vault.delete(f);
+
+    // Delete E2E-Multi folder itself
+    const mcFolder = app.vault.getAbstractFileByPath('${MULTI_CONFIG_FOLDER}');
+    if (mcFolder) await app.vault.delete(mcFolder);
+
+    // Remove second config from settings
+    const cfgIdx = p.settings.configs.findIndex(c => c.id === '${MULTI_CONFIG_ID}');
+    if (cfgIdx !== -1) {
+      p.configManager.removeConfig('${MULTI_CONFIG_ID}');
+      p.settings.configs.splice(cfgIdx, 1);
+      await p.saveSettings();
+    }
+
+    return '"mc-cleaned"';
+  })()`, 15000);
+  log('Multi-config test data cleaned up');
 }
 
 // ---------------------------------------------------------------------------
@@ -283,9 +324,9 @@ async function test(name, fn) {
     await test('from-airtable / all', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
-        await getPlugin().syncQueue.enqueue('from-airtable', 'all');
+        await enqueueSync('from-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
-        const files = app.vault.getFiles().filter(f => f.path.startsWith(getPlugin().settings.folderPath + '/'));
+        const files = app.vault.getFiles().filter(f => f.path.startsWith(getConfig().folderPath + '/'));
         return JSON.stringify({ fileCount: files.length });
       })()`, 15000);
       return { pass: r.fileCount >= 8, detail: `${r.fileCount} files` };
@@ -295,19 +336,22 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
-        const folderPath = p.settings.folderPath;
+        const cfg = getConfig();
+        const cred = getCredential();
+        const folderPath = cfg.folderPath;
 
         // Enable bases generation, vault-root location
-        p.settings.generateBasesFile = true;
-        p.settings.basesFileLocation = 'vault-root';
-        p.settings.basesRegenerateOnSync = false;
+        cfg.generateBasesFile = true;
+        cfg.basesFileLocation = 'vault-root';
+        cfg.basesRegenerateOnSync = false;
+        getInstance().updateSettings(cfg, cred);
 
         // Delete existing .base file if any (find by table name or folder name)
         const existingBases = app.vault.getFiles().filter(f => f.extension === 'base');
         for (const f of existingBases) await app.vault.delete(f);
 
         // Sync from Airtable
-        await p.syncQueue.enqueue('from-airtable', 'all');
+        await enqueueSync('from-airtable', 'all');
         await new Promise(r => setTimeout(r, 6000));
 
         // Check .base file was created
@@ -327,14 +371,14 @@ async function test(name, fn) {
 
         // Verify regenerate=false skips existing file
         const contentBefore = content;
-        await p.syncQueue.enqueue('from-airtable', 'all');
+        await enqueueSync('from-airtable', 'all');
         await new Promise(r => setTimeout(r, 6000));
         const contentAfter = await app.vault.read(baseFile);
         const skipWorks = contentBefore === contentAfter;
 
         // Cleanup
         await app.vault.delete(baseFile);
-        p.settings.generateBasesFile = true;
+        cfg.generateBasesFile = true;
 
         return JSON.stringify({
           pass: hasFilter && hasTableView && hasFileName && hasNotePrefix && skipWorks,
@@ -349,10 +393,12 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
+        const cfg = getConfig();
+        const cred = getCredential();
 
         // 1. Verify fetchViews returns available views
         const views = await p.fieldCache.fetchViews(
-          p.settings.apiKey, p.settings.baseId, p.settings.tableId
+          cred.apiKey, cfg.baseId, cfg.tableId
         );
         if (!views || views.length === 0) {
           return JSON.stringify({ pass: false, detail: 'No views found in table' });
@@ -362,32 +408,32 @@ async function test(name, fn) {
         const nonDefault = views.find(v => v.name !== 'Grid view') || views[0];
 
         // 3. Sync with view filter
-        const oldViewId = p.settings.viewId;
-        p.settings.viewId = nonDefault.id;
-        p.airtableClient.updateSettings(p.settings);
+        const oldViewId = cfg.viewId;
+        cfg.viewId = nonDefault.id;
+        getInstance().updateSettings(cfg, cred);
 
-        await p.syncQueue.enqueue('from-airtable', 'all');
+        await enqueueSync('from-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const viewFiles = app.vault.getFiles().filter(
-          f => f.path.startsWith(p.settings.folderPath + '/') && f.extension === 'md'
+          f => f.path.startsWith(cfg.folderPath + '/') && f.extension === 'md'
         );
         const viewCount = viewFiles.length;
 
         // 4. Sync without view filter
-        p.settings.viewId = '';
-        p.airtableClient.updateSettings(p.settings);
-        p.settings.allowOverwrite = true;
+        cfg.viewId = '';
+        cfg.allowOverwrite = true;
+        getInstance().updateSettings(cfg, cred);
 
-        await p.syncQueue.enqueue('from-airtable', 'all');
+        await enqueueSync('from-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const allFiles = app.vault.getFiles().filter(
-          f => f.path.startsWith(p.settings.folderPath + '/') && f.extension === 'md'
+          f => f.path.startsWith(cfg.folderPath + '/') && f.extension === 'md'
         );
         const allCount = allFiles.length;
 
         // Restore
-        p.settings.viewId = oldViewId;
-        p.airtableClient.updateSettings(p.settings);
+        cfg.viewId = oldViewId;
+        getInstance().updateSettings(cfg, cred);
 
         return JSON.stringify({
           pass: views.length > 0 && allCount > 0 && allCount >= viewCount,
@@ -401,9 +447,9 @@ async function test(name, fn) {
     await test('from-airtable / current', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
-        const file = await openAndActivate(getPlugin().settings.folderPath + '/E2E-Pull-Test.md');
+        const file = await openAndActivate(getConfig().folderPath + '/E2E-Pull-Test.md');
         try {
-          await getPlugin().syncQueue.enqueue('from-airtable', 'current');
+          await enqueueSync('from-airtable', 'current');
           await new Promise(r => setTimeout(r, 3000));
           const content = await app.vault.read(file);
           return JSON.stringify({ pass: content.includes('${testRecordIds[0]}') });
@@ -421,9 +467,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const file = app.vault.getAbstractFileByPath(getPlugin().settings.folderPath + '/E2E-Push-Test.md');
+        const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 555);
-        await getPlugin().syncQueue.enqueue('to-airtable', 'all');
+        await enqueueSync('to-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         setMode('manual');
@@ -437,9 +483,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const file = await openAndActivate(getPlugin().settings.folderPath + '/E2E-Bidir-Test.md');
+        const file = await openAndActivate(getConfig().folderPath + '/E2E-Bidir-Test.md');
         await modifyCount(file, 888);
-        await getPlugin().syncQueue.enqueue('to-airtable', 'current');
+        await enqueueSync('to-airtable', 'current');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[2]}');
         setMode('manual');
@@ -453,9 +499,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('airtable-wins');
-        const file = app.vault.getAbstractFileByPath(getPlugin().settings.folderPath + '/E2E-Pull-Test.md');
+        const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Pull-Test.md');
         await modifyCount(file, 9999);
-        await getPlugin().syncQueue.enqueue('to-airtable', 'all');
+        await enqueueSync('to-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[0]}');
         setMode('manual');
@@ -469,9 +515,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('airtable-wins');
-        const file = await openAndActivate(getPlugin().settings.folderPath + '/E2E-Push-Test.md');
+        const file = await openAndActivate(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 7777);
-        await getPlugin().syncQueue.enqueue('to-airtable', 'current');
+        await enqueueSync('to-airtable', 'current');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         setMode('manual');
@@ -485,9 +531,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('manual');
-        const file = app.vault.getAbstractFileByPath(getPlugin().settings.folderPath + '/E2E-Push-Test.md');
+        const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 7777);
-        await getPlugin().syncQueue.enqueue('to-airtable', 'all');
+        await enqueueSync('to-airtable', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         return JSON.stringify({ pass: fields.Count === 200, count: fields.Count });
@@ -502,9 +548,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', true);
-        const file = app.vault.getAbstractFileByPath(getPlugin().settings.folderPath + '/E2E-Bidir-Test.md');
+        const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Bidir-Test.md');
         await modifyCount(file, 450);
-        await getPlugin().syncQueue.enqueue('bidirectional', 'all');
+        await enqueueSync('bidirectional', 'all');
         await new Promise(r => setTimeout(r, 10000));
         const updated = await app.vault.read(file);
         const calMatch = updated.match(/Cal: (\\d+)/);
@@ -521,11 +567,11 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', false);
-        const file = app.vault.getAbstractFileByPath(getPlugin().settings.folderPath + '/E2E-Bidir-Test.md');
+        const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Bidir-Test.md');
         const before = await app.vault.read(file);
         const oldCal = parseInt(before.match(/Cal: (\\d+)/)?.[1] || '0');
         await modifyCount(file, 333);
-        await getPlugin().syncQueue.enqueue('bidirectional', 'all');
+        await enqueueSync('bidirectional', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const updated = await app.vault.read(file);
         const localCal = parseInt(updated.match(/Cal: (\\d+)/)?.[1] || '0');
@@ -541,9 +587,9 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', true);
-        const file = await openAndActivate(getPlugin().settings.folderPath + '/E2E-Push-Test.md');
+        const file = await openAndActivate(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 123);
-        await getPlugin().syncQueue.enqueue('bidirectional', 'current');
+        await enqueueSync('bidirectional', 'current');
         await new Promise(r => setTimeout(r, 10000));
         const updated = await app.vault.read(file);
         const localCal = parseInt(updated.match(/Cal: (\\d+)/)?.[1] || '0');
@@ -558,11 +604,11 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', false);
-        const file = await openAndActivate(getPlugin().settings.folderPath + '/E2E-Push-Test.md');
+        const file = await openAndActivate(getConfig().folderPath + '/E2E-Push-Test.md');
         const before = await app.vault.read(file);
         const oldCal = parseInt(before.match(/Cal: (\\d+)/)?.[1] || '0');
         await modifyCount(file, 777);
-        await getPlugin().syncQueue.enqueue('bidirectional', 'current');
+        await enqueueSync('bidirectional', 'current');
         await new Promise(r => setTimeout(r, 5000));
         const updated = await app.vault.read(file);
         const localCal = parseInt(updated.match(/Cal: (\\d+)/)?.[1] || '0');
@@ -571,6 +617,178 @@ async function test(name, fn) {
         return JSON.stringify({ pass: fields.Count === 777 && localCal === oldCal, localCal, oldCal, airtableCount: fields.Count });
       })()`, 25000);
       return { pass: r.pass, detail: `push=${r.airtableCount}, cal=${r.localCal}(unchanged)` };
+    });
+
+    // -- Multi-Config tests --
+
+    await test('multi-config / migration preserves settings', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const cfg = getConfig();
+        const cred = getCredential();
+
+        const hasVersion = p.settings.version === 2;
+        const hasConfigs = p.settings.configs.length >= 1;
+        const hasCreds = p.settings.credentials.length >= 1;
+        const hasBaseId = cfg.baseId && cfg.baseId.length > 0;
+        const hasTableId = cfg.tableId && cfg.tableId.length > 0;
+        const hasFolderPath = cfg.folderPath && cfg.folderPath.length > 0;
+        const hasApiKey = cred.apiKey && cred.apiKey.length > 0;
+        const credLinked = cfg.credentialId === cred.id;
+
+        return JSON.stringify({
+          pass: hasVersion && hasConfigs && hasCreds && hasBaseId && hasTableId && hasFolderPath && hasApiKey && credLinked,
+          detail: 'version=' + p.settings.version
+            + ' configs=' + p.settings.configs.length
+            + ' creds=' + p.settings.credentials.length
+            + ' baseId=' + hasBaseId
+            + ' tableId=' + hasTableId
+            + ' folderPath=' + hasFolderPath
+            + ' apiKey=' + hasApiKey
+            + ' credLinked=' + credLinked
+        });
+      })()`, 10000);
+      return { pass: r.pass, detail: r.detail || 'ok' };
+    });
+
+    await test('multi-config / independent sync', async () => {
+      // Setup: add second config and create records in second table
+      const mcSetup = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const cfg = getConfig();
+        const cred = getCredential();
+
+        // Add second config
+        const secondConfig = {
+          id: '${MULTI_CONFIG_ID}',
+          name: 'E2E Multi',
+          enabled: true,
+          credentialId: cred.id,
+          baseId: cfg.baseId,
+          tableId: '${MULTI_CONFIG_TABLE_ID}',
+          viewId: '',
+          folderPath: '${MULTI_CONFIG_FOLDER}',
+          templatePath: '',
+          filenameFieldName: 'Name',
+          subfolderFieldName: '',
+          syncInterval: 0,
+          allowOverwrite: true,
+          bidirectionalSync: false,
+          conflictResolution: 'manual',
+          watchForChanges: false,
+          fileWatchDebounce: 2000,
+          autoSyncFormulas: false,
+          formulaSyncDelay: 3000,
+          generateBasesFile: false,
+          basesFileLocation: 'vault-root',
+          basesCustomPath: '',
+          basesRegenerateOnSync: false,
+        };
+
+        // Remove existing if present (idempotent)
+        const existIdx = p.settings.configs.findIndex(c => c.id === '${MULTI_CONFIG_ID}');
+        if (existIdx !== -1) {
+          p.configManager.removeConfig('${MULTI_CONFIG_ID}');
+          p.settings.configs.splice(existIdx, 1);
+        }
+
+        p.settings.configs.push(secondConfig);
+        await p.saveSettings();
+
+        // Create records in second table
+        const resp = await fetch('https://api.airtable.com/v0/' + cfg.baseId + '/${MULTI_CONFIG_TABLE_ID}', {
+          method: 'POST',
+          headers: { 'Authorization': 'Bearer ' + cred.apiKey, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ records: [
+            { fields: { Name: 'MC-Test-1', Value: 42, Tag: 'alpha' } },
+            { fields: { Name: 'MC-Test-2', Value: 99, Tag: 'alpha' } }
+          ]})
+        });
+        const data = await resp.json();
+        return JSON.stringify(data.records.map(r => ({ id: r.id, name: r.fields.Name })));
+      })()`, 15000);
+
+      multiConfigRecordIds = mcSetup.map(rec => rec.id);
+      log(`Created ${mcSetup.length} multi-config records: ${multiConfigRecordIds.join(', ')}`);
+
+      // Record config 1 file state before config 2 sync
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const cfg1 = getConfig(0);
+        const cfg2 = p.settings.configs.find(c => c.id === '${MULTI_CONFIG_ID}');
+        if (!cfg2) return JSON.stringify({ pass: false, detail: 'Second config not found' });
+
+        // Record config 1 files before
+        const cfg1FilesBefore = app.vault.getFiles()
+          .filter(f => f.path.startsWith(cfg1.folderPath + '/') && f.extension === 'md')
+          .map(f => f.path);
+
+        // Sync config 2
+        await enqueueSync('from-airtable', 'all', cfg2);
+        await new Promise(r => setTimeout(r, 5000));
+
+        // Check config 2 files created in its folder
+        const cfg2Files = app.vault.getFiles()
+          .filter(f => f.path.startsWith('${MULTI_CONFIG_FOLDER}/') && f.extension === 'md');
+        const hasTestFile = cfg2Files.some(f => f.basename === 'MC-Test-1');
+
+        // Check config 1 files unchanged
+        const cfg1FilesAfter = app.vault.getFiles()
+          .filter(f => f.path.startsWith(cfg1.folderPath + '/') && f.extension === 'md')
+          .map(f => f.path);
+        const cfg1Unchanged = cfg1FilesBefore.length === cfg1FilesAfter.length
+          && cfg1FilesBefore.every(p => cfg1FilesAfter.includes(p));
+
+        return JSON.stringify({
+          pass: hasTestFile && cfg1Unchanged && cfg2Files.length >= 2,
+          detail: 'cfg2Files=' + cfg2Files.length
+            + ' hasTestFile=' + hasTestFile
+            + ' cfg1Unchanged=' + cfg1Unchanged
+            + ' cfg1Before=' + cfg1FilesBefore.length
+            + ' cfg1After=' + cfg1FilesAfter.length
+        });
+      })()`, 20000);
+      return { pass: r.pass, detail: r.detail || 'ok' };
+    });
+
+    await test('multi-config / folder isolation', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const cfg1 = getConfig(0);
+        const cfg2 = p.settings.configs.find(c => c.id === '${MULTI_CONFIG_ID}');
+        if (!cfg2) return JSON.stringify({ pass: false, detail: 'Second config not found' });
+
+        // Config 1 files
+        const cfg1Files = app.vault.getFiles()
+          .filter(f => f.path.startsWith(cfg1.folderPath + '/') && f.extension === 'md');
+
+        // Config 2 files
+        const cfg2Files = app.vault.getFiles()
+          .filter(f => f.path.startsWith('${MULTI_CONFIG_FOLDER}/') && f.extension === 'md');
+
+        // No config 2 content (MC-Test) in config 1 folder
+        const crossContamination1 = cfg1Files.some(f => f.basename.startsWith('MC-Test'));
+
+        // No config 1 content (E2E-Pull/Push/Bidir) in config 2 folder
+        const crossContamination2 = cfg2Files.some(f =>
+          f.basename.startsWith('E2E-Pull') ||
+          f.basename.startsWith('E2E-Push') ||
+          f.basename.startsWith('E2E-Bidir')
+        );
+
+        return JSON.stringify({
+          pass: !crossContamination1 && !crossContamination2 && cfg1Files.length > 0 && cfg2Files.length > 0,
+          detail: 'cfg1Count=' + cfg1Files.length
+            + ' cfg2Count=' + cfg2Files.length
+            + ' crossContam1=' + crossContamination1
+            + ' crossContam2=' + crossContamination2
+        });
+      })()`, 10000);
+      return { pass: r.pass, detail: r.detail || 'ok' };
     });
 
     // -- Summary --
@@ -590,6 +808,7 @@ async function test(name, fn) {
     // -- Cleanup --
     if (process.argv.includes('--cleanup')) {
       await cleanup();
+      await cleanupMultiConfig();
     } else {
       log('\nTest records left in Airtable. Run with --cleanup to remove them.');
     }

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -17,11 +17,12 @@
  *   CDP_TARGET_ID=<id> node tests/e2e/run-e2e.mjs       # specify CDP page target
  */
 
+import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
-const CDP_PORT = process.env.CDP_PORT || 9222;
 const PLUGIN_ID = 'auto-note-importer';
 const MULTI_CONFIG_TABLE_ID = 'tblZO35AeSdSmI3rr';
 const MULTI_CONFIG_FOLDER = 'E2E-Multi';
@@ -30,50 +31,6 @@ const MULTI_CONFIG_ID = 'e2e-cfg-2';
 // Test records created during setup — deleted during cleanup
 let testRecordIds = [];
 let multiConfigRecordIds = [];
-
-// ---------------------------------------------------------------------------
-// CDP helpers
-// ---------------------------------------------------------------------------
-
-async function findPageTarget() {
-  const override = process.env.CDP_TARGET_ID;
-  if (override) return override;
-
-  const resp = await fetch(`http://localhost:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  const page = targets.find(t => t.type === 'page' && t.url.includes('obsidian'));
-  if (!page) throw new Error('No Obsidian page target found. Is Obsidian running with --remote-debugging-port?');
-  return page.id;
-}
-
-function evalInObsidian(targetId, expression, timeout = 20000) {
-  const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${targetId}`;
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timeout (${timeout}ms)`)), timeout);
-    const ws = new WebSocket(wsUrl);
-    ws.addEventListener('open', () => {
-      ws.send(JSON.stringify({
-        id: 1,
-        method: 'Runtime.evaluate',
-        params: { expression, awaitPromise: true, returnByValue: true }
-      }));
-    });
-    ws.addEventListener('message', (e) => {
-      const result = JSON.parse(e.data);
-      if (result.id === 1) {
-        clearTimeout(timer);
-        if (result.result?.exceptionDetails) {
-          resolve({ __error: result.result.exceptionDetails.exception?.description || 'Unknown error' });
-        } else {
-          try { resolve(JSON.parse(result.result.result.value)); }
-          catch { resolve(result.result.result.value); }
-        }
-        ws.close();
-      }
-    });
-    ws.addEventListener('error', (err) => { clearTimeout(timer); ws.close(); reject(err); });
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Obsidian-side helpers (injected into eval expressions)

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -1,0 +1,852 @@
+/**
+ * Settings UI E2E Tests for Auto Note Importer
+ *
+ * Tests summary card rendering, badge statuses, summaries, expand/collapse,
+ * and all config option combinations via Chrome DevTools Protocol (CDP).
+ *
+ * Prerequisites:
+ *   1. Obsidian running with --remote-debugging-port=9222
+ *   2. A vault with the plugin installed and at least one configured credential
+ *
+ * Usage:
+ *   node tests/e2e/run-settings-e2e.mjs
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CDP_PORT = process.env.CDP_PORT || 9222;
+const PLUGIN_ID = 'auto-note-importer';
+
+// ---------------------------------------------------------------------------
+// CDP helpers (shared pattern with run-e2e.mjs)
+// ---------------------------------------------------------------------------
+
+async function findPageTarget() {
+  const override = process.env.CDP_TARGET_ID;
+  if (override) return override;
+
+  const resp = await fetch(`http://localhost:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const page = targets.find(t => t.type === 'page' && t.url.includes('obsidian'));
+  if (!page) throw new Error('No Obsidian page target found. Is Obsidian running with --remote-debugging-port?');
+  return page.id;
+}
+
+function evalInObsidian(targetId, expression, timeout = 15000) {
+  const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${targetId}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout (${timeout}ms)`)), timeout);
+    const ws = new WebSocket(wsUrl);
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({
+        id: 1,
+        method: 'Runtime.evaluate',
+        params: { expression, awaitPromise: true, returnByValue: true }
+      }));
+    });
+    ws.addEventListener('message', (e) => {
+      const result = JSON.parse(e.data);
+      if (result.id === 1) {
+        clearTimeout(timer);
+        if (result.result?.exceptionDetails) {
+          resolve({ __error: result.result.exceptionDetails.exception?.description || 'Unknown error' });
+        } else {
+          try { resolve(JSON.parse(result.result.result.value)); }
+          catch { resolve(result.result.result.value); }
+        }
+        ws.close();
+      }
+    });
+    ws.addEventListener('error', (err) => { clearTimeout(timer); ws.close(); reject(err); });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Obsidian-side helpers
+// ---------------------------------------------------------------------------
+
+const HELPERS = `
+  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
+
+  function getActiveConfig() {
+    const p = getPlugin();
+    const id = p.settings.activeConfigId;
+    return p.settings.configs.find(c => c.id === id) || p.settings.configs[0];
+  }
+
+  function getConfig(idx = 0) { return getPlugin().settings.configs[idx]; }
+
+  function getSettingsTab() {
+    return app.setting.pluginTabs.find(t => t.id === '${PLUGIN_ID}');
+  }
+
+  async function openSettingsTab() {
+    app.setting.open();
+    await new Promise(r => setTimeout(r, 200));
+    const tab = getSettingsTab();
+    if (!tab) throw new Error('Plugin settings tab not found');
+    app.setting.openTab(tab);
+    tab.display();
+    await new Promise(r => setTimeout(r, 400));
+    return tab;
+  }
+
+  async function rerenderTab() {
+    const tab = getSettingsTab();
+    if (tab) tab.display();
+    await new Promise(r => setTimeout(r, 300));
+    return tab;
+  }
+
+  function getContainer() {
+    const tab = getSettingsTab();
+    return tab?.containerEl;
+  }
+
+  function queryCards(container) {
+    const el = container || getContainer();
+    return Array.from(el.querySelectorAll('.ani-summary-card'));
+  }
+
+  function cardInfo(card) {
+    return {
+      title: card.querySelector('.ani-card-title')?.textContent || '',
+      summary: card.querySelector('.ani-card-summary')?.textContent || '',
+      badge: card.querySelector('.ani-card-badge')?.textContent || '',
+      isOk: !!card.querySelector('.ani-card-badge-ok'),
+      isOff: !!card.querySelector('.ani-card-badge-off'),
+      expanded: card.classList.contains('is-expanded'),
+    };
+  }
+
+  function allCardInfos(container) {
+    return queryCards(container).map(c => cardInfo(c));
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+const results = [];
+let targetId;
+
+function log(msg) { console.log(msg); }
+
+async function run(expr, timeout) {
+  return evalInObsidian(targetId, expr, timeout);
+}
+
+async function test(name, fn) {
+  log(`\n=== ${name} ===`);
+  try {
+    const { pass, detail } = await fn();
+    results.push({ test: name, pass, detail: detail || 'ok' });
+    log(pass ? 'PASS' : `FAIL - ${detail}`);
+  } catch (e) {
+    results.push({ test: name, pass: false, detail: e.message });
+    log(`FAIL - ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: set config fields and re-render settings tab
+// ---------------------------------------------------------------------------
+
+function buildConfigExpr(overrides) {
+  return Object.entries(overrides)
+    .map(([key, value]) => {
+      const v = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'`
+        : typeof value === 'boolean' ? String(value)
+        : value;
+      return `cfg.${key} = ${v};`;
+    })
+    .join('\n      ');
+}
+
+async function setConfigAndQuery(overrides) {
+  const assignments = buildConfigExpr(overrides);
+  return run(`(async () => {
+    ${HELPERS}
+    const p = getPlugin();
+    const cfg = getActiveConfig();
+    ${assignments}
+    await p.saveSettings();
+    await rerenderTab();
+    const infos = allCardInfos();
+    return JSON.stringify(infos);
+  })()`, 10000);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+(async () => {
+  try {
+    targetId = await findPageTarget();
+    log(`CDP target: ${targetId}`);
+
+    // ── Setup: save original config, open settings ──────────────────
+
+    log('\n=== Setup ===');
+    const originalConfig = await run(`(async () => {
+      ${HELPERS}
+      const cfg = getActiveConfig();
+      return JSON.stringify(Object.assign({}, cfg));
+    })()`, 10000);
+    log('Original config saved');
+
+    await run(`(async () => {
+      ${HELPERS}
+      await openSettingsTab();
+      return JSON.stringify({ ok: true });
+    })()`, 10000);
+    log('Settings tab opened');
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 1: Layout Structure
+    // ════════════════════════════════════════════════════════════════
+
+    await test('layout / debug section exists above tab bar', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const c = getContainer();
+        const debug = c.querySelector('.ani-debug-section');
+        const tabBar = c.querySelector('.ani-config-tab-bar');
+        if (!debug || !tabBar) {
+          return JSON.stringify({
+            debugExists: !!debug,
+            tabBarExists: !!tabBar,
+          });
+        }
+        // Check DOM order: debug should come before tab bar
+        const allEls = Array.from(c.children);
+        const debugIdx = allEls.indexOf(debug);
+        const tabBarIdx = allEls.indexOf(tabBar);
+        return JSON.stringify({
+          debugExists: true,
+          tabBarExists: true,
+          debugBeforeTabBar: debugIdx < tabBarIdx,
+          debugIdx,
+          tabBarIdx,
+        });
+      })()`, 10000);
+      const pass = r.debugExists && r.tabBarExists && r.debugBeforeTabBar;
+      return { pass, detail: `debug=${r.debugExists} tabBar=${r.tabBarExists} order=${r.debugBeforeTabBar}` };
+    });
+
+    await test('layout / card stack renders 4 summary cards', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const c = getContainer();
+        const stack = c.querySelector('.ani-card-stack');
+        const cards = stack ? stack.querySelectorAll('.ani-summary-card') : [];
+        const titles = Array.from(cards).map(card =>
+          card.querySelector('.ani-card-title')?.textContent || ''
+        );
+        return JSON.stringify({ count: cards.length, titles });
+      })()`, 10000);
+      const pass = r.count === 4
+        && r.titles.includes('Airtable Connection')
+        && r.titles.includes('File Settings')
+        && r.titles.includes('Bases Database')
+        && r.titles.includes('Bidirectional Sync');
+      return { pass, detail: `count=${r.count} titles=[${r.titles.join(', ')}]` };
+    });
+
+    await test('layout / card stack is inside container (not floating)', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const c = getContainer();
+        const stack = c.querySelector('.ani-card-stack');
+        return JSON.stringify({
+          exists: !!stack,
+          parentIsContainer: stack?.parentElement === c,
+        });
+      })()`, 10000);
+      return { pass: r.exists && r.parentIsContainer, detail: `exists=${r.exists} parent=${r.parentIsContainer}` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 2: Badge Status — Individual Card Boundaries
+    // ════════════════════════════════════════════════════════════════
+
+    await test('badge / connection — Connected when baseId+tableId set', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.badge === 'Connected' && card.isOk;
+      return { pass, detail: `badge="${card?.badge}" isOk=${card?.isOk}` };
+    });
+
+    await test('badge / connection — Setup required when baseId missing', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: '', tableId: 'tblTEST456',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.badge === 'Setup required' && card.isOff;
+      return { pass, detail: `badge="${card?.badge}" isOff=${card?.isOff}` };
+    });
+
+    await test('badge / connection — Setup required when tableId missing', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: '',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.badge === 'Setup required' && card.isOff;
+      return { pass, detail: `badge="${card?.badge}" isOff=${card?.isOff}` };
+    });
+
+    await test('badge / files — Configured when folderPath set', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        folderPath: 'Crawling',
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card && card.badge === 'Configured' && card.isOk;
+      return { pass, detail: `badge="${card?.badge}" isOk=${card?.isOk}` };
+    });
+
+    await test('badge / files — Setup required when folderPath empty', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        folderPath: '',
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card && card.badge === 'Setup required' && card.isOff;
+      return { pass, detail: `badge="${card?.badge}" isOff=${card?.isOff}` };
+    });
+
+    await test('badge / bases — On when generateBasesFile true', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        generateBasesFile: true,
+      });
+      const card = infos.find(c => c.title === 'Bases Database');
+      const pass = card && card.badge === 'On' && card.isOk;
+      return { pass, detail: `badge="${card?.badge}" isOk=${card?.isOk}` };
+    });
+
+    await test('badge / bases — Off when generateBasesFile false', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        generateBasesFile: false,
+      });
+      const card = infos.find(c => c.title === 'Bases Database');
+      const pass = card && card.badge === 'Off' && card.isOff;
+      return { pass, detail: `badge="${card?.badge}" isOff=${card?.isOff}` };
+    });
+
+    await test('badge / sync — On when bidirectionalSync true', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        bidirectionalSync: true,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.badge === 'On' && card.isOk;
+      return { pass, detail: `badge="${card?.badge}" isOk=${card?.isOk}` };
+    });
+
+    await test('badge / sync — Off when bidirectionalSync false', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST123', tableId: 'tblTEST456',
+        bidirectionalSync: false,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.badge === 'Off' && card.isOff;
+      return { pass, detail: `badge="${card?.badge}" isOff=${card?.isOff}` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 3: Badge Matrix — Combination Tests
+    // ════════════════════════════════════════════════════════════════
+
+    await test('badge-matrix / all features configured', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: 'TestFolder',
+        generateBasesFile: true,
+        bidirectionalSync: true,
+      });
+      const allOk = infos.every(c => c.isOk);
+      const badges = infos.map(c => `${c.title}:${c.badge}`).join(' | ');
+      return { pass: allOk, detail: badges };
+    });
+
+    await test('badge-matrix / all features unconfigured', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: '', tableId: '',
+        folderPath: '',
+        generateBasesFile: false,
+        bidirectionalSync: false,
+      });
+      // Connection card won't render (no apiKey check is at credential level, but baseId/tableId empty)
+      // Files, Bases, Sync should all be off
+      const filesOff = infos.find(c => c.title === 'File Settings')?.isOff;
+      const basesOff = infos.find(c => c.title === 'Bases Database')?.isOff;
+      const syncOff = infos.find(c => c.title === 'Bidirectional Sync')?.isOff;
+      const connOff = infos.find(c => c.title === 'Airtable Connection')?.isOff;
+      const pass = filesOff && basesOff && syncOff && (connOff === undefined || connOff);
+      return { pass, detail: `files=${filesOff} bases=${basesOff} sync=${syncOff} conn=${connOff}` };
+    });
+
+    await test('badge-matrix / mixed: connection+files on, bases+sync off', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: 'Mixed',
+        generateBasesFile: false,
+        bidirectionalSync: false,
+      });
+      const conn = infos.find(c => c.title === 'Airtable Connection');
+      const files = infos.find(c => c.title === 'File Settings');
+      const bases = infos.find(c => c.title === 'Bases Database');
+      const sync = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = conn?.isOk && files?.isOk && bases?.isOff && sync?.isOff;
+      return { pass, detail: `conn=${conn?.isOk} files=${files?.isOk} bases=${bases?.isOff} sync=${sync?.isOff}` };
+    });
+
+    await test('badge-matrix / mixed: sync+bases on, files empty', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: '',
+        generateBasesFile: true,
+        bidirectionalSync: true,
+      });
+      const files = infos.find(c => c.title === 'File Settings');
+      const bases = infos.find(c => c.title === 'Bases Database');
+      const sync = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = files?.isOff && bases?.isOk && sync?.isOk;
+      return { pass, detail: `files=${files?.isOff} bases=${bases?.isOk} sync=${sync?.isOk}` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 4: Summary Text
+    // ════════════════════════════════════════════════════════════════
+
+    await test('summary / connection — shows filenameField and View filtered', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        filenameFieldName: 'Name', viewId: 'viwTEST',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.summary.includes('Name') && card.summary.includes('View filtered');
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / connection — shows filenameField only when no view', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        filenameFieldName: 'Title', viewId: '',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.summary === 'Title';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / connection — empty when not connected', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: '', tableId: '',
+        filenameFieldName: 'Name', viewId: 'viwTEST',
+      });
+      const card = infos.find(c => c.title === 'Airtable Connection');
+      const pass = card && card.summary === '';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / files — full: folder + template + interval', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: 'Crawling', templatePath: 'Templates/note.md', syncInterval: 5,
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card
+        && card.summary.includes('Crawling/')
+        && card.summary.includes('note.md')
+        && card.summary.includes('5min');
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / files — folder only', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: 'Notes', templatePath: '', syncInterval: 0,
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card && card.summary === 'Notes/';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / files — empty when no folderPath', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: '', templatePath: '', syncInterval: 0,
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card && card.summary === '';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / files — template without folder still shows template', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: '', templatePath: 'Templates/tmpl.md', syncInterval: 3,
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      const pass = card && card.summary.includes('tmpl.md') && card.summary.includes('3min');
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / files — template extracts basename from path', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        folderPath: 'X', templatePath: 'deeply/nested/tmpl.md', syncInterval: 0,
+      });
+      const card = infos.find(c => c.title === 'File Settings');
+      // Should show 'tmpl.md' not the full path
+      const pass = card && card.summary.includes('tmpl.md') && !card.summary.includes('deeply');
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / bases — shows text when on', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        generateBasesFile: true,
+      });
+      const card = infos.find(c => c.title === 'Bases Database');
+      const pass = card && card.summary === 'Auto-generate enabled';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / bases — empty when off', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        generateBasesFile: false,
+      });
+      const card = infos.find(c => c.title === 'Bases Database');
+      const pass = card && card.summary === '';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / sync — shows conflictResolution + watching', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        bidirectionalSync: true, conflictResolution: 'obsidian-wins', watchForChanges: true,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.summary.includes('obsidian-wins') && card.summary.includes('watching');
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / sync — shows conflictResolution only when not watching', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        bidirectionalSync: true, conflictResolution: 'airtable-wins', watchForChanges: false,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.summary === 'airtable-wins';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / sync — empty when bidirectionalSync off', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        bidirectionalSync: false, conflictResolution: 'manual', watchForChanges: true,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.summary === '';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    await test('summary / sync — manual mode', async () => {
+      const infos = await setConfigAndQuery({
+        baseId: 'appTEST', tableId: 'tblTEST',
+        bidirectionalSync: true, conflictResolution: 'manual', watchForChanges: false,
+      });
+      const card = infos.find(c => c.title === 'Bidirectional Sync');
+      const pass = card && card.summary === 'manual';
+      return { pass, detail: `summary="${card?.summary}"` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 5: Card Interactions
+    // ════════════════════════════════════════════════════════════════
+
+    await test('interaction / card expands on header click', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const cfg = getActiveConfig();
+        cfg.baseId = 'appTEST';
+        cfg.tableId = 'tblTEST';
+        await getPlugin().saveSettings();
+
+        // Clear state so all cards start collapsed
+        const tab = getSettingsTab();
+        tab.expandedSections.clear();
+        tab.display();
+        await new Promise(r => setTimeout(r, 400));
+
+        const cards = queryCards();
+        const fileCard = cards.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'File Settings'
+        );
+        if (!fileCard) return JSON.stringify({ wasBefore: false, isAfter: false, hasBody: false, error: 'not found' });
+
+        const wasBefore = fileCard.classList.contains('is-expanded');
+
+        // Click to expand
+        fileCard.querySelector('.ani-card-header').click();
+        await new Promise(r => setTimeout(r, 500));
+
+        const cardsAfter = queryCards();
+        const fileCardAfter = cardsAfter.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'File Settings'
+        );
+        const isAfter = fileCardAfter?.classList.contains('is-expanded');
+        const hasBody = !!fileCardAfter?.querySelector('.ani-card-body');
+
+        return JSON.stringify({ wasBefore, isAfter, hasBody });
+      })()`, 10000);
+      const pass = !r.wasBefore && r.isAfter === true && r.hasBody === true;
+      return { pass, detail: `before=${r.wasBefore} after=${r.isAfter} body=${r.hasBody}` };
+    });
+
+    await test('interaction / card collapses on second click', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const cfg = getActiveConfig();
+        cfg.baseId = 'appTEST';
+        cfg.tableId = 'tblTEST';
+        await getPlugin().saveSettings();
+        await openSettingsTab();
+
+        // First click to expand
+        let cards = queryCards();
+        let basesCard = cards.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'Bases Database'
+        );
+        basesCard.querySelector('.ani-card-header').click();
+        await new Promise(r => setTimeout(r, 500));
+
+        // Verify expanded
+        cards = queryCards();
+        basesCard = cards.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'Bases Database'
+        );
+        const expandedAfterFirst = basesCard.classList.contains('is-expanded');
+
+        // Second click to collapse
+        basesCard.querySelector('.ani-card-header').click();
+        await new Promise(r => setTimeout(r, 500));
+
+        cards = queryCards();
+        basesCard = cards.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'Bases Database'
+        );
+        const expandedAfterSecond = basesCard.classList.contains('is-expanded');
+        const hasBody = !!basesCard.querySelector('.ani-card-body');
+
+        return JSON.stringify({ expandedAfterFirst, expandedAfterSecond, hasBody });
+      })()`, 10000);
+      const pass = r.expandedAfterFirst === true && r.expandedAfterSecond === false && r.hasBody === false;
+      return { pass, detail: `1st=${r.expandedAfterFirst} 2nd=${r.expandedAfterSecond} body=${r.hasBody}` };
+    });
+
+    await test('interaction / expanded card shows settings inside card-body', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const cfg = getActiveConfig();
+        cfg.baseId = 'appTEST';
+        cfg.tableId = 'tblTEST';
+        cfg.bidirectionalSync = true;
+        await getPlugin().saveSettings();
+
+        // Directly set expanded state for Bidirectional Sync
+        const tab = getSettingsTab();
+        tab.expandedSections.clear();
+        tab.expandedSections.add('bidirectional-sync');
+        tab.display();
+        await new Promise(r => setTimeout(r, 400));
+
+        const cards = queryCards();
+        const syncCard = cards.find(c =>
+          c.querySelector('.ani-card-title')?.textContent === 'Bidirectional Sync'
+        );
+        const body = syncCard?.querySelector('.ani-card-body');
+        const settingItems = body ? body.querySelectorAll('.setting-item').length : 0;
+        const isExpanded = syncCard?.classList.contains('is-expanded');
+
+        return JSON.stringify({ hasBody: !!body, settingItems, isExpanded });
+      })()`, 10000);
+      const pass = r.hasBody && r.settingItems >= 2 && r.isExpanded;
+      return { pass, detail: `body=${r.hasBody} settings=${r.settingItems} expanded=${r.isExpanded}` };
+    });
+
+    await test('interaction / chevron rotates when expanded', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const cfg = getActiveConfig();
+        cfg.baseId = 'appTEST';
+        cfg.tableId = 'tblTEST';
+        await getPlugin().saveSettings();
+
+        // Clear expandedSections to ensure all cards start collapsed
+        const tab = getSettingsTab();
+        tab.expandedSections?.clear();
+        tab.display();
+        await new Promise(r => setTimeout(r, 400));
+
+        // Verify first card starts collapsed
+        const cards = queryCards();
+        const card = cards[0];
+        const startedCollapsed = !card.classList.contains('is-expanded');
+
+        // Click to expand
+        card.querySelector('.ani-card-header').click();
+        await new Promise(r => setTimeout(r, 500));
+
+        const cardsAfter = queryCards();
+        const cardAfter = cardsAfter[0];
+        const isNowExpanded = cardAfter.classList.contains('is-expanded');
+
+        return JSON.stringify({ startedCollapsed, isNowExpanded });
+      })()`, 10000);
+      const pass = r.startedCollapsed && r.isNowExpanded;
+      return { pass, detail: `collapsed=${r.startedCollapsed} expanded=${r.isNowExpanded}` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 6: Delete Confirmation
+    // ════════════════════════════════════════════════════════════════
+
+    await test('interaction / delete button exists in danger zone', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const cfg = getActiveConfig();
+        cfg.baseId = 'appTEST';
+        cfg.tableId = 'tblTEST';
+        await getPlugin().saveSettings();
+        await openSettingsTab();
+
+        const c = getContainer();
+        const dangerHeading = Array.from(c.querySelectorAll('.setting-item-heading'))
+          .find(h => h.textContent.includes('Danger'));
+        const deleteBtn = c.querySelector('.ani-delete-config .mod-warning');
+
+        return JSON.stringify({
+          hasDangerHeading: !!dangerHeading,
+          hasDeleteBtn: !!deleteBtn,
+        });
+      })()`, 10000);
+      const pass = r.hasDangerHeading && r.hasDeleteBtn;
+      return { pass, detail: `heading=${r.hasDangerHeading} btn=${r.hasDeleteBtn}` };
+    });
+
+    // ════════════════════════════════════════════════════════════════
+    // Group 7: Edge Cases
+    // ════════════════════════════════════════════════════════════════
+
+    await test('edge / no config shows empty state', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const savedConfigs = [...p.settings.configs];
+        const savedActiveId = p.settings.activeConfigId;
+
+        // Temporarily remove all configs
+        p.settings.configs = [];
+        p.settings.activeConfigId = '';
+        await openSettingsTab();
+
+        const c = getContainer();
+        const cards = c.querySelectorAll('.ani-summary-card').length;
+        const noConfigMsg = c.textContent.includes('No configuration');
+
+        // Restore
+        p.settings.configs = savedConfigs;
+        p.settings.activeConfigId = savedActiveId;
+        await p.saveSettings();
+
+        return JSON.stringify({ cards, noConfigMsg });
+      })()`, 10000);
+      const pass = r.cards === 0 && r.noConfigMsg;
+      return { pass, detail: `cards=${r.cards} noConfigMsg=${r.noConfigMsg}` };
+    });
+
+    await test('edge / tab bar reflects config names', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        await openSettingsTab();
+        const c = getContainer();
+        const tabs = Array.from(c.querySelectorAll('.ani-config-tab:not(.ani-add-tab)'));
+        const names = tabs.map(t => t.textContent);
+        const addTab = c.querySelector('.ani-add-tab');
+        return JSON.stringify({ count: tabs.length, names, hasAddTab: !!addTab });
+      })()`, 10000);
+      const pass = r.count >= 1 && r.hasAddTab;
+      return { pass, detail: `tabs=${r.count} names=[${r.names.join(', ')}] addTab=${r.hasAddTab}` };
+    });
+
+    await test('edge / debug toggle reflects global debugMode', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const was = p.settings.debugMode;
+
+        p.settings.debugMode = true;
+        await p.saveSettings();
+        await openSettingsTab();
+        const c = getContainer();
+        const debugSection = c.querySelector('.ani-debug-section');
+        const toggle = debugSection?.querySelector('.checkbox-container');
+        const isChecked = toggle?.classList.contains('is-enabled');
+
+        // Restore
+        p.settings.debugMode = was;
+        await p.saveSettings();
+
+        return JSON.stringify({ isChecked, toggleExists: !!toggle });
+      })()`, 10000);
+      const pass = r.toggleExists && r.isChecked;
+      return { pass, detail: `toggle=${r.toggleExists} checked=${r.isChecked}` };
+    });
+
+    // ── Teardown: Restore original config, close settings ────────
+
+    log('\n=== Teardown ===');
+    await run(`(async () => {
+      ${HELPERS}
+      const p = getPlugin();
+      const cfg = getActiveConfig();
+      const orig = ${JSON.stringify(originalConfig)};
+      Object.assign(cfg, orig);
+      await p.saveSettings();
+      app.setting.close();
+      return JSON.stringify({ ok: true });
+    })()`, 10000);
+    log('Original config restored, settings closed');
+
+    // ── Summary ──────────────────────────────────────────────────
+
+    log('\n========================================');
+    log('     SETTINGS UI E2E TEST SUMMARY');
+    log('========================================');
+    let passCount = 0;
+    for (const r of results) {
+      const icon = r.pass ? 'PASS' : 'FAIL';
+      log(`${icon} | ${r.test}`);
+      if (!r.pass) log(`       ${r.detail}`);
+      if (r.pass) passCount++;
+    }
+    log(`\nTotal: ${passCount}/${results.length} passed`);
+
+    process.exit(passCount === results.length ? 0 : 1);
+
+  } catch (e) {
+    console.error('FATAL:', e.message);
+    process.exit(1);
+  }
+})();

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -12,56 +12,13 @@
  *   node tests/e2e/run-settings-e2e.mjs
  */
 
+import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
-const CDP_PORT = process.env.CDP_PORT || 9222;
 const PLUGIN_ID = 'auto-note-importer';
-
-// ---------------------------------------------------------------------------
-// CDP helpers (shared pattern with run-e2e.mjs)
-// ---------------------------------------------------------------------------
-
-async function findPageTarget() {
-  const override = process.env.CDP_TARGET_ID;
-  if (override) return override;
-
-  const resp = await fetch(`http://localhost:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  const page = targets.find(t => t.type === 'page' && t.url.includes('obsidian'));
-  if (!page) throw new Error('No Obsidian page target found. Is Obsidian running with --remote-debugging-port?');
-  return page.id;
-}
-
-function evalInObsidian(targetId, expression, timeout = 15000) {
-  const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${targetId}`;
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timeout (${timeout}ms)`)), timeout);
-    const ws = new WebSocket(wsUrl);
-    ws.addEventListener('open', () => {
-      ws.send(JSON.stringify({
-        id: 1,
-        method: 'Runtime.evaluate',
-        params: { expression, awaitPromise: true, returnByValue: true }
-      }));
-    });
-    ws.addEventListener('message', (e) => {
-      const result = JSON.parse(e.data);
-      if (result.id === 1) {
-        clearTimeout(timer);
-        if (result.result?.exceptionDetails) {
-          resolve({ __error: result.result.exceptionDetails.exception?.description || 'Unknown error' });
-        } else {
-          try { resolve(JSON.parse(result.result.result.value)); }
-          catch { resolve(result.result.result.value); }
-        }
-        ws.close();
-      }
-    });
-    ws.addEventListener('error', (err) => { clearTimeout(timer); ws.close(); reject(err); });
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Obsidian-side helpers

--- a/tests/file-operations/file-watcher.test.ts
+++ b/tests/file-operations/file-watcher.test.ts
@@ -4,16 +4,16 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FileWatcher } from '../../src/file-operations/file-watcher';
-import type { AutoNoteImporterSettings } from '../../src/types';
-import { DEFAULT_SETTINGS } from '../../src/types';
+import type { LegacySettings } from '../../src/types';
+import { DEFAULT_LEGACY_SETTINGS } from '../../src/types';
 import { DEBUG_DELAY_MULTIPLIER } from '../../src/constants';
 // Import from 'obsidian' (aliased to mock) to ensure same module identity as source code
 import { createMockApp, createMockTFile } from 'obsidian';
 import type { App } from 'obsidian';
 
-function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+function createSettings(overrides: Partial<LegacySettings> = {}): LegacySettings {
   return {
-    ...DEFAULT_SETTINGS,
+    ...DEFAULT_LEGACY_SETTINGS,
     folderPath: 'Sync',
     bidirectionalSync: true,
     watchForChanges: true,

--- a/tests/services/airtable-client-view.test.ts
+++ b/tests/services/airtable-client-view.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AirtableClient } from '../../src/services/airtable-client';
-import type { AutoNoteImporterSettings } from '../../src/types';
-import { DEFAULT_SETTINGS } from '../../src/types';
+import type { LegacySettings } from '../../src/types';
+import { DEFAULT_LEGACY_SETTINGS } from '../../src/types';
 import { RateLimiter } from '../../src/services/rate-limiter';
 
 vi.mock('obsidian', () => ({
@@ -16,9 +16,9 @@ import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
 
-function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+function createSettings(overrides: Partial<LegacySettings> = {}): LegacySettings {
   return {
-    ...DEFAULT_SETTINGS,
+    ...DEFAULT_LEGACY_SETTINGS,
     apiKey: 'pat-test-key',
     baseId: 'appTestBase',
     tableId: 'tblTestTable',

--- a/tests/services/airtable-client.test.ts
+++ b/tests/services/airtable-client.test.ts
@@ -4,17 +4,17 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AirtableClient } from '../../src/services/airtable-client';
-import type { AutoNoteImporterSettings } from '../../src/types';
-import { DEFAULT_SETTINGS } from '../../src/types';
+import type { LegacySettings } from '../../src/types';
+import { DEFAULT_LEGACY_SETTINGS } from '../../src/types';
 import { AIRTABLE_BATCH_SIZE } from '../../src/constants';
 import { RateLimiter } from '../../src/services/rate-limiter';
 import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
 
-function createSettings(overrides: Partial<AutoNoteImporterSettings> = {}): AutoNoteImporterSettings {
+function createSettings(overrides: Partial<LegacySettings> = {}): LegacySettings {
   return {
-    ...DEFAULT_SETTINGS,
+    ...DEFAULT_LEGACY_SETTINGS,
     apiKey: 'pat-test',
     baseId: 'appTest',
     tableId: 'tblTest',

--- a/tests/services/field-cache.test.ts
+++ b/tests/services/field-cache.test.ts
@@ -53,16 +53,15 @@ describe('FieldCache', () => {
       expect(mockRequestUrl).toHaveBeenCalledTimes(1);
     });
 
-    it('should clear cache when API key changes', async () => {
+    it('should return cached bases regardless of API key (caller manages invalidation)', async () => {
       mockRequestUrl
-        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app1', name: 'Base 1' }]))
-        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app2', name: 'Base 2' }]));
+        .mockResolvedValueOnce(mockBasesResponse([{ id: 'app1', name: 'Base 1' }]));
 
       await cache.fetchBases('key-1');
       const bases = await cache.fetchBases('key-2');
 
-      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
-      expect(bases[0].id).toBe('app2');
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+      expect(bases[0].id).toBe('app1');
     });
 
     it('should throw on non-200 response', async () => {

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for settings migration utility.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { migrateSettings } from '../../src/utils/migration';
+
+describe('migrateSettings', () => {
+  it('should return null for v2 settings', () => {
+    const data = { version: 2, credentials: [], configs: [], activeConfigId: '', debugMode: false };
+    expect(migrateSettings(data)).toBeNull();
+  });
+
+  it('should return null for null/undefined data', () => {
+    expect(migrateSettings(null)).toBeNull();
+    expect(migrateSettings(undefined)).toBeNull();
+  });
+
+  it('should migrate legacy settings to v2', () => {
+    const legacy = {
+      apiKey: 'pat_xxx', baseId: 'app123', tableId: 'tbl456', viewId: 'viw789',
+      folderPath: 'Notes/', templatePath: '', syncInterval: 300, allowOverwrite: true,
+      filenameFieldName: 'Name', subfolderFieldName: '', bidirectionalSync: false,
+      conflictResolution: 'obsidian-wins', watchForChanges: false, fileWatchDebounce: 2000,
+      autoSyncFormulas: false, formulaSyncDelay: 3000, generateBasesFile: false,
+      basesFileLocation: 'vault-root', basesCustomPath: '', basesRegenerateOnSync: false,
+      debugMode: true,
+    };
+
+    const result = migrateSettings(legacy);
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe(2);
+    expect(result!.debugMode).toBe(true);
+    expect(result!.credentials).toHaveLength(1);
+    expect(result!.credentials[0].type).toBe('airtable');
+    expect(result!.credentials[0].apiKey).toBe('pat_xxx');
+    expect(result!.configs).toHaveLength(1);
+    expect(result!.configs[0].credentialId).toBe(result!.credentials[0].id);
+    expect(result!.configs[0].baseId).toBe('app123');
+    expect(result!.configs[0].enabled).toBe(true);
+    expect(result!.activeConfigId).toBe(result!.configs[0].id);
+  });
+
+  it('should handle empty apiKey', () => {
+    const legacy = {
+      apiKey: '', baseId: '', tableId: '', viewId: '', folderPath: '', templatePath: '',
+      syncInterval: 0, allowOverwrite: true, filenameFieldName: '', subfolderFieldName: '',
+      bidirectionalSync: false, conflictResolution: 'manual', watchForChanges: false,
+      fileWatchDebounce: 2000, autoSyncFormulas: false, formulaSyncDelay: 3000,
+      generateBasesFile: false, basesFileLocation: 'vault-root', basesCustomPath: '',
+      basesRegenerateOnSync: false, debugMode: false,
+    };
+    const result = migrateSettings(legacy);
+    expect(result).not.toBeNull();
+    expect(result!.credentials).toHaveLength(1);
+  });
+
+  it('should generate unique ids for credential and config', () => {
+    const legacy = { apiKey: 'key', baseId: 'base', tableId: 'tbl', viewId: '' };
+    const result = migrateSettings(legacy);
+    expect(result).not.toBeNull();
+    expect(result!.credentials[0].id).toBeTruthy();
+    expect(result!.configs[0].id).toBeTruthy();
+    expect(result!.credentials[0].id).not.toBe(result!.configs[0].id);
+  });
+
+  it('should correctly map all legacy config fields', () => {
+    const legacy = {
+      apiKey: 'key',
+      baseId: 'app_base',
+      tableId: 'tbl_table',
+      viewId: 'viw_view',
+      folderPath: 'MyNotes',
+      templatePath: 'Templates/note.md',
+      syncInterval: 600,
+      allowOverwrite: false,
+      filenameFieldName: 'Title',
+      subfolderFieldName: 'Category',
+      bidirectionalSync: true,
+      conflictResolution: 'airtable-wins',
+      watchForChanges: true,
+      fileWatchDebounce: 5000,
+      autoSyncFormulas: true,
+      formulaSyncDelay: 1500,
+      generateBasesFile: true,
+      basesFileLocation: 'custom',
+      basesCustomPath: 'output/bases.md',
+      basesRegenerateOnSync: true,
+      debugMode: false,
+    };
+
+    const result = migrateSettings(legacy);
+    expect(result).not.toBeNull();
+    const config = result!.configs[0];
+    expect(config.baseId).toBe('app_base');
+    expect(config.tableId).toBe('tbl_table');
+    expect(config.viewId).toBe('viw_view');
+    expect(config.folderPath).toBe('MyNotes');
+    expect(config.templatePath).toBe('Templates/note.md');
+    expect(config.syncInterval).toBe(600);
+    expect(config.allowOverwrite).toBe(false);
+    expect(config.filenameFieldName).toBe('Title');
+    expect(config.subfolderFieldName).toBe('Category');
+    expect(config.bidirectionalSync).toBe(true);
+    expect(config.conflictResolution).toBe('airtable-wins');
+    expect(config.watchForChanges).toBe(true);
+    expect(config.fileWatchDebounce).toBe(5000);
+    expect(config.autoSyncFormulas).toBe(true);
+    expect(config.formulaSyncDelay).toBe(1500);
+    expect(config.generateBasesFile).toBe(true);
+    expect(config.basesFileLocation).toBe('custom');
+    expect(config.basesCustomPath).toBe('output/bases.md');
+    expect(config.basesRegenerateOnSync).toBe(true);
+  });
+});

--- a/tests/utils/object-utils.test.ts
+++ b/tests/utils/object-utils.test.ts
@@ -164,13 +164,9 @@ describe('generateId', () => {
     expect(typeof generateId()).toBe('string');
   });
 
-  it('should include timestamp', () => {
-    const before = Date.now();
+  it('should return a UUID v4 format', () => {
     const id = generateId();
-    const after = Date.now();
-    const timestamp = parseInt(id.split('-')[0], 10);
-    expect(timestamp).toBeGreaterThanOrEqual(before);
-    expect(timestamp).toBeLessThanOrEqual(after);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 
   it('should generate unique ids', () => {
@@ -179,10 +175,5 @@ describe('generateId', () => {
       ids.add(generateId());
     }
     expect(ids.size).toBe(100);
-  });
-
-  it('should match expected format', () => {
-    const id = generateId();
-    expect(id).toMatch(/^\d+-[a-z0-9]+$/);
   });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for folder overlap validation utility.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateFolderPath } from '../../src/utils/validation';
+import type { ConfigEntry } from '../../src/types/config.types';
+
+function makeConfig(overrides: Partial<ConfigEntry> & { id: string; name: string; folderPath: string }): ConfigEntry {
+  return {
+    enabled: true,
+    credentialId: 'cred-1',
+    baseId: '',
+    tableId: '',
+    viewId: '',
+    templatePath: '',
+    filenameFieldName: '',
+    subfolderFieldName: '',
+    syncInterval: 0,
+    allowOverwrite: true,
+    bidirectionalSync: false,
+    conflictResolution: 'manual',
+    watchForChanges: false,
+    fileWatchDebounce: 2000,
+    autoSyncFormulas: false,
+    formulaSyncDelay: 3000,
+    generateBasesFile: false,
+    basesFileLocation: 'vault-root',
+    basesCustomPath: '',
+    basesRegenerateOnSync: false,
+    ...overrides,
+  };
+}
+
+describe('validateFolderPath', () => {
+  it('should return null for non-overlapping folders', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Config A', folderPath: 'Notes' }),
+      makeConfig({ id: 'cfg-2', name: 'Config B', folderPath: 'Docs' }),
+    ];
+    expect(validateFolderPath('cfg-new', 'Tasks', configs)).toBeNull();
+  });
+
+  it('should return null for sibling folders (a/b and a/c)', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Config A', folderPath: 'Root/Alpha' }),
+    ];
+    expect(validateFolderPath('cfg-new', 'Root/Beta', configs)).toBeNull();
+  });
+
+  it('should return an error for identical folders', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Existing Config', folderPath: 'Notes' }),
+    ];
+    const result = validateFolderPath('cfg-new', 'Notes', configs);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Existing Config');
+  });
+
+  it('should return an error for parent-child overlap (new is child of existing)', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Parent Config', folderPath: 'Notes' }),
+    ];
+    const result = validateFolderPath('cfg-new', 'Notes/Sub', configs);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Parent Config');
+  });
+
+  it('should return an error for child-parent overlap (new is parent of existing)', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Child Config', folderPath: 'Notes/Sub' }),
+    ];
+    const result = validateFolderPath('cfg-new', 'Notes', configs);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Child Config');
+  });
+
+  it('should skip the config with the same configId (self-skip)', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-self', name: 'Self Config', folderPath: 'Notes' }),
+    ];
+    expect(validateFolderPath('cfg-self', 'Notes', configs)).toBeNull();
+  });
+
+  it('should check disabled configs too', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Disabled Config', folderPath: 'Notes', enabled: false }),
+    ];
+    const result = validateFolderPath('cfg-new', 'Notes', configs);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Disabled Config');
+  });
+
+  it('should skip configs with empty folderPath', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'No Folder Config', folderPath: '' }),
+    ];
+    expect(validateFolderPath('cfg-new', 'Notes', configs)).toBeNull();
+  });
+
+  it('should return null with no configs', () => {
+    expect(validateFolderPath('cfg-new', 'Notes', [])).toBeNull();
+  });
+
+  it('should detect conflict for deeply nested parent-child', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Deep Config', folderPath: 'A/B/C' }),
+    ];
+    const result = validateFolderPath('cfg-new', 'A/B/C/D/E', configs);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Deep Config');
+  });
+
+  it('should not match partial folder name prefix (a/bc vs a/b)', () => {
+    const configs = [
+      makeConfig({ id: 'cfg-1', name: 'Config B', folderPath: 'Notes/Sub' }),
+    ];
+    // "Notes/Subtext" should NOT conflict with "Notes/Sub"
+    expect(validateFolderPath('cfg-new', 'Notes/Subtext', configs)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- 여러 Airtable base/table을 독립 설정으로 동시 관리 가능
- Credential 레지스트리 (글로벌) + ConfigEntry (per-tab) 아키텍처
- 기존 사용자 v1 → v2 자동 마이그레이션
- Tab 방식 Settings UI, config별 동적 커맨드 등록
- DatabaseClient 인터페이스로 향후 Multi-DB (#11) 확장 준비

## Architecture
- **ConfigManager** → **ConfigInstance** (per-config service stack: AirtableClient, FileWatcher, SyncQueue, SyncOrchestrator, ConflictResolver)
- **SharedServices**: RateLimiter (credential별 공유), FieldCache, FrontmatterParser
- **Credential registry**: API key를 이름 붙여 등록, config에서 선택
- **Folder overlap validation**: 동일/부모-자식 경로 중복 금지

## Changes
### Core
- `ConfigInstance` — per-config 서비스 스택 lifecycle 관리
- `ConfigManager` — 다중 config 생성/삭제/업데이트 오케스트레이션
- `DatabaseClient` interface — AirtableClient가 구현, 향후 확장 가능
- `migrateSettings()` — v1 단일 설정을 v2 다중 설정으로 자동 변환

### Services
- `AirtableClient` implements `DatabaseClient`
- `ConflictResolver`, `SyncOrchestrator` — `DatabaseClient` 수용
- `FieldCache` — credential-aware 캐싱 (cross-credential 무효화 방지)

### UI
- Credential 관리 섹션 (추가/편집/삭제, API 키 마스킹)
- Tab 바로 config 전환 + 추가/삭제
- 폴더 겹침 실시간 검증
- Config별 enable/disable 토글

### Commands
- Config별 동적 커맨드 등록 (`Sync from Airtable — Blog Posts`)
- Config 변경 시 커맨드 자동 재등록
- Current scope에서 폴더 소속 검증

## Test plan
- [x] Unit tests: 372 passed (ConfigInstance, ConfigManager, migration, validation 포함)
- [x] E2E tests: 16/16 passed
  - [x] 기존 13개 테스트 v2 호환 업데이트
  - [x] multi-config / migration preserves settings
  - [x] multi-config / independent sync (2 config 독립 동기화)
  - [x] multi-config / folder isolation (교차 오염 없음)
- [x] Build: clean (0 errors, 0 warnings)

Closes #9