### PR TITLE
chore: add exhaustive switch guard to processSyncRequest (#65)

### DIFF
--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -124,6 +124,11 @@ export class SyncOrchestrator {
           }
           break;
         }
+
+        default: {
+          const _exhaustive: never = mode;
+          throw new Error(`Unknown sync mode: ${_exhaustive}`);
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary
Adopt the handbook §6.3 "Exhaustive Switch" pattern in `SyncOrchestrator.processSyncRequest` — was the only mode-dispatching switch in the codebase missing a `default: never` guard. Sibling `getFilesToSync()` already uses the pattern; this restores consistency.

## Changes
**`src/core/sync-orchestrator.ts`** — single 5-line addition:
```typescript
default: {
  const _exhaustive: never = mode;
  throw new Error(`Unknown sync mode: ${_exhaustive}`);
}
```

## Why this matters
- Future `SyncMode` additions (e.g., `'pull-current'`, `'pull-modified'`) will fail at compile time if any case is missed, preventing silent fall-through.
- Currently no `SyncMode` value escapes the case branches, so behavior is unchanged at runtime — pure compile-time safety net.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors (3 pre-existing warnings unchanged)
- [x] `npx vitest run` — 408/408 passed (no new tests; the `never` typing is the safety mechanism, default branch is unreachable by valid types)
- [x] Sync tags moved to HEAD (`test-sync` + `handbook-sync` → `20a6500`)

Closes #65