### PR TITLE
feat: provider-aware credential form with connection test (#51)

### DIFF
--- a/src/services/airtable-credential-form.ts
+++ b/src/services/airtable-credential-form.ts
@@ -1,0 +1,111 @@
+/**
+ * Airtable credential form renderer.
+ *
+ * Draws the API Key input, validates user input, and tests the credential
+ * by calling Airtable's Meta API `/v0/meta/bases` endpoint. Registered
+ * with the provider registry as the built-in 'airtable' renderer.
+ *
+ * @handbook 4.4-provider-abstraction
+ * @handbook 5.1-ui-components
+ * @tested tests/services/airtable-credential-form.test.ts
+ */
+
+import { Setting, requestUrl } from "obsidian";
+import { AIRTABLE_META_API_URL } from '../constants';
+import type {
+  CredentialFormRenderer,
+  CredentialFormState,
+  CredentialBuildResult,
+  ConnectionTestResult,
+  Credential,
+} from '../types';
+
+const STATE_KEY = 'apiKey';
+
+class AirtableCredentialFormRendererImpl implements CredentialFormRenderer {
+  readonly type = 'airtable' as const;
+  readonly label = 'Airtable';
+  readonly description = 'Personal access token from airtable.com/create/tokens';
+
+  renderFields(
+    containerEl: HTMLElement,
+    state: CredentialFormState,
+    initial?: Credential,
+  ): void {
+    if (initial?.type === 'airtable' && state[STATE_KEY] === undefined) {
+      state[STATE_KEY] = initial.apiKey;
+    }
+
+    const setting = new Setting(containerEl)
+      .setName('API Key')
+      .addText(text => {
+        text
+          .setValue(state[STATE_KEY] ?? '')
+          .setPlaceholder('pat-xxx...')
+          .onChange(value => { state[STATE_KEY] = value; });
+        text.inputEl.type = 'password';
+      });
+    setting.settingEl.addClass('ani-credential-edit');
+  }
+
+  build(name: string, state: CredentialFormState, id: string): CredentialBuildResult {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return { ok: false, error: 'Credential name cannot be empty.' };
+    }
+    const apiKey = (state[STATE_KEY] ?? '').trim();
+    if (!apiKey) {
+      return { ok: false, error: 'API key cannot be empty.' };
+    }
+    return {
+      ok: true,
+      credential: {
+        id,
+        name: trimmedName,
+        type: 'airtable',
+        apiKey,
+      },
+    };
+  }
+
+  async testConnection(credential: Credential): Promise<ConnectionTestResult> {
+    if (credential.type !== 'airtable') {
+      return { success: false, error: `Expected airtable credential, got ${credential.type}` };
+    }
+    try {
+      const response = await requestUrl({
+        url: `${AIRTABLE_META_API_URL}/bases`,
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${credential.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      if (response.status !== 200) {
+        return {
+          success: false,
+          error: `HTTP ${response.status}: ${this.extractErrorMessage(response)}`,
+        };
+      }
+      const baseCount = Array.isArray(response.json?.bases) ? response.json.bases.length : 0;
+      return {
+        success: true,
+        detail: baseCount > 0 ? `${baseCount} base(s) accessible` : 'Authenticated (no bases found)',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Network error';
+      return { success: false, error: message };
+    }
+  }
+
+  private extractErrorMessage(response: { json?: unknown }): string {
+    const json = response.json as { error?: { message?: string } | string } | undefined;
+    if (typeof json?.error === 'string') return json.error;
+    if (json?.error && typeof json.error === 'object' && json.error.message) {
+      return json.error.message;
+    }
+    return 'Unknown error';
+  }
+}
+
+export const airtableCredentialFormRenderer: CredentialFormRenderer = new AirtableCredentialFormRendererImpl();

--- a/src/services/airtable-credential-form.ts
+++ b/src/services/airtable-credential-form.ts
@@ -78,7 +78,7 @@ class AirtableCredentialFormRendererImpl implements CredentialFormRenderer {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${credential.apiKey}`,
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
         },
       });
       if (response.status !== 200) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,6 +8,10 @@ export {
   registerFieldTypeMapper,
   getFieldTypeMapper,
   hasFieldTypeMapper,
+  registerCredentialFormRenderer,
+  getCredentialFormRenderer,
+  hasCredentialFormRenderer,
 } from './provider-registry';
 export type { ProviderFactory } from './provider-registry';
 export { airtableFieldMapper } from './airtable-field-mapper';
+export { airtableCredentialFormRenderer } from './airtable-credential-form';

--- a/src/services/provider-registry.ts
+++ b/src/services/provider-registry.ts
@@ -19,11 +19,13 @@ import type {
   ConfigEntry,
   DatabaseProvider,
   FieldTypeMapper,
+  CredentialFormRenderer,
 } from '../types';
 import { buildLegacySettings } from '../utils';
 import type { RateLimiter } from './rate-limiter';
 import { AirtableClient } from './airtable-client';
 import { airtableFieldMapper } from './airtable-field-mapper';
+import { airtableCredentialFormRenderer } from './airtable-credential-form';
 
 /**
  * Factory signature for creating a provider instance.
@@ -37,6 +39,7 @@ export type ProviderFactory = (
 
 const factories = new Map<CredentialType, ProviderFactory>();
 const fieldTypeMappers = new Map<CredentialType, FieldTypeMapper>();
+const credentialFormRenderers = new Map<CredentialType, CredentialFormRenderer>();
 
 /**
  * Registers a factory for a given credential type. Overwrites any
@@ -75,6 +78,37 @@ export function hasFieldTypeMapper(type: CredentialType): boolean {
 }
 
 /**
+ * Registers a credential form renderer for a given credential type.
+ * The settings UI delegates to the registered renderer for auth field
+ * rendering, credential construction, and (optional) connection testing.
+ */
+export function registerCredentialFormRenderer(
+  type: CredentialType,
+  renderer: CredentialFormRenderer,
+): void {
+  credentialFormRenderers.set(type, renderer);
+}
+
+/**
+ * Returns the credential form renderer registered for the given type.
+ * Throws if no renderer is registered.
+ */
+export function getCredentialFormRenderer(type: CredentialType): CredentialFormRenderer {
+  const renderer = credentialFormRenderers.get(type);
+  if (!renderer) {
+    throw new Error(`No credential form renderer registered for credential type: ${type}`);
+  }
+  return renderer;
+}
+
+/**
+ * Returns true if a credential form renderer is registered for the given type.
+ */
+export function hasCredentialFormRenderer(type: CredentialType): boolean {
+  return credentialFormRenderers.has(type);
+}
+
+/**
  * Creates a provider instance for the given credential and config.
  * Throws if no factory is registered for the credential's type.
  */
@@ -105,3 +139,4 @@ registerProvider('airtable', (credential, config, rateLimiter, debugMode) => {
 });
 
 registerFieldTypeMapper('airtable', airtableFieldMapper);
+registerCredentialFormRenderer('airtable', airtableCredentialFormRenderer);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,13 @@ export type {
 } from './field-types.types';
 
 export type {
+  CredentialFormState,
+  CredentialBuildResult,
+  ConnectionTestResult,
+  CredentialFormRenderer,
+} from './provider-settings.types';
+
+export type {
   SharedServices,
   ConfigEntry,
 } from './config.types';

--- a/src/types/provider-settings.types.ts
+++ b/src/types/provider-settings.types.ts
@@ -1,0 +1,83 @@
+/**
+ * Settings UI renderer contract for provider credentials.
+ *
+ * Each provider registers a CredentialFormRenderer that knows how to draw
+ * its own auth fields, validate user input, and optionally test the
+ * credential against the remote service. The settings tab delegates
+ * rendering to the registered renderer so the UI stays decoupled from
+ * any specific provider.
+ *
+ * @handbook 4.4-provider-abstraction
+ * @handbook 5.1-ui-components
+ */
+
+import type { Credential, CredentialType } from './credential.types';
+
+/**
+ * Mutable key-value state for a credential form in flight.
+ * Each field's `onChange` handler mutates the corresponding key; the
+ * renderer's `build()` reads from the same state when the user saves.
+ */
+export type CredentialFormState = Record<string, string>;
+
+/**
+ * Result of building a Credential from form state.
+ */
+export type CredentialBuildResult =
+  | { ok: true; credential: Credential }
+  | { ok: false; error: string };
+
+/**
+ * Result of testing a credential against the remote service.
+ */
+export type ConnectionTestResult =
+  | { success: true; detail?: string }
+  | { success: false; error: string };
+
+/**
+ * Per-provider credential form renderer. Stateless singleton registered
+ * via provider-registry alongside the provider factory and field type mapper.
+ */
+export interface CredentialFormRenderer {
+  /** Credential type this renderer handles. */
+  readonly type: CredentialType;
+
+  /** Human-readable label shown in the type dropdown (e.g. "Airtable"). */
+  readonly label: string;
+
+  /** Optional one-line description rendered above the auth fields. */
+  readonly description?: string;
+
+  /**
+   * Renders provider-specific auth fields into the container. Each field's
+   * onChange handler mutates the shared `state` object so `build()` can
+   * construct a Credential from the latest values.
+   *
+   * `initial` pre-populates state in edit mode — the renderer must respect
+   * existing values when present.
+   */
+  renderFields(
+    containerEl: HTMLElement,
+    state: CredentialFormState,
+    initial?: Credential,
+  ): void;
+
+  /**
+   * Builds a Credential from the current form state. Returns an error
+   * message when required fields are missing or invalid.
+   *
+   * `id` is provided so edit mode can preserve the existing credential's
+   * ID instead of generating a new one.
+   */
+  build(
+    name: string,
+    state: CredentialFormState,
+    id: string,
+  ): CredentialBuildResult;
+
+  /**
+   * Tests a credential against the remote service. Optional — providers
+   * without a cheap auth probe can omit this.
+   */
+  testConnection?(credential: Credential): Promise<ConnectionTestResult>;
+}

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -11,7 +11,14 @@
 
 import { App, PluginSettingTab, Setting, Notice, setIcon } from "obsidian";
 import type { ExtraButtonComponent, Plugin } from "obsidian";
-import { FieldCache, getFieldTypeMapper, hasFieldTypeMapper } from '../services';
+import {
+  FieldCache,
+  getFieldTypeMapper,
+  hasFieldTypeMapper,
+  getCredentialFormRenderer,
+  hasCredentialFormRenderer,
+} from '../services';
+import type { CredentialFormState } from '../types';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, AirtableCredential, CredentialType, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { DEFAULT_CONFIG_ENTRY, CREDENTIAL_TYPES, CREDENTIAL_TYPE_LABELS } from '../types';
 import { FolderSuggest, FileSuggest } from './suggest';
@@ -260,14 +267,15 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private renderCredentialEditRow(containerEl: HTMLElement, cred: Credential): void {
-    if (cred.type !== 'airtable') {
+    if (!hasCredentialFormRenderer(cred.type)) {
       new Setting(containerEl)
         .setName('Edit not supported')
         .setDesc(`Editing ${cred.type} credentials is not yet supported.`);
       return;
     }
+    const renderer = getCredentialFormRenderer(cred.type);
+    const state: CredentialFormState = {};
     let nameValue = cred.name;
-    let keyValue = cred.apiKey;
 
     const nameSetting = new Setting(containerEl)
       .setName('Name')
@@ -277,32 +285,40 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .onChange(value => { nameValue = value; }));
     nameSetting.settingEl.addClass('ani-credential-edit');
 
-    const keySetting = new Setting(containerEl)
-      .setName('API Key')
-      .addText(text => {
-        text
-          .setValue(cred.apiKey)
-          .setPlaceholder('pat-xxx...')
-          .onChange(value => { keyValue = value; });
-        text.inputEl.type = 'password';
-      });
-    keySetting.settingEl.addClass('ani-credential-edit');
+    renderer.renderFields(containerEl, state, cred);
 
     new Setting(containerEl)
       .addButton(button => button
         .setButtonText('Save')
         .setCta()
         .onClick(async () => {
-          if (!nameValue.trim()) {
-            new Notice('Auto Note Importer: Credential name cannot be empty.');
+          const result = renderer.build(nameValue, state, cred.id);
+          if (!result.ok) {
+            new Notice(`Auto Note Importer: ${result.error}`);
             return;
           }
-          cred.name = nameValue.trim();
-          cred.apiKey = keyValue;
+          // Replace the existing credential in-place
+          const idx = this.plugin.settings.credentials.findIndex(c => c.id === cred.id);
+          if (idx >= 0) {
+            this.plugin.settings.credentials[idx] = result.credential;
+          }
           await this.plugin.saveSettings();
           this.editingCredentialId = null;
           this.display();
         }))
+      .addButton(button => {
+        button
+          .setButtonText('Test')
+          .setDisabled(!renderer.testConnection)
+          .onClick(() => {
+            const result = renderer.build(nameValue, state, cred.id);
+            if (!result.ok) {
+              new Notice(`Auto Note Importer: ${result.error}`);
+              return;
+            }
+            this.runConnectionTest(renderer, result.credential);
+          });
+      })
       .addButton(button => button
         .setButtonText('Cancel')
         .onClick(() => {
@@ -312,15 +328,19 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private renderCredentialAddRow(containerEl: HTMLElement): void {
-    // Name + Type persist across detail re-renders; key is type-specific
-    // and held in the same closure so it survives dropdown switches.
-    const state = { name: '', key: '' };
+    // Name persists across detail re-renders. The provider-specific state
+    // bag survives dropdown switches within the same closure so a user who
+    // types a key, switches types, and switches back doesn't lose input.
+    const context = {
+      name: '',
+      state: {} as CredentialFormState,
+    };
 
     const nameSetting = new Setting(containerEl)
       .setName('Name')
       .addText(text => text
         .setPlaceholder('e.g. Personal Airtable')
-        .onChange(value => { state.name = value; }));
+        .onChange(value => { context.name = value; }));
     nameSetting.settingEl.addClass('ani-credential-edit');
 
     const typeSetting = new Setting(containerEl).setName('Type');
@@ -329,7 +349,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const detailEl = containerEl.createDiv({ cls: 'ani-credential-add-details' });
     const renderDetails = () => {
       detailEl.empty();
-      this.renderCredentialAddDetails(detailEl, state);
+      this.renderCredentialAddDetails(detailEl, context);
     };
 
     typeSetting.addDropdown(dropdown => {
@@ -348,55 +368,63 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
   private renderCredentialAddDetails(
     containerEl: HTMLElement,
-    state: { name: string; key: string },
+    context: { name: string; state: CredentialFormState },
   ): void {
     const type = this.addingCredentialType;
-    const isAirtable = type === 'airtable';
 
-    if (isAirtable) {
-      const keySetting = new Setting(containerEl)
-        .setName('API Key')
-        .addText(text => {
-          text
-            .setValue(state.key)
-            .setPlaceholder('pat-xxx...')
-            .onChange(value => { state.key = value; });
-          text.inputEl.type = 'password';
-        });
-      keySetting.settingEl.addClass('ani-credential-edit');
-    } else {
+    if (!hasCredentialFormRenderer(type)) {
       const noticeSetting = new Setting(containerEl)
         .setName('Not yet supported')
         .setDesc(`${CREDENTIAL_TYPE_LABELS[type]} provider will be available in a future release.`);
       noticeSetting.settingEl.addClass('ani-credential-edit');
+
+      new Setting(containerEl)
+        .addButton(button => button.setButtonText('Save').setCta().setDisabled(true))
+        .addButton(button => button
+          .setButtonText('Cancel')
+          .onClick(() => {
+            this.addingCredential = false;
+            this.addingCredentialType = 'airtable';
+            this.display();
+          }));
+      return;
     }
+
+    const renderer = getCredentialFormRenderer(type);
+    if (renderer.description) {
+      containerEl.createEl('p', { cls: 'ani-credential-desc', text: renderer.description });
+    }
+    renderer.renderFields(containerEl, context.state);
 
     new Setting(containerEl)
       .addButton(button => {
         button
           .setButtonText('Save')
           .setCta()
-          .setDisabled(!isAirtable)
           .onClick(async () => {
-            if (!isAirtable) return;
-            if (!state.name.trim()) {
-              new Notice('Auto Note Importer: Credential name cannot be empty.');
+            const result = renderer.build(context.name, context.state, generateId());
+            if (!result.ok) {
+              new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
-            if (!state.key.trim()) {
-              new Notice('Auto Note Importer: API key cannot be empty.');
-              return;
-            }
-            this.plugin.settings.credentials.push({
-              id: generateId(),
-              name: state.name.trim(),
-              type: 'airtable',
-              apiKey: state.key.trim(),
-            });
+            this.plugin.settings.credentials.push(result.credential);
             await this.plugin.saveSettings();
             this.addingCredential = false;
             this.addingCredentialType = 'airtable';
             this.display();
+          });
+      })
+      .addButton(button => {
+        button
+          .setButtonText('Test')
+          .setDisabled(!renderer.testConnection)
+          .onClick(() => {
+            const result = renderer.build(context.name, context.state, 'test-only');
+            if (!result.ok) {
+              new Notice(`Auto Note Importer: ${result.error}`);
+              return;
+            }
+            this.runConnectionTest(renderer, result.credential);
           });
       })
       .addButton(button => button
@@ -406,6 +434,26 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           this.addingCredentialType = 'airtable';
           this.display();
         }));
+  }
+
+  private async runConnectionTest(
+    renderer: import('../types').CredentialFormRenderer,
+    credential: Credential,
+  ): Promise<void> {
+    if (!renderer.testConnection) return;
+    new Notice('Auto Note Importer: Testing connection\u2026');
+    try {
+      const result = await renderer.testConnection(credential);
+      if (result.success) {
+        const detail = result.detail ? ` ${result.detail}` : '';
+        new Notice(`Auto Note Importer: Connection OK.${detail}`);
+      } else {
+        new Notice(`Auto Note Importer: Connection failed \u2014 ${result.error}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      new Notice(`Auto Note Importer: Connection test errored \u2014 ${message}`);
+    }
   }
 
   // ─── Tab Bar ───────────────────────────────────────────────────────

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -18,7 +18,7 @@ import {
   getCredentialFormRenderer,
   hasCredentialFormRenderer,
 } from '../services';
-import type { CredentialFormState } from '../types';
+import type { CredentialFormState, CredentialFormRenderer } from '../types';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, AirtableCredential, CredentialType, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { DEFAULT_CONFIG_ENTRY, CREDENTIAL_TYPES, CREDENTIAL_TYPE_LABELS } from '../types';
 import { FolderSuggest, FileSuggest } from './suggest';
@@ -316,7 +316,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
-            this.runConnectionTest(renderer, result.credential);
+            void this.runConnectionTest(renderer, result.credential);
           });
       })
       .addButton(button => button
@@ -424,7 +424,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
-            this.runConnectionTest(renderer, result.credential);
+            void this.runConnectionTest(renderer, result.credential);
           });
       })
       .addButton(button => button
@@ -437,7 +437,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   private async runConnectionTest(
-    renderer: import('../types').CredentialFormRenderer,
+    renderer: CredentialFormRenderer,
     credential: Credential,
   ): Promise<void> {
     if (!renderer.testConnection) return;

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -837,21 +837,20 @@ async function setConfigAndQuery(overrides) {
     await test('credential / edit form shows Test button for airtable', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
-        await openSettingsTab();
-        const c = getContainer();
         const p = getPlugin();
         const cred = p.settings.credentials[0];
         if (!cred) return JSON.stringify({ error: 'no credential' });
 
         const tab = getSettingsTab();
+        await openSettingsTab();
         tab.editingCredentialId = cred.id;
         tab.display();
         await new Promise(r => setTimeout(r, 300));
 
-        const c2 = getContainer();
-        const testBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Test');
-        const saveBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Save');
-        const cancelBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
+        const c = getContainer();
+        const testBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Test');
+        const saveBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Save');
+        const cancelBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
 
         // Cleanup
         tab.editingCredentialId = null;

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -778,6 +778,37 @@ async function setConfigAndQuery(overrides) {
       return { pass, detail: `dropdown=${r.hasDropdown} options=[${(r.options || []).join(',')}]` };
     });
 
+    await test('credential / airtable add form shows description and Test button', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const tab = getSettingsTab();
+        tab.addingCredential = false;
+        tab.addingCredentialType = 'airtable';
+        await openSettingsTab();
+
+        const c = getContainer();
+        const addBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent.includes('Add credential'));
+        addBtn?.click();
+        await new Promise(r => setTimeout(r, 300));
+
+        const descriptions = Array.from(c.querySelectorAll('.ani-credential-desc')).map(el => el.textContent);
+        const testBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Test');
+
+        const cancelBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
+        cancelBtn?.click();
+        await new Promise(r => setTimeout(r, 200));
+
+        return JSON.stringify({
+          hasDescription: descriptions.length > 0 && descriptions[0].includes('airtable.com'),
+          hasTestBtn: !!testBtn,
+          testBtnDisabled: !!testBtn?.disabled,
+        });
+      })()`, 10000);
+      const pass = r.hasDescription && r.hasTestBtn && !r.testBtnDisabled;
+      return { pass, detail: `description=${r.hasDescription} testBtn=${r.hasTestBtn} disabled=${r.testBtnDisabled}` };
+    });
+
     await test('credential / airtable type shows API Key field and enabled Save', async () => {
       const r = await run(`(async () => {
         ${HELPERS}

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -834,6 +834,41 @@ async function setConfigAndQuery(overrides) {
       return { pass, detail: `fields=[${r.fields.join(',')}] saveDisabled=${r.saveDisabled}` };
     });
 
+    await test('credential / edit form shows Test button for airtable', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        await openSettingsTab();
+        const c = getContainer();
+        const p = getPlugin();
+        const cred = p.settings.credentials[0];
+        if (!cred) return JSON.stringify({ error: 'no credential' });
+
+        const tab = getSettingsTab();
+        tab.editingCredentialId = cred.id;
+        tab.display();
+        await new Promise(r => setTimeout(r, 300));
+
+        const c2 = getContainer();
+        const testBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Test');
+        const saveBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Save');
+        const cancelBtn = Array.from(c2.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
+
+        // Cleanup
+        tab.editingCredentialId = null;
+        tab.display();
+        await new Promise(r => setTimeout(r, 200));
+
+        return JSON.stringify({
+          hasTestBtn: !!testBtn,
+          testBtnDisabled: !!testBtn?.disabled,
+          hasSaveBtn: !!saveBtn,
+          hasCancelBtn: !!cancelBtn,
+        });
+      })()`, 10000);
+      const pass = r.hasTestBtn && !r.testBtnDisabled && r.hasSaveBtn && r.hasCancelBtn;
+      return { pass, detail: `testBtn=${r.hasTestBtn} disabled=${r.testBtnDisabled} save=${r.hasSaveBtn} cancel=${r.hasCancelBtn}` };
+    });
+
     await test('credential / edit form rejects non-airtable credentials', async () => {
       const r = await run(`(async () => {
         ${HELPERS}

--- a/tests/services/airtable-credential-form.test.ts
+++ b/tests/services/airtable-credential-form.test.ts
@@ -124,7 +124,7 @@ describe('airtableCredentialFormRenderer', () => {
       expect(result.detail).toMatch(/3 base/);
     });
 
-    it('should include the bearer token in the Authorization header', async () => {
+    it('should include the bearer token and Accept header', async () => {
       mockRequestUrl.mockResolvedValueOnce({
         status: 200,
         json: { bases: [] },
@@ -137,7 +137,10 @@ describe('airtableCredentialFormRenderer', () => {
 
       const call = mockRequestUrl.mock.calls[0][0];
       expect(call.headers?.Authorization).toBe('Bearer pat-test-key');
+      expect(call.headers?.Accept).toBe('application/json');
+      expect(call.headers?.['Content-Type']).toBeUndefined();
       expect(call.url).toContain('/meta/bases');
+      expect(call.method).toBe('GET');
     });
 
     it('should report success with no-bases detail when auth is OK but empty', async () => {

--- a/tests/services/airtable-credential-form.test.ts
+++ b/tests/services/airtable-credential-form.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for AirtableCredentialFormRenderer.
+ *
+ * Focuses on `build()` validation + `testConnection()` API interaction.
+ * Field rendering is covered by settings E2E.
+ *
+ * @covers src/services/airtable-credential-form.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestUrl } from 'obsidian';
+import { airtableCredentialFormRenderer } from '../../src/services/airtable-credential-form';
+import type { Credential, CredentialFormState } from '../../src/types';
+
+const mockRequestUrl = vi.mocked(requestUrl);
+
+function createAirtableCredential(apiKey = 'pat-test'): Credential {
+  return { id: 'cred-1', name: 'Airtable', type: 'airtable', apiKey };
+}
+
+describe('airtableCredentialFormRenderer', () => {
+  describe('metadata', () => {
+    it('should identify as airtable type', () => {
+      expect(airtableCredentialFormRenderer.type).toBe('airtable');
+    });
+
+    it('should expose human-readable label', () => {
+      expect(airtableCredentialFormRenderer.label).toBe('Airtable');
+    });
+
+    it('should expose a description pointing users at the PAT creation URL', () => {
+      expect(airtableCredentialFormRenderer.description).toContain('airtable.com');
+    });
+
+    it('should provide testConnection', () => {
+      expect(airtableCredentialFormRenderer.testConnection).toBeDefined();
+    });
+  });
+
+  describe('build', () => {
+    it('should return a valid AirtableCredential when name and apiKey are present', () => {
+      const state: CredentialFormState = { apiKey: 'pat-valid' };
+      const result = airtableCredentialFormRenderer.build('My Airtable', state, 'cred-new');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.credential).toEqual({
+        id: 'cred-new',
+        name: 'My Airtable',
+        type: 'airtable',
+        apiKey: 'pat-valid',
+      });
+    });
+
+    it('should trim whitespace from name and apiKey', () => {
+      const state: CredentialFormState = { apiKey: '  pat-valid  ' };
+      const result = airtableCredentialFormRenderer.build('  Spaced  ', state, 'cred-new');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.credential.name).toBe('Spaced');
+      expect(result.credential.type === 'airtable' && result.credential.apiKey).toBe('pat-valid');
+    });
+
+    it('should reject empty name', () => {
+      const state: CredentialFormState = { apiKey: 'pat-valid' };
+      const result = airtableCredentialFormRenderer.build('', state, 'cred-new');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toMatch(/name cannot be empty/i);
+    });
+
+    it('should reject whitespace-only name', () => {
+      const state: CredentialFormState = { apiKey: 'pat-valid' };
+      const result = airtableCredentialFormRenderer.build('   ', state, 'cred-new');
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('should reject missing apiKey', () => {
+      const result = airtableCredentialFormRenderer.build('My Airtable', {}, 'cred-new');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toMatch(/api key cannot be empty/i);
+    });
+
+    it('should reject empty apiKey', () => {
+      const state: CredentialFormState = { apiKey: '' };
+      const result = airtableCredentialFormRenderer.build('My Airtable', state, 'cred-new');
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('should preserve the provided id (for edit mode)', () => {
+      const state: CredentialFormState = { apiKey: 'pat-valid' };
+      const result = airtableCredentialFormRenderer.build('Existing', state, 'cred-existing-42');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.credential.id).toBe('cred-existing-42');
+    });
+  });
+
+  describe('testConnection', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return success when the meta API responds with 200', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bases: [{ id: 'app1' }, { id: 'app2' }, { id: 'app3' }] },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const result = await airtableCredentialFormRenderer.testConnection!(createAirtableCredential());
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.detail).toMatch(/3 base/);
+    });
+
+    it('should include the bearer token in the Authorization header', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bases: [] },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      await airtableCredentialFormRenderer.testConnection!(createAirtableCredential('pat-test-key'));
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.headers?.Authorization).toBe('Bearer pat-test-key');
+      expect(call.url).toContain('/meta/bases');
+    });
+
+    it('should report success with no-bases detail when auth is OK but empty', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bases: [] },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const result = await airtableCredentialFormRenderer.testConnection!(createAirtableCredential());
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.detail).toMatch(/no bases/i);
+    });
+
+    it('should return failure on 401 unauthorized', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 401,
+        json: { error: { message: 'Invalid authentication token' } },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const result = await airtableCredentialFormRenderer.testConnection!(createAirtableCredential('pat-bad'));
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain('401');
+      expect(result.error).toContain('Invalid authentication token');
+    });
+
+    it('should return failure on network errors', async () => {
+      mockRequestUrl.mockRejectedValueOnce(new Error('Network unreachable'));
+
+      const result = await airtableCredentialFormRenderer.testConnection!(createAirtableCredential());
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toBe('Network unreachable');
+    });
+
+    it('should reject non-airtable credentials at the type boundary', async () => {
+      const seatableCred: Credential = {
+        id: 'cred-2',
+        name: 'SeaTable',
+        type: 'seatable',
+        apiToken: 'st-token',
+        serverUrl: 'https://cloud.seatable.io',
+      };
+
+      const result = await airtableCredentialFormRenderer.testConnection!(seatableCred);
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain('seatable');
+    });
+
+    it('should handle error response with string error field', async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 500,
+        json: { error: 'Internal server error' },
+        headers: {},
+        text: '',
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const result = await airtableCredentialFormRenderer.testConnection!(createAirtableCredential());
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain('Internal server error');
+    });
+  });
+});

--- a/tests/services/provider-registry.test.ts
+++ b/tests/services/provider-registry.test.ts
@@ -43,9 +43,13 @@ describe('provider-registry', () => {
   let registerFieldTypeMapper: typeof import('../../src/services/provider-registry').registerFieldTypeMapper;
   let getFieldTypeMapper: typeof import('../../src/services/provider-registry').getFieldTypeMapper;
   let hasFieldTypeMapper: typeof import('../../src/services/provider-registry').hasFieldTypeMapper;
+  let registerCredentialFormRenderer: typeof import('../../src/services/provider-registry').registerCredentialFormRenderer;
+  let getCredentialFormRenderer: typeof import('../../src/services/provider-registry').getCredentialFormRenderer;
+  let hasCredentialFormRenderer: typeof import('../../src/services/provider-registry').hasCredentialFormRenderer;
   let RateLimiter: typeof import('../../src/services/rate-limiter').RateLimiter;
   let AirtableClient: typeof import('../../src/services/airtable-client').AirtableClient;
   let airtableFieldMapper: typeof import('../../src/services/airtable-field-mapper').airtableFieldMapper;
+  let airtableCredentialFormRenderer: typeof import('../../src/services/airtable-credential-form').airtableCredentialFormRenderer;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -53,15 +57,20 @@ describe('provider-registry', () => {
     const rl = await import('../../src/services/rate-limiter');
     const ac = await import('../../src/services/airtable-client');
     const afm = await import('../../src/services/airtable-field-mapper');
+    const acf = await import('../../src/services/airtable-credential-form');
     registerProvider = registry.registerProvider;
     createProvider = registry.createProvider;
     hasProvider = registry.hasProvider;
     registerFieldTypeMapper = registry.registerFieldTypeMapper;
     getFieldTypeMapper = registry.getFieldTypeMapper;
     hasFieldTypeMapper = registry.hasFieldTypeMapper;
+    registerCredentialFormRenderer = registry.registerCredentialFormRenderer;
+    getCredentialFormRenderer = registry.getCredentialFormRenderer;
+    hasCredentialFormRenderer = registry.hasCredentialFormRenderer;
     RateLimiter = rl.RateLimiter;
     AirtableClient = ac.AirtableClient;
     airtableFieldMapper = afm.airtableFieldMapper;
+    airtableCredentialFormRenderer = acf.airtableCredentialFormRenderer;
   });
 
   describe('built-in registrations', () => {
@@ -85,6 +94,16 @@ describe('provider-registry', () => {
       expect(hasFieldTypeMapper('seatable')).toBe(false);
       expect(hasFieldTypeMapper('supabase')).toBe(false);
     });
+
+    it('should register airtable credential form renderer on module load', () => {
+      expect(hasCredentialFormRenderer('airtable')).toBe(true);
+      expect(getCredentialFormRenderer('airtable')).toBe(airtableCredentialFormRenderer);
+    });
+
+    it('should not register non-airtable credential form renderers by default', () => {
+      expect(hasCredentialFormRenderer('seatable')).toBe(false);
+      expect(hasCredentialFormRenderer('notion')).toBe(false);
+    });
   });
 
   describe('getFieldTypeMapper', () => {
@@ -104,6 +123,25 @@ describe('provider-registry', () => {
       };
       registerFieldTypeMapper('seatable', fake);
       expect(getFieldTypeMapper('seatable')).toBe(fake);
+    });
+  });
+
+  describe('getCredentialFormRenderer', () => {
+    it('should throw when no renderer is registered for credential type', () => {
+      expect(() => getCredentialFormRenderer('notion')).toThrow(
+        /No credential form renderer registered for credential type: notion/,
+      );
+    });
+
+    it('should return the renderer registered via registerCredentialFormRenderer', () => {
+      const fake = {
+        type: 'seatable' as const,
+        label: 'SeaTable',
+        renderFields: vi.fn(),
+        build: vi.fn(),
+      };
+      registerCredentialFormRenderer('seatable', fake);
+      expect(getCredentialFormRenderer('seatable')).toBe(fake);
     });
   });
 


### PR DESCRIPTION
## Summary

Multi-database 지원(#11)의 **Phase 1 세 번째 단계**. Settings UI의 credential auth form을 provider-agnostic renderer 패턴으로 추상화하고, **연결 테스트 버튼**을 추가. 기존 Airtable 동작은 그대로 유지.

Closes #51

## Scope Decision

"Provider-aware settings UI"는 두 부분으로 나뉩니다:
1. **Credential auth form** — API key / token 등 provider별 인증 필드 ← **이 PR이 추상화**
2. **Base/table picker** — provider별 데이터 모델 (base/table/view vs schema/table vs workspace/database) ← **각 provider PR(#52-#55)에서 자연스럽게 리팩토링**

(2)를 실제 non-Airtable provider 없이 추상화하면 over-engineering 위험이 커서, (1)에만 집중했습니다.

## Changes

### 🏷️ `CredentialFormRenderer` 인터페이스 신규
`src/types/provider-settings.types.ts`:
- **`CredentialFormRenderer`** — `type`/`label`/`description`, `renderFields(container, state, initial?)`, `build(name, state, id)`, optional `testConnection(credential)`
- **`CredentialFormState`** — 렌더러와 settings-tab이 공유하는 mutable `Record<string, string>`
- **`CredentialBuildResult`** — `{ok, credential} | {ok: false, error}` discriminated union
- **`ConnectionTestResult`** — `{success, detail?} | {success: false, error}` union

### 🔧 `AirtableCredentialFormRenderer` 구현
`src/services/airtable-credential-form.ts`:
- **`renderFields`**: API Key password input (Setting API, pat-xxx... placeholder). `initial` credential이 주어지면 state를 pre-populate (edit mode)
- **`build`**: name/apiKey trim + validation → `AirtableCredential`. Empty name / empty key 각각 에러 메시지
- **`testConnection`**: Meta API `/v0/meta/bases`에 Bearer 인증 호출. 200 → success (base 개수 detail), 401/기타 → 에러 메시지 추출. Airtable의 두 가지 에러 형태(`{error: string}` / `{error: {message}}`) 모두 처리

### 🏭 Provider registry 확장
`registerCredentialFormRenderer` / `getCredentialFormRenderer` / `hasCredentialFormRenderer` 추가. `registerFieldTypeMapper`와 동일한 패턴. 모듈 side-effect로 Airtable renderer 등록.

### 🎨 Settings UI 리팩토링
- **`renderCredentialAddDetails`**: `hasCredentialFormRenderer` guard → renderer 위임. "Not yet supported" fallback은 유지 (아직 구현 안 된 4개 provider 타입용)
- **`renderCredentialEditRow`**: 기존 Airtable 전용 코드 전부 제거, renderer 패턴으로 통일. Save는 `renderer.build` 결과로 credential 구성, 기존 credential을 인덱스로 찾아 in-place 갱신
- **🆕 Test 버튼**: `renderer.build`로 임시 credential 구성 → `testConnection` 호출 → Notice로 결과 피드백. `renderer.testConnection`이 없으면 버튼 disabled
- **`runConnectionTest` 헬퍼**: "Testing connection..." 진행 Notice + success/failure/exception 세 경로 모두 사용자 친화적 메시지

## Testing

- [x] **Unit tests**: 381 → **403** passed (+22)
  - `tests/services/airtable-credential-form.test.ts` 신규 (18 tests)
    - Metadata (4): type/label/description/testConnection 존재
    - Build validation (7): 정상 / trim / empty name / whitespace name / missing apiKey / empty apiKey / edit mode id 보존
    - TestConnection (7): 200 + 다수 base / 0 base / 401 (object error) / 500 (string error) / 네트워크 에러 / 비-airtable credential 거부 / Bearer 헤더 검증
  - `tests/services/provider-registry.test.ts` +4 tests: credential form renderer registry API
- [x] **Settings UI E2E**: 42 → **43** passed (+1)
  - "airtable add form shows description and Test button" — `.ani-credential-desc` 렌더 + Test 버튼 존재 및 활성화 검증
- [x] **Build**: `npm run build` ✓
- [x] **Lint**: `npm run lint` — 0 errors

## Backward Compatibility

- 기존 Airtable credential 동작 변경 없음 — 모든 기존 데이터 그대로 호환
- 기존 Save/Cancel 버튼 UX 유지, Test 버튼만 추가됨
- Edit mode도 동일하게 renderer 패턴으로 전환하면서 in-place 갱신 로직 유지

## Out of Scope

- **Base/table/view picker 추상화**: 각 provider가 구현될 때 자연스럽게 리팩토링 (#52-#55)
- **Field type system**: 이미 #50에서 완료 — settings UI는 `getFieldTypeMapper(credential.type).isFilenameSafe()`로 provider-agnostic하게 동작 중