### PR TITLE
refactor: rename autoSyncFormulas + airtable-wins to provider-agnostic (settings v2→v3 migration) (#64)

### DIFF
--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -73,7 +73,7 @@ export class ConfigInstance {
       this.app,
       this.settings,
       async (files) => {
-        const mode: SyncMode = this.settings.autoSyncFormulas ? 'bidirectional' : 'push';
+        const mode: SyncMode = this.settings.autoSyncComputedFields ? 'bidirectional' : 'push';
         await this.syncQueue.enqueue(mode, 'modified', files.map(f => f.path));
       }
     );

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -88,7 +88,7 @@ export class ConflictResolver {
   }
 
   /**
-   * Resolves conflicts with Airtable winning.
+   * Resolves conflicts by letting the remote win.
    */
   private async resolveRemoteWins(
     conflicts: ConflictInfo[],
@@ -106,7 +106,7 @@ export class ConflictResolver {
 
     if (conflicts.length > 0) {
       const conflictFields = conflicts.map(c => c.field).join(', ');
-      new Notice(`Auto Note Importer: Conflicted fields ignored (Airtable wins): ${conflictFields}`);
+      new Notice(`Auto Note Importer: Conflicted fields ignored (remote wins): ${conflictFields}`);
     }
 
     if (Object.keys(nonConflictedFields).length > 0) {

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -74,8 +74,8 @@ export class ConflictResolver {
       case 'obsidian-wins':
         return this.provider.updateRecord(recordId, fieldsToSync);
 
-      case 'airtable-wins':
-        return this.resolveAirtableWins(conflicts, fieldsToSync, recordId);
+      case 'remote-wins':
+        return this.resolveRemoteWins(conflicts, fieldsToSync, recordId);
 
       case 'manual':
         return this.resolveManual(conflicts, recordId);
@@ -90,7 +90,7 @@ export class ConflictResolver {
   /**
    * Resolves conflicts with Airtable winning.
    */
-  private async resolveAirtableWins(
+  private async resolveRemoteWins(
     conflicts: ConflictInfo[],
     fieldsToSync: Record<string, unknown>,
     recordId: string

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -106,7 +106,7 @@ export class SyncOrchestrator {
             statusBarItem.setText(`Phase 1/2 - Syncing ${files.length} file(s) to ${label}...`);
             await this.pushFiles(files);
 
-            if (this.settings.autoSyncFormulas) {
+            if (this.settings.autoSyncComputedFields) {
               const delay = this.settings.debugMode
                 ? this.settings.formulaSyncDelay * DEBUG_DELAY_MULTIPLIER
                 : this.settings.formulaSyncDelay;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -36,7 +36,7 @@ export interface ConfigEntry {
   conflictResolution: ConflictResolutionMode;
   watchForChanges: boolean;
   fileWatchDebounce: number;
-  autoSyncFormulas: boolean;
+  autoSyncComputedFields: boolean;
   formulaSyncDelay: number;
 
   generateBasesFile: boolean;
@@ -60,7 +60,7 @@ export const DEFAULT_CONFIG_ENTRY: Omit<ConfigEntry, 'id' | 'name' | 'credential
   conflictResolution: 'manual',
   watchForChanges: false,
   fileWatchDebounce: 2000,
-  autoSyncFormulas: false,
+  autoSyncComputedFields: false,
   formulaSyncDelay: 1500,
   generateBasesFile: false,
   basesFileLocation: 'vault-root',

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -25,7 +25,7 @@ export type SyncScope = 'current' | 'modified' | 'all';
 /**
  * Legacy single-config settings interface.
  * Used by services internally via ConfigInstance.buildSettingsFromConfig().
- * @deprecated Use AutoNoteImporterSettings (v2 multi-config) for plugin-level settings.
+ * @deprecated Use AutoNoteImporterSettings (v3 multi-config) for plugin-level settings.
  */
 export interface LegacySettings {
   apiKey: string;

--- a/src/types/settings.types.ts
+++ b/src/types/settings.types.ts
@@ -8,8 +8,9 @@ import type { ConfigEntry } from './config.types';
 
 /**
  * Conflict resolution modes for bidirectional sync.
+ * `remote-wins` was named `airtable-wins` in settings v2; v3 migration renames it.
  */
-export type ConflictResolutionMode = 'obsidian-wins' | 'airtable-wins' | 'manual';
+export type ConflictResolutionMode = 'obsidian-wins' | 'remote-wins' | 'manual';
 
 /**
  * Location options for the generated Bases database file.
@@ -41,7 +42,7 @@ export interface LegacySettings {
   conflictResolution: ConflictResolutionMode;
   watchForChanges: boolean;
   fileWatchDebounce: number;
-  autoSyncFormulas: boolean;
+  autoSyncComputedFields: boolean;
   formulaSyncDelay: number;
   generateBasesFile: boolean;
   basesFileLocation: BasesFileLocation;
@@ -51,10 +52,15 @@ export interface LegacySettings {
 }
 
 /**
- * Plugin settings interface (v2 multi-config).
+ * Plugin settings interface (v3 multi-config with provider-agnostic field names).
+ *
+ * Version history:
+ *   v1 (no version field): legacy single-config flat shape
+ *   v2: multi-config (`credentials[]` + `configs[]`)
+ *   v3: rename `autoSyncFormulas` → `autoSyncComputedFields`, `airtable-wins` → `remote-wins`
  */
 export interface AutoNoteImporterSettings {
-  version: 2;
+  version: 3;
   credentials: Credential[];
   configs: ConfigEntry[];
   activeConfigId: string;
@@ -80,7 +86,7 @@ export const DEFAULT_LEGACY_SETTINGS: LegacySettings = {
   conflictResolution: 'manual',
   watchForChanges: true,
   fileWatchDebounce: 2000,
-  autoSyncFormulas: true,
+  autoSyncComputedFields: true,
   formulaSyncDelay: 1500,
   generateBasesFile: false,
   basesFileLocation: 'vault-root',
@@ -93,7 +99,7 @@ export const DEFAULT_LEGACY_SETTINGS: LegacySettings = {
  * Default values for the plugin settings.
  */
 export const DEFAULT_SETTINGS: AutoNoteImporterSettings = {
-  version: 2,
+  version: 3,
   credentials: [],
   configs: [],
   activeConfigId: '',

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -984,8 +984,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setDesc("How to handle conflicts when the same field is modified in both places.")
         .addDropdown(dropdown => dropdown
           .addOption('manual', 'Manual resolution (show conflicts)')
-          .addOption('obsidian-wins', 'Obsidian wins (overwrite Airtable)')
-          .addOption('airtable-wins', 'Airtable wins (overwrite Obsidian)')
+          .addOption('obsidian-wins', 'Obsidian wins (overwrite remote)')
+          .addOption('remote-wins', 'Remote wins (overwrite Obsidian)')
           .setValue(config.conflictResolution)
           .onChange(async (value) => {
             config.conflictResolution = value as ConflictResolutionMode;
@@ -1011,20 +1011,20 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       }
 
       new Setting(containerEl)
-        .setName("Auto-sync formulas and relations")
-        .setDesc("Automatically fetch computed formula and relation results after syncing.")
+        .setName("Auto-sync server-computed fields")
+        .setDesc("Automatically fetch fields the remote computes server-side (formulas, lookups, rollups, generated columns) after each sync.")
         .addToggle(toggle => toggle
-          .setValue(config.autoSyncFormulas)
+          .setValue(config.autoSyncComputedFields)
           .onChange(async (value) => {
-            config.autoSyncFormulas = value;
+            config.autoSyncComputedFields = value;
             await this.plugin.saveSettings();
             this.debounceDisplay();
           }));
 
-      if (config.autoSyncFormulas) {
-        this.renderNumberSetting(containerEl, "Formula sync delay (milliseconds)",
-          "How long to wait for Airtable to compute formulas before fetching.", "1500",
-          config.formulaSyncDelay, "Formula sync delay",
+      if (config.autoSyncComputedFields) {
+        this.renderNumberSetting(containerEl, "Computed-field sync delay (milliseconds)",
+          "How long to wait for the remote to compute fields before fetching.", "1500",
+          config.formulaSyncDelay, "Computed-field sync delay",
           (num) => { config.formulaSyncDelay = num; }, undefined, "100");
       }
     }

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -1,5 +1,5 @@
 /**
- * Settings migration utility for upgrading legacy single-config settings to v2 multi-config format.
+ * Settings migration utility for upgrading legacy settings to the current version.
  *
  * @handbook 9.9-settings-migration
  * @tested tests/utils/migration.test.ts
@@ -7,34 +7,87 @@
 
 import type { Credential } from '../types/credential.types';
 import type { ConfigEntry } from '../types/config.types';
-import type { AutoNoteImporterSettings } from '../types/settings.types';
+import type { AutoNoteImporterSettings, ConflictResolutionMode } from '../types/settings.types';
 import { generateId } from './object-utils';
 
+const CURRENT_VERSION = 3 as const;
+
 /**
- * Migrates legacy single-config settings data to the v2 multi-config format.
+ * Normalizes a possibly-legacy conflictResolution value to the current `ConflictResolutionMode`.
+ * v2 used `'airtable-wins'`; v3 uses `'remote-wins'`. Unknown values fall back to `'manual'`.
+ */
+function migrateConflictResolution(value: unknown): ConflictResolutionMode {
+  if (value === 'obsidian-wins' || value === 'remote-wins' || value === 'manual') {
+    return value;
+  }
+  if (value === 'airtable-wins') {
+    return 'remote-wins';
+  }
+  return 'manual';
+}
+
+/**
+ * Reads a possibly-legacy `autoSyncComputedFields` value (named `autoSyncFormulas` in v2).
+ */
+function readAutoSyncComputedFields(record: Record<string, unknown>, fallback: boolean): boolean {
+  const v3 = record['autoSyncComputedFields'];
+  if (typeof v3 === 'boolean') return v3;
+  const v2 = record['autoSyncFormulas'];
+  if (typeof v2 === 'boolean') return v2;
+  return fallback;
+}
+
+/**
+ * Migrates settings data to the current version.
  *
  * - Returns null for null/undefined input (fresh install, no migration needed).
- * - Returns null if data is already v2 format (migration already done).
- * - Otherwise converts legacy settings into a single credential + config entry.
+ * - Returns null if data is already at the current version.
+ * - v2 → v3: rename `autoSyncFormulas` → `autoSyncComputedFields` and `airtable-wins` → `remote-wins` per config; bump version.
+ * - v1 / unknown → v3: convert flat legacy single-config layout to multi-config with current field names.
  *
  * @param data - Raw settings data loaded from plugin storage (unknown type)
- * @returns Migrated v2 settings, or null if migration is not applicable
+ * @returns Migrated settings, or null if migration is not applicable
  */
 export function migrateSettings(data: unknown): AutoNoteImporterSettings | null {
-  if (data == null) {
-    return null;
-  }
-
-  if (typeof data !== 'object') {
+  if (data == null || typeof data !== 'object') {
     return null;
   }
 
   const record = data as Record<string, unknown>;
 
-  if (record['version'] === 2) {
+  if (record['version'] === CURRENT_VERSION) {
     return null;
   }
 
+  if (record['version'] === 2) {
+    return migrateV2toV3(record);
+  }
+
+  return migrateLegacyToV3(record);
+}
+
+function migrateV2toV3(record: Record<string, unknown>): AutoNoteImporterSettings {
+  const credentials = Array.isArray(record['credentials']) ? record['credentials'] as Credential[] : [];
+  const rawConfigs = Array.isArray(record['configs']) ? record['configs'] as Record<string, unknown>[] : [];
+
+  const configs = rawConfigs.map(cfg => {
+    const next: Record<string, unknown> = { ...cfg };
+    next['conflictResolution'] = migrateConflictResolution(cfg['conflictResolution']);
+    next['autoSyncComputedFields'] = readAutoSyncComputedFields(cfg, false);
+    delete next['autoSyncFormulas'];
+    return next as unknown as ConfigEntry;
+  });
+
+  return {
+    version: CURRENT_VERSION,
+    credentials,
+    configs,
+    activeConfigId: typeof record['activeConfigId'] === 'string' ? record['activeConfigId'] : '',
+    debugMode: typeof record['debugMode'] === 'boolean' ? record['debugMode'] : false,
+  };
+}
+
+function migrateLegacyToV3(record: Record<string, unknown>): AutoNoteImporterSettings {
   const credentialId = generateId();
   const configId = generateId();
 
@@ -60,12 +113,10 @@ export function migrateSettings(data: unknown): AutoNoteImporterSettings | null 
     syncInterval: typeof record['syncInterval'] === 'number' ? record['syncInterval'] : 0,
     allowOverwrite: typeof record['allowOverwrite'] === 'boolean' ? record['allowOverwrite'] : true,
     bidirectionalSync: typeof record['bidirectionalSync'] === 'boolean' ? record['bidirectionalSync'] : false,
-    conflictResolution: (record['conflictResolution'] === 'obsidian-wins' || record['conflictResolution'] === 'airtable-wins')
-      ? record['conflictResolution']
-      : 'manual',
+    conflictResolution: migrateConflictResolution(record['conflictResolution']),
     watchForChanges: typeof record['watchForChanges'] === 'boolean' ? record['watchForChanges'] : false,
     fileWatchDebounce: typeof record['fileWatchDebounce'] === 'number' ? record['fileWatchDebounce'] : 2000,
-    autoSyncFormulas: typeof record['autoSyncFormulas'] === 'boolean' ? record['autoSyncFormulas'] : false,
+    autoSyncComputedFields: readAutoSyncComputedFields(record, false),
     formulaSyncDelay: typeof record['formulaSyncDelay'] === 'number' ? record['formulaSyncDelay'] : 1500,
     generateBasesFile: typeof record['generateBasesFile'] === 'boolean' ? record['generateBasesFile'] : false,
     basesFileLocation: (record['basesFileLocation'] === 'synced-folder' || record['basesFileLocation'] === 'custom')
@@ -76,7 +127,7 @@ export function migrateSettings(data: unknown): AutoNoteImporterSettings | null 
   };
 
   return {
-    version: 2,
+    version: CURRENT_VERSION,
     credentials: [credential],
     configs: [config],
     activeConfigId: configId,

--- a/tests/core/conflict-resolver.test.ts
+++ b/tests/core/conflict-resolver.test.ts
@@ -19,7 +19,7 @@ describe('ConflictResolver', () => {
   let mockProvider: MockDatabaseProvider;
   let resolver: ConflictResolver;
 
-  const createSettings = (conflictResolution: 'obsidian-wins' | 'airtable-wins' | 'manual'): LegacySettings => ({
+  const createSettings = (conflictResolution: 'obsidian-wins' | 'remote-wins' | 'manual'): LegacySettings => ({
     ...DEFAULT_LEGACY_SETTINGS,
     apiKey: 'key',
     baseId: 'base123',
@@ -42,8 +42,8 @@ describe('ConflictResolver', () => {
       expect(resolver.shouldSkipConflictDetection()).toBe(true);
     });
 
-    it('should return false for airtable-wins mode (CR-2.2)', () => {
-      const settings = createSettings('airtable-wins');
+    it('should return false for remote-wins mode (CR-2.2)', () => {
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(false);
@@ -59,7 +59,7 @@ describe('ConflictResolver', () => {
 
   describe('detectConflicts', () => {
     it('should return empty array when record not found', async () => {
-      const settings = createSettings('airtable-wins');
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       mockProvider.fetchRecord.mockResolvedValue(null);
@@ -74,7 +74,7 @@ describe('ConflictResolver', () => {
     });
 
     it('should detect conflicting field values', async () => {
-      const settings = createSettings('airtable-wins');
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       mockProvider.fetchRecord.mockResolvedValue({
@@ -105,7 +105,7 @@ describe('ConflictResolver', () => {
     });
 
     it('should not detect conflict when values are equal', async () => {
-      const settings = createSettings('airtable-wins');
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       mockProvider.fetchRecord.mockResolvedValue({
@@ -123,7 +123,7 @@ describe('ConflictResolver', () => {
     });
 
     it('should not detect conflict for new fields in obsidian', async () => {
-      const settings = createSettings('airtable-wins');
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       mockProvider.fetchRecord.mockResolvedValue({
@@ -141,7 +141,7 @@ describe('ConflictResolver', () => {
     });
 
     it('should propagate fetch errors to caller', async () => {
-      const settings = createSettings('airtable-wins');
+      const settings = createSettings('remote-wins');
       resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
       mockProvider.fetchRecord.mockRejectedValue(new Error('Network error'));
@@ -185,9 +185,9 @@ describe('ConflictResolver', () => {
       });
     });
 
-    describe('airtable-wins mode (CR-1.2)', () => {
+    describe('remote-wins mode (CR-1.2)', () => {
       it('should skip conflicted fields and sync non-conflicted fields only', async () => {
-        const settings = createSettings('airtable-wins');
+        const settings = createSettings('remote-wins');
         resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
         const conflicts = [createConflict('field1')];
@@ -211,7 +211,7 @@ describe('ConflictResolver', () => {
       });
 
       it('should return success without calling updateRecord if all fields conflicted', async () => {
-        const settings = createSettings('airtable-wins');
+        const settings = createSettings('remote-wins');
         resolver = new ConflictResolver(settings, mockProvider as unknown as DatabaseProvider);
 
         const conflicts = [createConflict('field1')];
@@ -249,7 +249,7 @@ describe('ConflictResolver', () => {
 
       expect(resolver.shouldSkipConflictDetection()).toBe(true);
 
-      const newSettings = createSettings('airtable-wins');
+      const newSettings = createSettings('remote-wins');
       resolver.updateSettings(newSettings);
 
       expect(resolver.shouldSkipConflictDetection()).toBe(false);

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -147,8 +147,8 @@ describe('SyncOrchestrator', () => {
   });
 
   describe('processSyncRequest — bidirectional', () => {
-    it('should execute two phases when autoSyncFormulas is true', async () => {
-      settings.autoSyncFormulas = true;
+    it('should execute two phases when autoSyncComputedFields is true', async () => {
+      settings.autoSyncComputedFields = true;
       settings.formulaSyncDelay = 0;
       orchestrator.updateSettings(settings);
 
@@ -175,8 +175,8 @@ describe('SyncOrchestrator', () => {
       expect(mockProvider.fetchNotes).toHaveBeenCalled();
     });
 
-    it('should skip phase 2 when autoSyncFormulas is false', async () => {
-      settings.autoSyncFormulas = false;
+    it('should skip phase 2 when autoSyncComputedFields is false', async () => {
+      settings.autoSyncComputedFields = false;
       orchestrator.updateSettings(settings);
 
       const file = createMockTFile('Sync/note.md');

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -95,7 +95,7 @@ const HELPERS = `
     const cfg = config || getConfig();
     const cred = getCredential(cfg);
     cfg.conflictResolution = mode;
-    if (autoFormula !== undefined) cfg.autoSyncFormulas = autoFormula;
+    if (autoFormula !== undefined) cfg.autoSyncComputedFields = autoFormula;
     getInstance(cfg).updateSettings(cfg, cred);
   }
 
@@ -459,11 +459,11 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count}` };
     });
 
-    await test('push / all / airtable-wins', async () => {
+    await test('push / all / remote-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
-        setMode('airtable-wins');
+        setMode('remote-wins');
         const file = app.vault.getAbstractFileByPath(getConfig().folderPath + '/E2E-Pull-Test.md');
         await modifyCount(file, 9999);
         await enqueueSync('push', 'all');
@@ -475,11 +475,11 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Count=${r.count} (expected 100)` };
     });
 
-    await test('push / current / airtable-wins', async () => {
+    await test('push / current / remote-wins', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
-        setMode('airtable-wins');
+        setMode('remote-wins');
         const file = await openAndActivate(getConfig().folderPath + '/E2E-Push-Test.md');
         await modifyCount(file, 7777);
         await enqueueSync('push', 'current');
@@ -508,7 +508,7 @@ async function test(name, fn) {
 
     // -- Bidirectional tests --
 
-    await test('bidirectional / all / autoSyncFormulas=true', async () => {
+    await test('bidirectional / all / autoSyncComputedFields=true', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
@@ -527,7 +527,7 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `localCal=${r.localCal}, airtableCal=${r.airtableCal}` };
     });
 
-    await test('bidirectional / all / autoSyncFormulas=false', async () => {
+    await test('bidirectional / all / autoSyncComputedFields=false', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
@@ -547,7 +547,7 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `push=${r.airtableCount}, cal=${r.localCal}(unchanged from ${r.oldCal})` };
     });
 
-    await test('bidirectional / current / autoSyncFormulas=true', async () => {
+    await test('bidirectional / current / autoSyncComputedFields=true', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
@@ -564,7 +564,7 @@ async function test(name, fn) {
       return { pass: r.pass, detail: `Cal=${r.localCal} (expected 246)` };
     });
 
-    await test('bidirectional / current / autoSyncFormulas=false', async () => {
+    await test('bidirectional / current / autoSyncComputedFields=false', async () => {
       await doReset();
       const r = await run(`(async () => {
         ${HELPERS}
@@ -593,7 +593,7 @@ async function test(name, fn) {
         const cfg = getConfig();
         const cred = getCredential();
 
-        const hasVersion = p.settings.version === 2;
+        const hasVersion = p.settings.version === 3;
         const hasConfigs = p.settings.configs.length >= 1;
         const hasCreds = p.settings.credentials.length >= 1;
         const hasBaseId = cfg.baseId && cfg.baseId.length > 0;
@@ -644,7 +644,7 @@ async function test(name, fn) {
           conflictResolution: 'manual',
           watchForChanges: false,
           fileWatchDebounce: 2000,
-          autoSyncFormulas: false,
+          autoSyncComputedFields: false,
           formulaSyncDelay: 3000,
           generateBasesFile: false,
           basesFileLocation: 'vault-root',

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -503,10 +503,10 @@ async function setConfigAndQuery(overrides) {
     await test('summary / sync — shows conflictResolution only when not watching', async () => {
       const infos = await setConfigAndQuery({
         baseId: 'appTEST', tableId: 'tblTEST',
-        bidirectionalSync: true, conflictResolution: 'airtable-wins', watchForChanges: false,
+        bidirectionalSync: true, conflictResolution: 'remote-wins', watchForChanges: false,
       });
       const card = infos.find(c => c.title === 'Bidirectional Sync');
-      const pass = card && card.summary === 'airtable-wins';
+      const pass = card && card.summary === 'remote-wins';
       return { pass, detail: `summary="${card?.summary}"` };
     });
 

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -7,8 +7,8 @@ import { describe, it, expect } from 'vitest';
 import { migrateSettings } from '../../src/utils/migration';
 
 describe('migrateSettings', () => {
-  it('should return null for v2 settings', () => {
-    const data = { version: 2, credentials: [], configs: [], activeConfigId: '', debugMode: false };
+  it('should return null for v3 settings (already current)', () => {
+    const data = { version: 3, credentials: [], configs: [], activeConfigId: '', debugMode: false };
     expect(migrateSettings(data)).toBeNull();
   });
 
@@ -17,100 +17,139 @@ describe('migrateSettings', () => {
     expect(migrateSettings(undefined)).toBeNull();
   });
 
-  it('should migrate legacy settings to v2', () => {
-    const legacy = {
-      apiKey: 'pat_xxx', baseId: 'app123', tableId: 'tbl456', viewId: 'viw789',
-      folderPath: 'Notes/', templatePath: '', syncInterval: 300, allowOverwrite: true,
-      filenameFieldName: 'Name', subfolderFieldName: '', bidirectionalSync: false,
-      conflictResolution: 'obsidian-wins', watchForChanges: false, fileWatchDebounce: 2000,
-      autoSyncFormulas: false, formulaSyncDelay: 3000, generateBasesFile: false,
-      basesFileLocation: 'vault-root', basesCustomPath: '', basesRegenerateOnSync: false,
-      debugMode: true,
-    };
+  describe('v1 (legacy flat) → v3', () => {
+    it('should migrate legacy single-config settings to v3 with renamed fields', () => {
+      const legacy = {
+        apiKey: 'pat_xxx', baseId: 'app123', tableId: 'tbl456', viewId: 'viw789',
+        folderPath: 'Notes/', templatePath: '', syncInterval: 300, allowOverwrite: true,
+        filenameFieldName: 'Name', subfolderFieldName: '', bidirectionalSync: false,
+        conflictResolution: 'obsidian-wins', watchForChanges: false, fileWatchDebounce: 2000,
+        autoSyncFormulas: false, formulaSyncDelay: 3000, generateBasesFile: false,
+        basesFileLocation: 'vault-root', basesCustomPath: '', basesRegenerateOnSync: false,
+        debugMode: true,
+      };
 
-    const result = migrateSettings(legacy);
-    expect(result).not.toBeNull();
-    expect(result!.version).toBe(2);
-    expect(result!.debugMode).toBe(true);
-    expect(result!.credentials).toHaveLength(1);
-    expect(result!.credentials[0].type).toBe('airtable');
-    expect(result!.credentials[0].apiKey).toBe('pat_xxx');
-    expect(result!.configs).toHaveLength(1);
-    expect(result!.configs[0].credentialId).toBe(result!.credentials[0].id);
-    expect(result!.configs[0].baseId).toBe('app123');
-    expect(result!.configs[0].enabled).toBe(true);
-    expect(result!.activeConfigId).toBe(result!.configs[0].id);
+      const result = migrateSettings(legacy);
+      expect(result).not.toBeNull();
+      expect(result!.version).toBe(3);
+      expect(result!.debugMode).toBe(true);
+      expect(result!.credentials).toHaveLength(1);
+      expect(result!.credentials[0].type).toBe('airtable');
+      expect(result!.configs).toHaveLength(1);
+      expect(result!.activeConfigId).toBe(result!.configs[0].id);
+    });
+
+    it('should handle empty apiKey', () => {
+      const legacy = {
+        apiKey: '', baseId: '', tableId: '', viewId: '', folderPath: '', templatePath: '',
+        syncInterval: 0, allowOverwrite: true, filenameFieldName: '', subfolderFieldName: '',
+        bidirectionalSync: false, conflictResolution: 'manual', watchForChanges: false,
+        fileWatchDebounce: 2000, autoSyncFormulas: false, formulaSyncDelay: 3000,
+        generateBasesFile: false, basesFileLocation: 'vault-root', basesCustomPath: '',
+        basesRegenerateOnSync: false, debugMode: false,
+      };
+      const result = migrateSettings(legacy);
+      expect(result).not.toBeNull();
+      expect(result!.version).toBe(3);
+    });
+
+    it('should generate unique ids for credential and config', () => {
+      const result = migrateSettings({ apiKey: 'key', baseId: 'base', tableId: 'tbl', viewId: '' });
+      expect(result).not.toBeNull();
+      expect(result!.credentials[0].id).toBeTruthy();
+      expect(result!.configs[0].id).toBeTruthy();
+      expect(result!.credentials[0].id).not.toBe(result!.configs[0].id);
+    });
+
+    it('should rename airtable-wins → remote-wins and autoSyncFormulas → autoSyncComputedFields', () => {
+      const legacy = {
+        apiKey: 'key', baseId: 'app_base', tableId: 'tbl_table', viewId: 'viw_view',
+        folderPath: 'MyNotes', templatePath: 'Templates/note.md', syncInterval: 600,
+        allowOverwrite: false, filenameFieldName: 'Title', subfolderFieldName: 'Category',
+        bidirectionalSync: true, conflictResolution: 'airtable-wins',
+        watchForChanges: true, fileWatchDebounce: 5000, autoSyncFormulas: true,
+        formulaSyncDelay: 1500, generateBasesFile: true, basesFileLocation: 'custom',
+        basesCustomPath: 'output/bases.md', basesRegenerateOnSync: true, debugMode: false,
+      };
+
+      const result = migrateSettings(legacy);
+      expect(result).not.toBeNull();
+      const config = result!.configs[0];
+      expect(config.conflictResolution).toBe('remote-wins');
+      expect(config.autoSyncComputedFields).toBe(true);
+      expect((config as Record<string, unknown>)['autoSyncFormulas']).toBeUndefined();
+      // sanity: other fields still mapped
+      expect(config.baseId).toBe('app_base');
+      expect(config.bidirectionalSync).toBe(true);
+      expect(config.basesCustomPath).toBe('output/bases.md');
+    });
   });
 
-  it('should handle empty apiKey', () => {
-    const legacy = {
-      apiKey: '', baseId: '', tableId: '', viewId: '', folderPath: '', templatePath: '',
-      syncInterval: 0, allowOverwrite: true, filenameFieldName: '', subfolderFieldName: '',
-      bidirectionalSync: false, conflictResolution: 'manual', watchForChanges: false,
-      fileWatchDebounce: 2000, autoSyncFormulas: false, formulaSyncDelay: 3000,
-      generateBasesFile: false, basesFileLocation: 'vault-root', basesCustomPath: '',
-      basesRegenerateOnSync: false, debugMode: false,
-    };
-    const result = migrateSettings(legacy);
-    expect(result).not.toBeNull();
-    expect(result!.credentials).toHaveLength(1);
-  });
+  describe('v2 → v3', () => {
+    it('should rename per-config fields and bump version', () => {
+      const v2 = {
+        version: 2,
+        credentials: [{ id: 'c1', name: 'AT', type: 'airtable', apiKey: 'k' }],
+        configs: [{
+          id: 'cfg1', name: 'Default', enabled: true, credentialId: 'c1',
+          baseId: 'b', tableId: 't', viewId: '', folderPath: 'F', templatePath: '',
+          filenameFieldName: '', subfolderFieldName: '', syncInterval: 0,
+          allowOverwrite: true, bidirectionalSync: true,
+          conflictResolution: 'airtable-wins',
+          watchForChanges: true, fileWatchDebounce: 2000,
+          autoSyncFormulas: true,
+          formulaSyncDelay: 1500, generateBasesFile: false,
+          basesFileLocation: 'vault-root', basesCustomPath: '', basesRegenerateOnSync: false,
+        }],
+        activeConfigId: 'cfg1',
+        debugMode: true,
+      };
 
-  it('should generate unique ids for credential and config', () => {
-    const legacy = { apiKey: 'key', baseId: 'base', tableId: 'tbl', viewId: '' };
-    const result = migrateSettings(legacy);
-    expect(result).not.toBeNull();
-    expect(result!.credentials[0].id).toBeTruthy();
-    expect(result!.configs[0].id).toBeTruthy();
-    expect(result!.credentials[0].id).not.toBe(result!.configs[0].id);
-  });
+      const result = migrateSettings(v2);
+      expect(result).not.toBeNull();
+      expect(result!.version).toBe(3);
+      expect(result!.activeConfigId).toBe('cfg1');
+      expect(result!.debugMode).toBe(true);
+      expect(result!.credentials).toHaveLength(1);
 
-  it('should correctly map all legacy config fields', () => {
-    const legacy = {
-      apiKey: 'key',
-      baseId: 'app_base',
-      tableId: 'tbl_table',
-      viewId: 'viw_view',
-      folderPath: 'MyNotes',
-      templatePath: 'Templates/note.md',
-      syncInterval: 600,
-      allowOverwrite: false,
-      filenameFieldName: 'Title',
-      subfolderFieldName: 'Category',
-      bidirectionalSync: true,
-      conflictResolution: 'airtable-wins',
-      watchForChanges: true,
-      fileWatchDebounce: 5000,
-      autoSyncFormulas: true,
-      formulaSyncDelay: 1500,
-      generateBasesFile: true,
-      basesFileLocation: 'custom',
-      basesCustomPath: 'output/bases.md',
-      basesRegenerateOnSync: true,
-      debugMode: false,
-    };
+      const cfg = result!.configs[0];
+      expect(cfg.id).toBe('cfg1');
+      expect(cfg.conflictResolution).toBe('remote-wins');
+      expect(cfg.autoSyncComputedFields).toBe(true);
+      expect((cfg as Record<string, unknown>)['autoSyncFormulas']).toBeUndefined();
+      // unchanged fields preserved
+      expect(cfg.bidirectionalSync).toBe(true);
+      expect(cfg.formulaSyncDelay).toBe(1500);
+    });
 
-    const result = migrateSettings(legacy);
-    expect(result).not.toBeNull();
-    const config = result!.configs[0];
-    expect(config.baseId).toBe('app_base');
-    expect(config.tableId).toBe('tbl_table');
-    expect(config.viewId).toBe('viw_view');
-    expect(config.folderPath).toBe('MyNotes');
-    expect(config.templatePath).toBe('Templates/note.md');
-    expect(config.syncInterval).toBe(600);
-    expect(config.allowOverwrite).toBe(false);
-    expect(config.filenameFieldName).toBe('Title');
-    expect(config.subfolderFieldName).toBe('Category');
-    expect(config.bidirectionalSync).toBe(true);
-    expect(config.conflictResolution).toBe('airtable-wins');
-    expect(config.watchForChanges).toBe(true);
-    expect(config.fileWatchDebounce).toBe(5000);
-    expect(config.autoSyncFormulas).toBe(true);
-    expect(config.formulaSyncDelay).toBe(1500);
-    expect(config.generateBasesFile).toBe(true);
-    expect(config.basesFileLocation).toBe('custom');
-    expect(config.basesCustomPath).toBe('output/bases.md');
-    expect(config.basesRegenerateOnSync).toBe(true);
+    it('preserves non-airtable-wins conflict modes unchanged', () => {
+      for (const mode of ['obsidian-wins', 'manual'] as const) {
+        const v2 = {
+          version: 2,
+          credentials: [],
+          configs: [{ id: 'c', name: 'n', enabled: true, credentialId: '',
+            baseId: '', tableId: '', viewId: '', folderPath: '', templatePath: '',
+            filenameFieldName: '', subfolderFieldName: '', syncInterval: 0,
+            allowOverwrite: true, bidirectionalSync: false,
+            conflictResolution: mode,
+            watchForChanges: false, fileWatchDebounce: 2000,
+            autoSyncFormulas: false, formulaSyncDelay: 1500,
+            generateBasesFile: false, basesFileLocation: 'vault-root',
+            basesCustomPath: '', basesRegenerateOnSync: false }],
+          activeConfigId: '', debugMode: false,
+        };
+        const result = migrateSettings(v2);
+        expect(result!.configs[0].conflictResolution).toBe(mode);
+      }
+    });
+
+    it('falls back to manual for unknown conflictResolution values', () => {
+      const v2 = {
+        version: 2, credentials: [], configs: [{ conflictResolution: 'garbage' }],
+        activeConfigId: '', debugMode: false,
+      };
+      const result = migrateSettings(v2);
+      expect(result!.configs[0].conflictResolution).toBe('manual');
+    });
   });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -23,7 +23,7 @@ function makeConfig(overrides: Partial<ConfigEntry> & { id: string; name: string
     conflictResolution: 'manual',
     watchForChanges: false,
     fileWatchDebounce: 2000,
-    autoSyncFormulas: false,
+    autoSyncComputedFields: false,
     formulaSyncDelay: 3000,
     generateBasesFile: false,
     basesFileLocation: 'vault-root',


### PR DESCRIPTION
## Summary
PR #62 (#59) deferred된 사용자 설정 필드명 정리. 두 항목 모두 Airtable 용어를 노출하던 것을 provider-agnostic하게 변경. settings.json 데이터 모델이 변경되므로 **v2 → v3 마이그레이션** 동반.

## Renames

| Field | v2 | v3 |
|---|---|---|
| `ConflictResolutionMode` value | `'airtable-wins'` | `'remote-wins'` |
| `ConfigEntry` / `LegacySettings` field | `autoSyncFormulas: boolean` | `autoSyncComputedFields: boolean` |
| `AutoNoteImporterSettings.version` | `2` | `3` |

## Settings UI labels (`src/ui/settings-tab.ts`)

| Before | After |
|---|---|
| "Obsidian wins (overwrite Airtable)" | "Obsidian wins (overwrite remote)" |
| "Airtable wins (overwrite Obsidian)" | "Remote wins (overwrite Obsidian)" |
| "Auto-sync formulas and relations" | "Auto-sync server-computed fields" |
| "Automatically fetch computed formula and relation results after syncing." | "Automatically fetch fields the remote computes server-side (formulas, lookups, rollups, generated columns) after each sync." |
| "Formula sync delay" | "Computed-field sync delay" |
| "How long to wait for Airtable to compute formulas before fetching." | "How long to wait for the remote to compute fields before fetching." |

## Migration (`src/utils/migration.ts`)

기존 v1 → v2 변환을 v1 → v3 직접 변환으로 통합하고, v2 → v3 변환 패스 추가.

- `migrateConflictResolution()`: `'airtable-wins'` → `'remote-wins'` 매핑. 다른 모드(`obsidian-wins` / `manual`)는 그대로 보존. 알 수 없는 값은 fail-safe `'manual'` 폴백.
- `readAutoSyncComputedFields()`: 새 필드명 우선 읽되 v2 필드명도 호환 (partial migration 상태 안전).
- v3가 이미 적용된 데이터는 `null` 반환 (no-op).
- One-way migration: 한 번 v3로 저장되면 옛 필드명(`autoSyncFormulas`)은 제거됨.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run` — **411 / 411 passed** (3 신규 migration 테스트: v2→v3 변환, conflict mode 보존, garbage 값 fallback)
- [x] **실제 Obsidian e2e 16/16 PASS** — v2 데이터(autoSyncFormulas: false)를 가진 vault에서 plugin reload 시 자동 v3 마이그레이션 직접 확인:
  - version: 2 → 3
  - autoSyncFormulas 제거
  - autoSyncComputedFields 추가 (값 보존)
  - conflictResolution 'manual' 보존
- [x] Sync tags moved to HEAD (`test-sync` + `handbook-sync` → `ce4aab9`)

## Migration safety
- v2 → v3 변환은 plugin onload의 `migrateSettings()`에서 자동 실행되고 결과를 `saveData()`로 영구화 (CLAUDE.md §9.9 패턴)
- 데이터 손실 없음: 모든 값은 새 필드로 매핑되어 보존
- v2 필드를 직접 읽는 코드는 모두 v3 필드로 갱신됨 (orchestrator, conflict-resolver, config-instance, settings-tab, validation)
- E2E의 `multi-config / migration preserves settings` 테스트에서 version=3 보존 + 모든 필드 무손실 검증

## Breaking change scope
- 사용자에게 **투명함** — 마이그레이션 자동 실행, UI도 새 라벨로 자연스럽게 표시
- 직접 settings.json을 편집하던 외부 도구가 있다면 새 필드명으로 갱신 필요 (현재 없음)

## Out of scope (별도 이슈로 추적 가능)
- `formulaSyncDelay` 필드명 — Airtable formula 용어 잔존이지만 본 이슈 명시 범위 밖
- 노트 콘텐츠 마커 `<!-- Content imported from Airtable -->` — 기존 노트 backward compat 영향 있어 별도 디자인 고려

Closes #64