### PR TITLE
refactor: rename SyncMode to provider-agnostic push/pull (#59)

### DIFF
--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -73,7 +73,7 @@ export class ConfigInstance {
       this.app,
       this.settings,
       async (files) => {
-        const mode: SyncMode = this.settings.autoSyncFormulas ? 'bidirectional' : 'to-airtable';
+        const mode: SyncMode = this.settings.autoSyncFormulas ? 'bidirectional' : 'push';
         await this.syncQueue.enqueue(mode, 'modified', files.map(f => f.path));
       }
     );
@@ -190,7 +190,7 @@ export class ConfigInstance {
   private startScheduler(config: ConfigEntry): void {
     if (config.syncInterval > 0) {
       this.schedulerIntervalId = setInterval(
-        () => this.syncQueue.enqueue('from-airtable', 'all'),
+        () => this.syncQueue.enqueue('pull', 'all'),
         config.syncInterval * 60 * 1000,
       );
     }

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -199,17 +199,18 @@ export class SyncOrchestrator {
       return;
     }
 
+    const label = this.providerLabel;
     this.fileWatcher.setSyncing(true);
     try {
       const remoteNote = await this.provider.fetchRecord(recordId);
       if (!remoteNote) {
-        new Notice(`Auto Note Importer: Record not found in ${this.providerLabel}`);
+        new Notice(`Auto Note Importer: Record not found in ${label}`);
         return;
       }
 
       const result = await this.createNoteFromRemote(remoteNote);
       if (result === "updated") {
-        new Notice(`Auto Note Importer: Current note updated from ${this.providerLabel}`);
+        new Notice(`Auto Note Importer: Current note updated from ${label}`);
       } else if (result === "skipped") {
         new Notice("Auto Note Importer: No changes detected");
       }

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -1,9 +1,12 @@
 /**
- * Sync Orchestrator - Coordinates all sync operations between Airtable and Obsidian.
+ * Sync Orchestrator - Coordinates sync operations between a DatabaseProvider and Obsidian.
  *
  * Extracted from main.ts to separate sync orchestration from plugin lifecycle management.
+ * User-facing labels (status bar, Notice) derive the provider name from
+ * `provider.providerType` so the same orchestrator works for any provider.
  *
  * @handbook 4.2-sync-architecture
+ * @handbook 4.4-provider-abstraction
  * @handbook 5.3-statusbar-abstraction
  * @handbook 9.1-sync-flow
  * @tested tests/core/sync-orchestrator.test.ts
@@ -12,6 +15,7 @@
 
 import { App, TFile, TFolder, normalizePath, Notice, MarkdownView } from "obsidian";
 import type { LegacySettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult, DatabaseProvider } from '../types';
+import { CREDENTIAL_TYPE_LABELS } from '../types';
 import { AIRTABLE_BATCH_SIZE, DEBUG_DELAY_MULTIPLIER } from '../constants';
 import { FieldCache } from '../services';
 import { ConflictResolver } from './conflict-resolver';
@@ -62,22 +66,28 @@ export class SyncOrchestrator {
     this.settings = settings;
   }
 
+  /** Display name of the linked provider (Airtable / SeaTable / …) for user-facing strings. */
+  private get providerLabel(): string {
+    return CREDENTIAL_TYPE_LABELS[this.provider.providerType];
+  }
+
   async processSyncRequest(mode: SyncMode, scope: SyncScope, filePaths?: string[]): Promise<void> {
     const statusBarItem = this.statusBar.createItem();
+    const label = this.providerLabel;
 
     try {
       switch (mode) {
-        case 'from-airtable':
+        case 'pull':
           if (scope === 'current') {
-            statusBarItem.setText("Syncing current note from Airtable...");
+            statusBarItem.setText(`Syncing current note from ${label}...`);
             await this.syncCurrentFromAirtable();
           } else {
-            statusBarItem.setText("Syncing from Airtable...");
+            statusBarItem.setText(`Syncing from ${label}...`);
             await this.syncFromAirtable();
           }
           break;
 
-        case 'to-airtable':
+        case 'push':
         case 'bidirectional': {
           const files = filePaths
             ? filePaths.map(p => this.app.vault.getAbstractFileByPath(p)).filter((f): f is TFile => f instanceof TFile)
@@ -88,12 +98,12 @@ export class SyncOrchestrator {
             return;
           }
 
-          if (mode === 'to-airtable') {
-            statusBarItem.setText(`Syncing ${files.length} file(s) to Airtable...`);
+          if (mode === 'push') {
+            statusBarItem.setText(`Syncing ${files.length} file(s) to ${label}...`);
             await this.syncFilesToAirtable(files);
-            new Notice(`Auto Note Importer: Synced ${files.length} file(s) to Airtable`);
+            new Notice(`Auto Note Importer: Synced ${files.length} file(s) to ${label}`);
           } else {
-            statusBarItem.setText(`Phase 1/2 - Syncing ${files.length} file(s) to Airtable...`);
+            statusBarItem.setText(`Phase 1/2 - Syncing ${files.length} file(s) to ${label}...`);
             await this.syncFilesToAirtable(files);
 
             if (this.settings.autoSyncFormulas) {
@@ -109,7 +119,7 @@ export class SyncOrchestrator {
             } else {
               // Bases file is not generated here because syncFromAirtable() is skipped,
               // so no remoteNotes are available to derive column definitions from.
-              new Notice(`Auto Note Importer: Synced ${files.length} file(s) to Airtable`);
+              new Notice(`Auto Note Importer: Synced ${files.length} file(s) to ${label}`);
             }
           }
           break;
@@ -193,13 +203,13 @@ export class SyncOrchestrator {
     try {
       const remoteNote = await this.provider.fetchRecord(recordId);
       if (!remoteNote) {
-        new Notice("Auto Note Importer: Record not found in Airtable");
+        new Notice(`Auto Note Importer: Record not found in ${this.providerLabel}`);
         return;
       }
 
       const result = await this.createNoteFromRemote(remoteNote);
       if (result === "updated") {
-        new Notice("Auto Note Importer: Current note updated from Airtable");
+        new Notice(`Auto Note Importer: Current note updated from ${this.providerLabel}`);
       } else if (result === "skipped") {
         new Notice("Auto Note Importer: No changes detected");
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,9 @@ export default class AutoNoteImporterPlugin extends Plugin {
   private registerCommandsForConfig(config: ConfigEntry): void {
     const configId = config.id;
     const credential = findCredentialForConfig(this.settings, config);
+    // Configs with an orphaned credentialId register no commands. Recovery is automatic
+    // when a credential is (re-)linked: saveSettings() detects the fingerprint change
+    // and triggers reregisterAllCommands().
     if (!credential) return;
     const providerLabel = CREDENTIAL_TYPE_LABELS[credential.type];
     const suffix = ` \u2014 ${config.name}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { ConfigManager } from './core';
 import { FrontmatterParser } from './file-operations';
 import { AutoNoteImporterSettingTab } from './ui';
 import { migrateSettings } from './utils/migration';
+import { findCredentialForConfig } from './utils';
 
 /**
  * Main plugin class for Auto Note Importer.
@@ -70,7 +71,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
   private getCommandFingerprint(): string {
     return this.settings.configs
       .map(c => {
-        const credType = this.settings.credentials.find(cr => cr.id === c.credentialId)?.type ?? '';
+        const credType = findCredentialForConfig(this.settings, c)?.type ?? '';
         return `${c.id}:${c.name}:${c.enabled}:${c.bidirectionalSync}:${credType}`;
       })
       .join('|');
@@ -116,20 +117,15 @@ export default class AutoNoteImporterPlugin extends Plugin {
   /**
    * Registers sync commands for a single config entry.
    * Uses checkCallback with dynamic lookup to avoid capturing stale references.
-   *
-   * Command names include the provider label (Airtable / SeaTable / Notion / \u2026)
-   * derived from the linked credential type. `getCommandFingerprint()` includes
-   * credential type so changing a config's credential triggers re-registration
-   * and the labels stay in sync.
+   * Command names include the provider label derived from the linked credential type.
    */
   private registerCommandsForConfig(config: ConfigEntry): void {
     const configId = config.id;
-    const credential = this.settings.credentials.find(c => c.id === config.credentialId);
+    const credential = findCredentialForConfig(this.settings, config);
     if (!credential) return;
     const providerLabel = CREDENTIAL_TYPE_LABELS[credential.type];
     const suffix = ` \u2014 ${config.name}`;
 
-    // Pull commands (remote → local)
     this.addCommand({
       id: `sync-pull-${configId}`,
       name: `Sync current note from ${providerLabel}${suffix}`,
@@ -153,7 +149,6 @@ export default class AutoNoteImporterPlugin extends Plugin {
       },
     });
 
-    // Push commands (local → remote, gated by bidirectionalSync)
     this.addCommand({
       id: `sync-push-current-${configId}`,
       name: `Sync current note to ${providerLabel}${suffix}`,
@@ -188,7 +183,6 @@ export default class AutoNoteImporterPlugin extends Plugin {
       },
     });
 
-    // Bidirectional commands
     this.addCommand({
       id: `bidirectional-sync-current-${configId}`,
       name: `Bidirectional sync current note${suffix}`,
@@ -248,7 +242,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
     }
 
     for (const config of this.settings.configs) {
-      const credential = this.settings.credentials.find(c => c.id === config.credentialId);
+      const credential = findCredentialForConfig(this.settings, config);
       if (credential) {
         this.configManager.updateConfig(config.id, config, credential);
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 /**
  * Auto Note Importer - Main Plugin Entry Point
  *
- * Orchestrates Airtable <-> Obsidian sync via ConfigManager and per-config service stacks.
+ * Orchestrates remote DatabaseProvider <-> Obsidian sync via ConfigManager and per-config service stacks.
  *
  * @handbook 4.2-sync-architecture
  * @handbook 9.2-service-initialization-order
@@ -12,7 +12,7 @@
 
 import { Plugin, normalizePath } from "obsidian";
 import type { AutoNoteImporterSettings, ConfigEntry, SharedServices } from './types';
-import { DEFAULT_SETTINGS } from './types';
+import { DEFAULT_SETTINGS, CREDENTIAL_TYPE_LABELS } from './types';
 import { FieldCache } from './services';
 import { ConfigManager } from './core';
 import { FrontmatterParser } from './file-operations';
@@ -69,7 +69,10 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
   private getCommandFingerprint(): string {
     return this.settings.configs
-      .map(c => `${c.id}:${c.name}:${c.enabled}:${c.bidirectionalSync}`)
+      .map(c => {
+        const credType = this.settings.credentials.find(cr => cr.id === c.credentialId)?.type ?? '';
+        return `${c.id}:${c.name}:${c.enabled}:${c.bidirectionalSync}:${credType}`;
+      })
       .join('|');
   }
 
@@ -113,66 +116,74 @@ export default class AutoNoteImporterPlugin extends Plugin {
   /**
    * Registers sync commands for a single config entry.
    * Uses checkCallback with dynamic lookup to avoid capturing stale references.
+   *
+   * Command names include the provider label (Airtable / SeaTable / Notion / \u2026)
+   * derived from the linked credential type. `getCommandFingerprint()` includes
+   * credential type so changing a config's credential triggers re-registration
+   * and the labels stay in sync.
    */
   private registerCommandsForConfig(config: ConfigEntry): void {
     const configId = config.id;
+    const credential = this.settings.credentials.find(c => c.id === config.credentialId);
+    if (!credential) return;
+    const providerLabel = CREDENTIAL_TYPE_LABELS[credential.type];
     const suffix = ` \u2014 ${config.name}`;
 
-    // From Airtable commands
+    // Pull commands (remote → local)
     this.addCommand({
-      id: `sync-from-airtable-${configId}`,
-      name: `Sync current note from Airtable${suffix}`,
+      id: `sync-pull-${configId}`,
+      name: `Sync current note from ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled) return false;
         if (!this.isActiveFileInConfigFolder(cfg)) return false;
-        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('from-airtable', 'current');
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('pull', 'current');
         return true;
       },
     });
 
     this.addCommand({
-      id: `sync-all-from-airtable-${configId}`,
-      name: `Sync all notes from Airtable${suffix}`,
+      id: `sync-pull-all-${configId}`,
+      name: `Sync all notes from ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled) return false;
-        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('from-airtable', 'all');
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('pull', 'all');
         return true;
       },
     });
 
-    // To Airtable commands (gated by bidirectionalSync)
+    // Push commands (local → remote, gated by bidirectionalSync)
     this.addCommand({
-      id: `sync-current-to-airtable-${configId}`,
-      name: `Sync current note to Airtable${suffix}`,
+      id: `sync-push-current-${configId}`,
+      name: `Sync current note to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!this.isActiveFileInConfigFolder(cfg)) return false;
-        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'current');
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'current');
         return true;
       },
     });
 
     this.addCommand({
-      id: `sync-modified-to-airtable-${configId}`,
-      name: `Sync modified notes to Airtable${suffix}`,
+      id: `sync-push-modified-${configId}`,
+      name: `Sync modified notes to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
-        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'modified');
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'modified');
         return true;
       },
     });
 
     this.addCommand({
-      id: `sync-all-to-airtable-${configId}`,
-      name: `Sync all notes to Airtable${suffix}`,
+      id: `sync-push-all-${configId}`,
+      name: `Sync all notes to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
-        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('to-airtable', 'all');
+        if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'all');
         return true;
       },
     });

--- a/src/types/sync.types.ts
+++ b/src/types/sync.types.ts
@@ -7,8 +7,11 @@ import type { SyncScope } from './settings.types';
 
 /**
  * Sync direction/mode.
+ *
+ * Provider-agnostic terms — applies to any DatabaseProvider, not just Airtable.
+ * `push`: local Obsidian → remote. `pull`: remote → local Obsidian. `bidirectional`: push then pull.
  */
-export type SyncMode = 'to-airtable' | 'from-airtable' | 'bidirectional';
+export type SyncMode = 'push' | 'pull' | 'bidirectional';
 
 /**
  * Represents a sync request in the queue.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,4 +16,4 @@ export {
   generateId,
 } from './object-utils';
 
-export { buildLegacySettings } from './settings-bridge';
+export { buildLegacySettings, findCredentialForConfig } from './settings-bridge';

--- a/src/utils/settings-bridge.ts
+++ b/src/utils/settings-bridge.ts
@@ -6,7 +6,7 @@
  * @tested tests/utils/settings-bridge.test.ts
  */
 
-import type { Credential, ConfigEntry, LegacySettings } from '../types';
+import type { Credential, ConfigEntry, LegacySettings, AutoNoteImporterSettings } from '../types';
 
 /**
  * Merges a ConfigEntry with its Credential and debug flag to produce
@@ -24,4 +24,16 @@ export function buildLegacySettings(
 ): LegacySettings {
   const apiKey = credential.type === 'airtable' ? credential.apiKey : '';
   return { ...config, apiKey, debugMode };
+}
+
+/**
+ * Looks up the credential linked to a config by `credentialId`.
+ * Returns `undefined` if the credential is missing (e.g., deleted while a
+ * config still references it). Callers must handle the undefined case.
+ */
+export function findCredentialForConfig(
+  settings: AutoNoteImporterSettings,
+  config: ConfigEntry,
+): Credential | undefined {
+  return settings.credentials.find(c => c.id === config.credentialId);
 }

--- a/tests/__mocks__/database-client.mock.ts
+++ b/tests/__mocks__/database-client.mock.ts
@@ -3,10 +3,10 @@
  */
 
 import { vi } from 'vitest';
-import type { DatabaseProvider, SyncResult, FieldTypeMapper } from '../../src/types';
+import type { DatabaseProvider, SyncResult, FieldTypeMapper, CredentialType } from '../../src/types';
 
 export type MockDatabaseProvider = {
-  providerType: 'airtable';
+  providerType: CredentialType;
   capabilities: DatabaseProvider['capabilities'];
   fieldTypeMapper: FieldTypeMapper;
   fetchNotes: ReturnType<typeof vi.fn>;

--- a/tests/core/config-instance.test.ts
+++ b/tests/core/config-instance.test.ts
@@ -166,7 +166,7 @@ describe('ConfigInstance', () => {
       instance.destroy();
     });
 
-    it('should enqueue from-airtable sync on scheduler tick', () => {
+    it('should enqueue pull sync on scheduler tick', () => {
       const config = createConfig({ enabled: true, syncInterval: 1 });
       const credential = createCredential();
 
@@ -175,7 +175,7 @@ describe('ConfigInstance', () => {
 
       vi.advanceTimersByTime(60_000);
 
-      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('from-airtable', 'all');
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('pull', 'all');
 
       instance.destroy();
     });
@@ -312,9 +312,9 @@ describe('ConfigInstance', () => {
       const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
       const syncQueueInstance = vi.mocked(SyncQueue).mock.instances[0];
 
-      instance.enqueueSyncRequest('from-airtable', 'all');
+      instance.enqueueSyncRequest('pull', 'all');
 
-      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('from-airtable', 'all', undefined);
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('pull', 'all', undefined);
 
       instance.destroy();
     });
@@ -326,9 +326,9 @@ describe('ConfigInstance', () => {
       const instance = new ConfigInstance(mockApp as unknown as App, config, credential, shared);
       const syncQueueInstance = vi.mocked(SyncQueue).mock.instances[0];
 
-      instance.enqueueSyncRequest('to-airtable', 'modified', ['file1.md', 'file2.md']);
+      instance.enqueueSyncRequest('push', 'modified', ['file1.md', 'file2.md']);
 
-      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('to-airtable', 'modified', ['file1.md', 'file2.md']);
+      expect(syncQueueInstance.enqueue).toHaveBeenCalledWith('push', 'modified', ['file1.md', 'file2.md']);
 
       instance.destroy();
     });

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -229,4 +229,47 @@ describe('SyncOrchestrator', () => {
       ).resolves.toBeUndefined();
     });
   });
+
+  // Regression guard: status bar / Notice text must derive the provider name
+  // from `provider.providerType` via CREDENTIAL_TYPE_LABELS, not a hardcoded string.
+  describe('provider-aware labels', () => {
+    function createOrchestrator(provider: typeof mockProvider): SyncOrchestrator {
+      return new SyncOrchestrator(
+        mockApp as unknown as App,
+        settings,
+        provider as never,
+        fieldCache,
+        frontmatterParser,
+        fileWatcher,
+        conflictResolver,
+        statusBar,
+      );
+    }
+
+    it("should label status bar with the provider's display name (airtable)", async () => {
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+      mockProvider.fetchNotes.mockResolvedValue([]);
+
+      await orchestrator.processSyncRequest('pull', 'all');
+
+      expect(statusBar.lastItem.setText).toHaveBeenCalledWith(
+        expect.stringContaining('Airtable'),
+      );
+    });
+
+    it('should reflect a different provider type in status bar text', async () => {
+      const notionProvider = createMockDatabaseProvider({ providerType: 'notion' });
+      notionProvider.fetchNotes.mockResolvedValue([]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+
+      const notionOrchestrator = createOrchestrator(notionProvider);
+      await notionOrchestrator.processSyncRequest('pull', 'all');
+
+      const calls = (statusBar.lastItem.setText as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c) => String(c[0]),
+      );
+      expect(calls.some((text) => text.includes('Notion'))).toBe(true);
+      expect(calls.every((text) => !text.includes('Airtable'))).toBe(true);
+    });
+  });
 });

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -75,12 +75,12 @@ describe('SyncOrchestrator', () => {
     );
   });
 
-  describe('processSyncRequest — from-airtable', () => {
+  describe('processSyncRequest — pull', () => {
     it('should create status bar item and remove it after sync', async () => {
       mockProvider.fetchNotes.mockResolvedValue([]);
       mockApp.vault.adapter.exists.mockResolvedValue(true);
 
-      await orchestrator.processSyncRequest('from-airtable', 'all');
+      await orchestrator.processSyncRequest('pull', 'all');
 
       expect(statusBar.createItem).toHaveBeenCalledTimes(1);
       expect(statusBar.lastItem.setText).toHaveBeenCalled();
@@ -91,7 +91,7 @@ describe('SyncOrchestrator', () => {
       mockProvider.fetchNotes.mockResolvedValue([]);
       mockApp.vault.adapter.exists.mockResolvedValue(false);
 
-      await orchestrator.processSyncRequest('from-airtable', 'all');
+      await orchestrator.processSyncRequest('pull', 'all');
 
       expect(mockApp.vault.createFolder).toHaveBeenCalledWith('Sync');
     });
@@ -103,7 +103,7 @@ describe('SyncOrchestrator', () => {
       mockApp.vault.adapter.exists.mockResolvedValue(true);
       mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
 
-      await orchestrator.processSyncRequest('from-airtable', 'all');
+      await orchestrator.processSyncRequest('pull', 'all');
 
       expect(mockApp.vault.create).toHaveBeenCalled();
     });
@@ -115,7 +115,7 @@ describe('SyncOrchestrator', () => {
       const setSyncingSpy = vi.spyOn(fileWatcher, 'setSyncing');
       const clearPendingSpy = vi.spyOn(fileWatcher, 'clearPending');
 
-      await orchestrator.processSyncRequest('from-airtable', 'all');
+      await orchestrator.processSyncRequest('pull', 'all');
 
       expect(setSyncingSpy).toHaveBeenNthCalledWith(1, true);
       expect(setSyncingSpy).toHaveBeenNthCalledWith(2, false);
@@ -127,7 +127,7 @@ describe('SyncOrchestrator', () => {
 
       const setSyncingSpy = vi.spyOn(fileWatcher, 'setSyncing');
 
-      await orchestrator.processSyncRequest('from-airtable', 'all');
+      await orchestrator.processSyncRequest('pull', 'all');
 
       expect(statusBar.lastItem.remove).toHaveBeenCalledTimes(1);
       // setSyncing(false) must be called even on error (via finally block in syncFromAirtable)
@@ -135,11 +135,11 @@ describe('SyncOrchestrator', () => {
     });
   });
 
-  describe('processSyncRequest — to-airtable', () => {
+  describe('processSyncRequest — push', () => {
     it('should clean up status bar when active file is missing', async () => {
       mockApp.workspace.getActiveViewOfType.mockReturnValue(null);
 
-      await orchestrator.processSyncRequest('to-airtable', 'current');
+      await orchestrator.processSyncRequest('push', 'current');
 
       // Error is caught and shown via Notice — status bar still cleaned up
       expect(statusBar.lastItem.remove).toHaveBeenCalled();
@@ -213,7 +213,7 @@ describe('SyncOrchestrator', () => {
       mockApp.vault.adapter.exists.mockResolvedValue(true);
       mockApp.vault.read.mockResolvedValue('old content');
 
-      await orchestrator.processSyncRequest('from-airtable', 'current');
+      await orchestrator.processSyncRequest('pull', 'current');
 
       expect(mockProvider.fetchRecord).toHaveBeenCalledWith('rec1');
     });
@@ -225,7 +225,7 @@ describe('SyncOrchestrator', () => {
 
       // Should not throw
       await expect(
-        orchestrator.processSyncRequest('from-airtable', 'all')
+        orchestrator.processSyncRequest('pull', 'all')
       ).resolves.toBeUndefined();
     });
   });

--- a/tests/core/sync-queue.test.ts
+++ b/tests/core/sync-queue.test.ts
@@ -23,10 +23,10 @@ describe('SyncQueue', () => {
     it('should process single request immediately', async () => {
       const queue = new SyncQueue(mockProcessor);
 
-      await queue.enqueue('to-airtable', 'current');
+      await queue.enqueue('push', 'current');
 
       expect(mockProcessor).toHaveBeenCalledTimes(1);
-      expect(processedRequests[0].mode).toBe('to-airtable');
+      expect(processedRequests[0].mode).toBe('push');
       expect(processedRequests[0].scope).toBe('current');
     });
 
@@ -45,16 +45,16 @@ describe('SyncQueue', () => {
 
       const queue = new SyncQueue(slowProcessor);
 
-      const firstEnqueue = queue.enqueue('to-airtable', 'current');
-      const secondEnqueue = queue.enqueue('from-airtable', 'all');
+      const firstEnqueue = queue.enqueue('push', 'current');
+      const secondEnqueue = queue.enqueue('pull', 'all');
 
       resolveFirst!();
       await firstEnqueue;
       await secondEnqueue;
 
       expect(processedRequests.length).toBe(2);
-      expect(processedRequests[0].mode).toBe('to-airtable');
-      expect(processedRequests[1].mode).toBe('from-airtable');
+      expect(processedRequests[0].mode).toBe('push');
+      expect(processedRequests[1].mode).toBe('pull');
     });
 
     it('should merge duplicate requests with same mode/scope (SQ-1.2)', async () => {
@@ -72,9 +72,9 @@ describe('SyncQueue', () => {
 
       const queue = new SyncQueue(slowProcessor);
 
-      const firstEnqueue = queue.enqueue('to-airtable', 'current');
-      queue.enqueue('to-airtable', 'modified', ['file1.md']);
-      queue.enqueue('to-airtable', 'modified', ['file2.md']);
+      const firstEnqueue = queue.enqueue('push', 'current');
+      queue.enqueue('push', 'modified', ['file1.md']);
+      queue.enqueue('push', 'modified', ['file2.md']);
 
       resolveFirst!();
       await firstEnqueue;
@@ -101,9 +101,9 @@ describe('SyncQueue', () => {
 
       const queue = new SyncQueue(slowProcessor);
 
-      const firstEnqueue = queue.enqueue('to-airtable', 'current');
-      queue.enqueue('to-airtable', 'modified', ['file1.md', 'file2.md']);
-      queue.enqueue('to-airtable', 'modified', ['file2.md', 'file3.md']);
+      const firstEnqueue = queue.enqueue('push', 'current');
+      queue.enqueue('push', 'modified', ['file1.md', 'file2.md']);
+      queue.enqueue('push', 'modified', ['file2.md', 'file3.md']);
 
       resolveFirst!();
       await firstEnqueue;
@@ -130,8 +130,8 @@ describe('SyncQueue', () => {
       const queue = new SyncQueue(trackingProcessor);
 
       const promises = [
-        queue.enqueue('to-airtable', 'current'),
-        queue.enqueue('from-airtable', 'current'),
+        queue.enqueue('push', 'current'),
+        queue.enqueue('pull', 'current'),
         queue.enqueue('bidirectional', 'current')
       ];
 
@@ -145,15 +145,15 @@ describe('SyncQueue', () => {
     it('should continue processing after error', async () => {
       const errorProcessor: SyncProcessor = vi.fn(async (request: SyncRequest) => {
         processedRequests.push(request);
-        if (request.mode === 'to-airtable') {
+        if (request.mode === 'push') {
           throw new Error('Sync failed');
         }
       });
 
       const queue = new SyncQueue(errorProcessor);
 
-      await queue.enqueue('to-airtable', 'current');
-      await queue.enqueue('from-airtable', 'all');
+      await queue.enqueue('push', 'current');
+      await queue.enqueue('pull', 'all');
 
       expect(processedRequests.length).toBe(2);
     });
@@ -166,7 +166,7 @@ describe('SyncQueue', () => {
 
       const queue = new SyncQueue(errorProcessor, onError);
 
-      await queue.enqueue('to-airtable', 'current');
+      await queue.enqueue('push', 'current');
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -179,7 +179,7 @@ function resetExpr() {
       ]})
     });
     setMode('manual', false);
-    await enqueueSync('from-airtable', 'all');
+    await enqueueSync('pull', 'all');
     await new Promise(r => setTimeout(r, 5000));
     return '"reset"';
   })()`;
@@ -286,10 +286,10 @@ async function test(name, fn) {
 
     // -- Pull tests --
 
-    await test('from-airtable / all', async () => {
+    await test('pull / all', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
-        await enqueueSync('from-airtable', 'all');
+        await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const files = app.vault.getFiles().filter(f => f.path.startsWith(getConfig().folderPath + '/'));
         return JSON.stringify({ fileCount: files.length });
@@ -297,7 +297,7 @@ async function test(name, fn) {
       return { pass: r.fileCount >= 8, detail: `${r.fileCount} files` };
     });
 
-    await test('from-airtable / bases file generation', async () => {
+    await test('pull / bases file generation', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
@@ -316,7 +316,7 @@ async function test(name, fn) {
         for (const f of existingBases) await app.vault.delete(f);
 
         // Sync from Airtable
-        await enqueueSync('from-airtable', 'all');
+        await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 6000));
 
         // Check .base file was created
@@ -336,7 +336,7 @@ async function test(name, fn) {
 
         // Verify regenerate=false skips existing file
         const contentBefore = content;
-        await enqueueSync('from-airtable', 'all');
+        await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 6000));
         const contentAfter = await app.vault.read(baseFile);
         const skipWorks = contentBefore === contentAfter;
@@ -354,7 +354,7 @@ async function test(name, fn) {
       return { pass: r.pass, detail: r.detail || 'ok' };
     });
 
-    await test('from-airtable / view filter', async () => {
+    await test('pull / view filter', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
@@ -377,7 +377,7 @@ async function test(name, fn) {
         cfg.viewId = nonDefault.id;
         getInstance().updateSettings(cfg, cred);
 
-        await enqueueSync('from-airtable', 'all');
+        await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const viewFiles = app.vault.getFiles().filter(
           f => f.path.startsWith(cfg.folderPath + '/') && f.extension === 'md'
@@ -389,7 +389,7 @@ async function test(name, fn) {
         cfg.allowOverwrite = true;
         getInstance().updateSettings(cfg, cred);
 
-        await enqueueSync('from-airtable', 'all');
+        await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const allFiles = app.vault.getFiles().filter(
           f => f.path.startsWith(cfg.folderPath + '/') && f.extension === 'md'
@@ -409,12 +409,12 @@ async function test(name, fn) {
       return { pass: r.pass, detail: r.detail || 'ok' };
     });
 
-    await test('from-airtable / current', async () => {
+    await test('pull / current', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
         const file = await openAndActivate(getConfig().folderPath + '/E2E-Pull-Test.md');
         try {
-          await enqueueSync('from-airtable', 'current');
+          await enqueueSync('pull', 'current');
           await new Promise(r => setTimeout(r, 3000));
           const content = await app.vault.read(file);
           return JSON.stringify({ pass: content.includes('${testRecordIds[0]}') });
@@ -427,14 +427,14 @@ async function test(name, fn) {
 
     // -- Push tests --
 
-    await test('to-airtable / all / obsidian-wins', async () => {
+    await test('push / all / obsidian-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
         const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 555);
-        await enqueueSync('to-airtable', 'all');
+        await enqueueSync('push', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         setMode('manual');
@@ -443,14 +443,14 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count}` };
     });
 
-    await test('to-airtable / current / obsidian-wins', async () => {
+    await test('push / current / obsidian-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
         const file = await openAndActivate(getConfig().folderPath + '/E2E-Bidir-Test.md');
         await modifyCount(file, 888);
-        await enqueueSync('to-airtable', 'current');
+        await enqueueSync('push', 'current');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[2]}');
         setMode('manual');
@@ -459,14 +459,14 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count}` };
     });
 
-    await test('to-airtable / all / airtable-wins', async () => {
+    await test('push / all / airtable-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('airtable-wins');
         const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Pull-Test.md');
         await modifyCount(file, 9999);
-        await enqueueSync('to-airtable', 'all');
+        await enqueueSync('push', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[0]}');
         setMode('manual');
@@ -475,14 +475,14 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count} (expected 100)` };
     });
 
-    await test('to-airtable / current / airtable-wins', async () => {
+    await test('push / current / airtable-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('airtable-wins');
         const file = await openAndActivate(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 7777);
-        await enqueueSync('to-airtable', 'current');
+        await enqueueSync('push', 'current');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         setMode('manual');
@@ -491,14 +491,14 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count} (expected 200)` };
     });
 
-    await test('to-airtable / all / manual (conflict blocks)', async () => {
+    await test('push / all / manual (conflict blocks)', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('manual');
         const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 7777);
-        await enqueueSync('to-airtable', 'all');
+        await enqueueSync('push', 'all');
         await new Promise(r => setTimeout(r, 5000));
         const fields = await fetchRecord('${testRecordIds[1]}');
         return JSON.stringify({ pass: fields.Count === 200, count: fields.Count });
@@ -692,7 +692,7 @@ async function test(name, fn) {
           .map(f => f.path);
 
         // Sync config 2
-        await enqueueSync('from-airtable', 'all', cfg2);
+        await enqueueSync('pull', 'all', cfg2);
         await new Promise(r => setTimeout(r, 5000));
 
         // Check config 2 files created in its folder

--- a/tests/utils/settings-bridge.test.ts
+++ b/tests/utils/settings-bridge.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildLegacySettings } from '../../src/utils/settings-bridge';
-import type { ConfigEntry, Credential, AirtableCredential } from '../../src/types';
-import { DEFAULT_CONFIG_ENTRY } from '../../src/types';
+import { buildLegacySettings, findCredentialForConfig } from '../../src/utils/settings-bridge';
+import type { ConfigEntry, Credential, AirtableCredential, AutoNoteImporterSettings } from '../../src/types';
+import { DEFAULT_CONFIG_ENTRY, DEFAULT_SETTINGS } from '../../src/types';
 
 function createConfig(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return {
@@ -161,5 +161,26 @@ describe('buildLegacySettings', () => {
       expect(result['id']).toBe('cfg-1');
       expect(result['name']).toBe('Test Config');
     });
+  });
+});
+
+describe('findCredentialForConfig', () => {
+  function createSettings(credentials: Credential[]): AutoNoteImporterSettings {
+    return { ...DEFAULT_SETTINGS, credentials };
+  }
+
+  it('returns the matching credential by id', () => {
+    const cred = createAirtableCredential({ id: 'cred-1' });
+    const settings = createSettings([cred]);
+    expect(findCredentialForConfig(settings, createConfig({ credentialId: 'cred-1' }))).toBe(cred);
+  });
+
+  it('returns undefined when the linked credential is missing', () => {
+    const settings = createSettings([createAirtableCredential({ id: 'cred-1' })]);
+    expect(findCredentialForConfig(settings, createConfig({ credentialId: 'cred-99' }))).toBeUndefined();
+  });
+
+  it('returns undefined when credentials list is empty', () => {
+    expect(findCredentialForConfig(createSettings([]), createConfig())).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Rename `SyncMode` literals from Airtable-specific (`'to-airtable'`/`'from-airtable'`) to provider-agnostic (`'push'`/`'pull'`); `'bidirectional'` unchanged.
- Add dynamic provider label to user-facing strings — command names and `SyncOrchestrator` status bar / `Notice` messages now derive the provider name from `provider.providerType` via `CREDENTIAL_TYPE_LABELS`, so a SeaTable provider produces `"Syncing from SeaTable..."` instead of hardcoded `"Airtable"`.
- Extract `findCredentialForConfig()` helper in `src/utils/settings-bridge.ts` to dedupe the credential-lookup-by-id pattern (3 sites in `main.ts`).

## Changes

### Type / dispatch rename
- `src/types/sync.types.ts` — `SyncMode = 'push' | 'pull' | 'bidirectional'` (was `'to-airtable' | 'from-airtable' | 'bidirectional'`)
- `src/core/sync-orchestrator.ts`, `src/core/config-instance.ts`, `src/main.ts` — switch cases, `enqueueSyncRequest` calls, and 5 command IDs renamed mechanically
- `tests/core/{sync-queue,sync-orchestrator,config-instance}.test.ts` + `tests/e2e/run-e2e.mjs` — 30+ test literals updated

### Command ID rename (BREAKING for user hotkeys)
| Before | After |
|---|---|
| `sync-from-airtable-{configId}` | `sync-pull-{configId}` |
| `sync-all-from-airtable-{configId}` | `sync-pull-all-{configId}` |
| `sync-current-to-airtable-{configId}` | `sync-push-current-{configId}` |
| `sync-modified-to-airtable-{configId}` | `sync-push-modified-{configId}` |
| `sync-all-to-airtable-{configId}` | `sync-push-all-{configId}` |

`bidirectional-sync-*-{configId}` IDs unchanged.

### Provider-aware UX
- `registerCommandsForConfig` looks up the linked credential and uses `CREDENTIAL_TYPE_LABELS[type]` for command names.
- `getCommandFingerprint` includes credential `type` so swapping a config to a different credential triggers re-registration and labels stay in sync.
- `SyncOrchestrator` adds a `providerLabel` getter (`CREDENTIAL_TYPE_LABELS[this.provider.providerType]`) used in 6 user-facing strings.

### Cleanup (from `/simplify` round)
- Extract `findCredentialForConfig(settings, config)` helper; replace 3 inline `find()` calls in `main.ts`.
- Drop 3 narrating comments (`// Pull commands (remote → local)` etc.) and trim a JSDoc paragraph that leaked sibling-method coupling.
- Widen `MockDatabaseProvider.providerType` to the `CredentialType` union (was hardcoded `'airtable'`) so tests can simulate other providers.

### Tests
- 3 new vitest cases for `findCredentialForConfig` (matching / missing / empty credentials list).
- 2 new regression-guard tests in `sync-orchestrator.test.ts` (`provider-aware labels` describe block) — verify status bar text reflects the provider type, locking the dynamic-label contract against future hardcode regressions.

## Out of scope (follow-up candidates)
- `autoSyncFormulas` setting name (Airtable `formula` term, requires settings migration).
- Internal method names: `syncFromAirtable` / `syncFilesToAirtable` / `syncCurrentFromAirtable` and `AIRTABLE_BATCH_SIZE` constant.
- Non-formula `airtable-wins` conflict resolution mode value (also Airtable-specific term).
- `processSyncRequest` switch missing `default: never` exhaustiveness check (pre-existing per handbook §6.3).
- Note content marker `<!-- Content imported from Airtable -->` written by `note-builder` (changing it would break backward compatibility on existing notes).

## Migration note for users
Existing custom keyboard shortcuts bound to the old command IDs will stop working after upgrade. Users need to re-bind their hotkeys to the new IDs (`sync-pull-*`, `sync-push-*-*`).

## Test plan
- [x] `npm run build` — TypeScript + esbuild production build, clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings unchanged)
- [x] `npx vitest run` — **408 / 408 passed** (added 5 new tests: 3 helper, 2 regression guard)
- [x] **Real Obsidian e2e against `tbl1hFi5iRcju2NJV` Test table — 16 / 16 passed** (pull / push / bidirectional / multi-config / view filter / bases file generation / 3 conflict resolution modes)
- [x] **Dynamic provider label verified in real Obsidian** for all 5 credential types (airtable / notion / seatable / custom-api / restore-to-airtable) via in-memory `cred.type` mutation + `reregisterAllCommands()` + label inspection
- [x] No orphan vault artifacts after restoration

Closes #59