### PR TITLE
feat: include provider label in bidirectional command names (#66)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
     this.addCommand({
       id: `bidirectional-sync-current-${configId}`,
-      name: `Bidirectional sync current note${suffix}`,
+      name: `Bidirectional sync current note with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
@@ -200,7 +200,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
     this.addCommand({
       id: `bidirectional-sync-modified-${configId}`,
-      name: `Bidirectional sync modified notes${suffix}`,
+      name: `Bidirectional sync modified notes with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
@@ -211,7 +211,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
     this.addCommand({
       id: `bidirectional-sync-all-${configId}`,
-      name: `Bidirectional sync all notes${suffix}`,
+      name: `Bidirectional sync all notes with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
         const cfg = this.settings.configs.find(c => c.id === configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;


### PR DESCRIPTION
## Summary
PR #62 review에서 지적된 일관성 갭 해소. Pull/Push 명령어는 provider 라벨을 포함하는데 bidirectional만 누락되어 있던 것을 동일하게 동적 라벨로 변경.

## Before / After

| Type | Before | After |
|---|---|---|
| Pull (current) | `Sync current note from Airtable — {cfg}` | (unchanged) |
| Push (all) | `Sync all notes to Airtable — {cfg}` | (unchanged) |
| Bidirectional (current) | `Bidirectional sync current note — {cfg}` ❌ | `Bidirectional sync current note with Airtable — {cfg}` ✅ |
| Bidirectional (modified) | `Bidirectional sync modified notes — {cfg}` ❌ | `Bidirectional sync modified notes with Airtable — {cfg}` ✅ |
| Bidirectional (all) | `Bidirectional sync all notes — {cfg}` ❌ | `Bidirectional sync all notes with Airtable — {cfg}` ✅ |

`with {providerLabel}` 패턴은 pull의 `from {providerLabel}` / push의 `to {providerLabel}`과 대칭. SeaTable / Notion / Custom API 같이 다른 provider도 같은 메커니즘으로 자동 반영.

## Changes
- `src/main.ts` — bidirectional 3개 `addCommand`의 `name` 문자열에 `with ${providerLabel}` 삽입
- 명령어 **ID는 변경 없음** — `bidirectional-sync-{current|modified|all}-{configId}` 그대로. 사용자 키바인딩 hotkey **유지됨** (breaking 아님)
- 라벨 도출 메커니즘은 PR #62의 기존 인프라(`CREDENTIAL_TYPE_LABELS[credential.type]`, `getCommandFingerprint` credential type 포함) 그대로 활용 — 신규 코드 무

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run` — 408/408 passed
- [x] **실제 Obsidian (uppinote vault, debug mode) 검증** — bidirectional 명령어 6개 (2 configs × 3 commands) 모두 "with Airtable" 라벨 정확히 출력
- [x] Sync tags moved to HEAD (`test-sync` + `handbook-sync` → `b2789e0`)

## Out of scope
새 단위 테스트는 추가하지 않음 — `provider-aware labels` 회귀 가드는 sync-orchestrator의 status bar 메시지를 검증하는 패턴이고, command name 검증은 main.ts 단위 테스트 인프라가 부재. 실제 Obsidian e2e로 직접 verify했고 PR #62의 dynamic 라벨 메커니즘을 재사용하므로 추가 가드 가치 낮음.

Closes #66