### PR TITLE
refactor: rename Airtable-specific internal API + use provider batch capability (#63)

### DIFF
--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -434,7 +434,8 @@ export class SyncOrchestrator {
     }
 
     let syncedCount = 0;
-    const batchSize = this.provider.capabilities.batchUpdateMaxSize;
+    // Guard against a misimplemented provider reporting 0 — would otherwise infinite-loop below.
+    const batchSize = Math.max(1, this.provider.capabilities.batchUpdateMaxSize);
 
     for (let i = 0; i < batchUpdates.length; i += batchSize) {
       const batch = batchUpdates.slice(i, i + batchSize);

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -16,7 +16,7 @@
 import { App, TFile, TFolder, normalizePath, Notice, MarkdownView } from "obsidian";
 import type { LegacySettings, RemoteNote, BatchUpdate, SyncMode, SyncScope, NoteCreationResult, DatabaseProvider } from '../types';
 import { CREDENTIAL_TYPE_LABELS } from '../types';
-import { AIRTABLE_BATCH_SIZE, DEBUG_DELAY_MULTIPLIER } from '../constants';
+import { DEBUG_DELAY_MULTIPLIER } from '../constants';
 import { FieldCache } from '../services';
 import { ConflictResolver } from './conflict-resolver';
 import { FrontmatterParser, FileWatcher } from '../file-operations';
@@ -80,10 +80,10 @@ export class SyncOrchestrator {
         case 'pull':
           if (scope === 'current') {
             statusBarItem.setText(`Syncing current note from ${label}...`);
-            await this.syncCurrentFromAirtable();
+            await this.pullCurrent();
           } else {
             statusBarItem.setText(`Syncing from ${label}...`);
-            await this.syncFromAirtable();
+            await this.pullAll();
           }
           break;
 
@@ -100,11 +100,11 @@ export class SyncOrchestrator {
 
           if (mode === 'push') {
             statusBarItem.setText(`Syncing ${files.length} file(s) to ${label}...`);
-            await this.syncFilesToAirtable(files);
+            await this.pushFiles(files);
             new Notice(`Auto Note Importer: Synced ${files.length} file(s) to ${label}`);
           } else {
             statusBarItem.setText(`Phase 1/2 - Syncing ${files.length} file(s) to ${label}...`);
-            await this.syncFilesToAirtable(files);
+            await this.pushFiles(files);
 
             if (this.settings.autoSyncFormulas) {
               const delay = this.settings.debugMode
@@ -114,10 +114,10 @@ export class SyncOrchestrator {
               await this.sleep(delay);
 
               statusBarItem.setText("Phase 2/2 - Fetching computed results...");
-              await this.syncFromAirtable();
+              await this.pullAll();
               new Notice("Auto Note Importer: Bidirectional sync complete!");
             } else {
-              // Bases file is not generated here because syncFromAirtable() is skipped,
+              // Bases file is not generated here because pullAll() is skipped,
               // so no remoteNotes are available to derive column definitions from.
               new Notice(`Auto Note Importer: Synced ${files.length} file(s) to ${label}`);
             }
@@ -184,7 +184,7 @@ export class SyncOrchestrator {
     return files;
   }
 
-  private async syncCurrentFromAirtable(): Promise<void> {
+  private async pullCurrent(): Promise<void> {
     const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (!activeView?.file) {
       new Notice("Auto Note Importer: No active markdown file");
@@ -225,7 +225,7 @@ export class SyncOrchestrator {
     }
   }
 
-  private async syncFromAirtable(): Promise<void> {
+  private async pullAll(): Promise<void> {
     const folderPath = normalizePath(this.settings.folderPath);
     if (!await this.app.vault.adapter.exists(folderPath)) {
       await this.app.vault.createFolder(folderPath);
@@ -373,7 +373,7 @@ export class SyncOrchestrator {
     return buildMarkdownContent(note);
   }
 
-  private async syncFilesToAirtable(files: TFile[]): Promise<void> {
+  private async pushFiles(files: TFile[]): Promise<void> {
     const cacheKey = this.fieldCache.getCacheKey(this.settings.baseId, this.settings.tableId);
 
     let cachedFields = this.fieldCache.getFields(cacheKey);
@@ -434,9 +434,10 @@ export class SyncOrchestrator {
     }
 
     let syncedCount = 0;
+    const batchSize = this.provider.capabilities.batchUpdateMaxSize;
 
-    for (let i = 0; i < batchUpdates.length; i += AIRTABLE_BATCH_SIZE) {
-      const batch = batchUpdates.slice(i, i + AIRTABLE_BATCH_SIZE);
+    for (let i = 0; i < batchUpdates.length; i += batchSize) {
+      const batch = batchUpdates.slice(i, i + batchSize);
 
       try {
         const results = await this.provider.batchUpdate(batch);

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -130,7 +130,7 @@ describe('SyncOrchestrator', () => {
       await orchestrator.processSyncRequest('pull', 'all');
 
       expect(statusBar.lastItem.remove).toHaveBeenCalledTimes(1);
-      // setSyncing(false) must be called even on error (via finally block in syncFromAirtable)
+      // setSyncing(false) must be called even on error (via finally block in pullAll)
       expect(setSyncingSpy).toHaveBeenCalledWith(false);
     });
   });


### PR DESCRIPTION
## Summary
PR #62 (#59) deferred된 internal naming 정리. Private 메서드 이름과 batch 사이즈 결정 로직을 provider-agnostic하게 변경.

## Changes

### Method renames (`src/core/sync-orchestrator.ts`)
모두 `private` 메서드 — 외부 API 영향 없음.

| Before | After |
|---|---|
| `syncCurrentFromAirtable()` | `pullCurrent()` |
| `syncFromAirtable()` | `pullAll()` |
| `syncFilesToAirtable(files)` | `pushFiles(files)` |

`SyncMode` literal(`pull` / `push`)과 어휘 일치.

### Batch size: constant import → provider capability
**Before** — orchestrator가 Airtable 상수 직접 import:
```typescript
import { AIRTABLE_BATCH_SIZE } from '../constants';
// ...
for (let i = 0; i < batchUpdates.length; i += AIRTABLE_BATCH_SIZE) { ... }
```

**After** — runtime provider capability 활용:
```typescript
const batchSize = this.provider.capabilities.batchUpdateMaxSize;
for (let i = 0; i < batchUpdates.length; i += batchSize) { ... }
```

- `DatabaseProvider.capabilities.batchUpdateMaxSize`는 PR #58에서 이미 인터페이스 필드로 정의됨 (handbook §4.4)
- Airtable 외 provider가 다른 batch 한도(예: Notion 100, Supabase ?, SeaTable ?)를 가져도 자동 적용
- `AIRTABLE_BATCH_SIZE` 상수 자체는 유지 — `airtable-client.ts` 내부에서만 사용 (Airtable API 실제 한도 10을 표현)

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run` — 408/408 passed (메서드 모두 private, 시그니처 동일하므로 호출 사이트만 갱신됨)
- [x] **실제 Obsidian e2e 16/16 PASS** — pull / push / bidirectional / multi-config / view filter / bases / 3 conflict modes 모두 회귀 없음
- [x] Sync tags moved to HEAD (`test-sync` + `handbook-sync` → `24e7f00`)

## Out of scope (별도 이슈)
- **#64** `autoSyncFormulas` / `airtable-wins` 사용자 설정 rename — settings v2→v3 migration 필요
- 노트 콘텐츠 마커 `<!-- Content imported from Airtable -->` — 기존 노트 backward compat 영향 있어 별도 디자인 고려

Closes #63