### PR TITLE
refactor: post-merge /simplify cleanup + handbook updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { ConfigManager } from './core';
 import { FrontmatterParser } from './file-operations';
 import { AutoNoteImporterSettingTab } from './ui';
 import { migrateSettings } from './utils/migration';
-import { findCredentialForConfig } from './utils';
+import { findCredentialForConfig, findConfigById, buildCredentialIndex } from './utils';
 
 /**
  * Main plugin class for Auto Note Importer.
@@ -68,10 +68,11 @@ export default class AutoNoteImporterPlugin extends Plugin {
     this.commandFingerprint = this.getCommandFingerprint();
   }
 
-  private getCommandFingerprint(): string {
+  private getCommandFingerprint(credIndex?: Map<string, { type: string }>): string {
+    const index = credIndex ?? buildCredentialIndex(this.settings);
     return this.settings.configs
       .map(c => {
-        const credType = findCredentialForConfig(this.settings, c)?.type ?? '';
+        const credType = index.get(c.credentialId)?.type ?? '';
         return `${c.id}:${c.name}:${c.enabled}:${c.bidirectionalSync}:${credType}`;
       })
       .join('|');
@@ -116,15 +117,12 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
   /**
    * Registers sync commands for a single config entry.
-   * Uses checkCallback with dynamic lookup to avoid capturing stale references.
-   * Command names include the provider label derived from the linked credential type.
+   * Configs with an orphaned credentialId register no commands; they recover
+   * automatically when a credential is linked (fingerprint changes → re-register).
    */
   private registerCommandsForConfig(config: ConfigEntry): void {
     const configId = config.id;
     const credential = findCredentialForConfig(this.settings, config);
-    // Configs with an orphaned credentialId register no commands. Recovery is automatic
-    // when a credential is (re-)linked: saveSettings() detects the fingerprint change
-    // and triggers reregisterAllCommands().
     if (!credential) return;
     const providerLabel = CREDENTIAL_TYPE_LABELS[credential.type];
     const suffix = ` \u2014 ${config.name}`;
@@ -133,7 +131,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `sync-pull-${configId}`,
       name: `Sync current note from ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled) return false;
         if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('pull', 'current');
@@ -145,7 +143,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `sync-pull-all-${configId}`,
       name: `Sync all notes from ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('pull', 'all');
         return true;
@@ -156,7 +154,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `sync-push-current-${configId}`,
       name: `Sync current note to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'current');
@@ -168,7 +166,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `sync-push-modified-${configId}`,
       name: `Sync modified notes to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'modified');
         return true;
@@ -179,7 +177,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `sync-push-all-${configId}`,
       name: `Sync all notes to ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('push', 'all');
         return true;
@@ -190,7 +188,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `bidirectional-sync-current-${configId}`,
       name: `Bidirectional sync current note with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!this.isActiveFileInConfigFolder(cfg)) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'current');
@@ -202,7 +200,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `bidirectional-sync-modified-${configId}`,
       name: `Bidirectional sync modified notes with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'modified');
         return true;
@@ -213,7 +211,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       id: `bidirectional-sync-all-${configId}`,
       name: `Bidirectional sync all notes with ${providerLabel}${suffix}`,
       checkCallback: (checking) => {
-        const cfg = this.settings.configs.find(c => c.id === configId);
+        const cfg = findConfigById(this.settings, configId);
         if (!cfg?.enabled || !cfg.bidirectionalSync) return false;
         if (!checking) this.configManager.getInstance(configId)?.enqueueSyncRequest('bidirectional', 'all');
         return true;
@@ -244,8 +242,9 @@ export default class AutoNoteImporterPlugin extends Plugin {
       }
     }
 
+    const credIndex = buildCredentialIndex(this.settings);
     for (const config of this.settings.configs) {
-      const credential = findCredentialForConfig(this.settings, config);
+      const credential = credIndex.get(config.credentialId);
       if (credential) {
         this.configManager.updateConfig(config.id, config, credential);
       } else {
@@ -253,7 +252,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
       }
     }
 
-    const newFingerprint = this.getCommandFingerprint();
+    const newFingerprint = this.getCommandFingerprint(credIndex);
     if (this.commandFingerprint !== newFingerprint) {
       this.commandFingerprint = newFingerprint;
       this.reregisterAllCommands();

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -1,5 +1,7 @@
 /**
  * Configuration entry type definitions for multi-config support.
+ *
+ * @handbook 9.8-multi-config-architecture
  */
 
 import type { ConflictResolutionMode, BasesFileLocation } from './settings.types';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,4 +16,9 @@ export {
   generateId,
 } from './object-utils';
 
-export { buildLegacySettings, findCredentialForConfig } from './settings-bridge';
+export {
+  buildLegacySettings,
+  findCredentialForConfig,
+  findConfigById,
+  buildCredentialIndex,
+} from './settings-bridge';

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -159,8 +159,12 @@ function buildCredentialFromRecord(raw: Record<string, unknown>): Credential | u
         authValue: readString(raw, 'authValue', ''),
       };
     default: {
-      const _exhaustive: never = type as CredentialType as never;
-      throw new Error(`Unknown credential type: ${_exhaustive}`);
+      // Unreachable at runtime — guarded by the `CREDENTIAL_TYPES.includes(type)` check
+      // above. Exists purely as a compile-time exhaustiveness check: adding a new
+      // CredentialType variant without a case here will be caught by tsc.
+      const _exhaustive: never = type as never;
+      void _exhaustive;
+      return undefined;
     }
   }
 }

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -159,9 +159,7 @@ function buildCredentialFromRecord(raw: Record<string, unknown>): Credential | u
         authValue: readString(raw, 'authValue', ''),
       };
     default: {
-      // Unreachable at runtime — guarded by the `CREDENTIAL_TYPES.includes(type)` check
-      // above. Exists purely as a compile-time exhaustiveness check: adding a new
-      // CredentialType variant without a case here will be caught by tsc.
+      // Compile-time exhaustiveness guard — unreachable at runtime (CREDENTIAL_TYPES.includes guards above).
       const _exhaustive: never = type as never;
       void _exhaustive;
       return undefined;

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -5,7 +5,8 @@
  * @tested tests/utils/migration.test.ts
  */
 
-import type { Credential } from '../types/credential.types';
+import type { Credential, CredentialType } from '../types/credential.types';
+import { CREDENTIAL_TYPES } from '../types/credential.types';
 import type { ConfigEntry } from '../types/config.types';
 import type { AutoNoteImporterSettings, ConflictResolutionMode } from '../types/settings.types';
 import { generateId } from './object-utils';
@@ -109,9 +110,67 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function readString(record: Record<string, unknown>, key: string, fallback: string): string {
+  const v = record[key];
+  return typeof v === 'string' ? v : fallback;
+}
+
+/**
+ * Builds a typed `Credential` from a raw record. Returns `undefined` if the
+ * record cannot be safely interpreted as one of the discriminated-union variants
+ * (e.g., missing/unknown `type`, missing `id`). The caller filters undefined out.
+ *
+ * Mirrors `buildConfigFromRecord`'s per-field fallback discipline so a
+ * malformed credential like `{ id: 123, name: null }` cannot reach runtime
+ * with wrong types.
+ */
+function buildCredentialFromRecord(raw: Record<string, unknown>): Credential | undefined {
+  const id = raw['id'];
+  if (typeof id !== 'string' || id.length === 0) return undefined;
+
+  const type = raw['type'];
+  if (typeof type !== 'string' || !(CREDENTIAL_TYPES as readonly string[]).includes(type)) {
+    return undefined;
+  }
+
+  const base = { id, name: readString(raw, 'name', '') };
+  switch (type as CredentialType) {
+    case 'airtable':
+      return { ...base, type: 'airtable', apiKey: readString(raw, 'apiKey', '') };
+    case 'seatable':
+      return {
+        ...base, type: 'seatable',
+        apiToken: readString(raw, 'apiToken', ''),
+        serverUrl: readString(raw, 'serverUrl', ''),
+      };
+    case 'supabase':
+      return {
+        ...base, type: 'supabase',
+        projectUrl: readString(raw, 'projectUrl', ''),
+        apiKey: readString(raw, 'apiKey', ''),
+      };
+    case 'notion':
+      return { ...base, type: 'notion', integrationToken: readString(raw, 'integrationToken', '') };
+    case 'custom-api':
+      return {
+        ...base, type: 'custom-api',
+        baseUrl: readString(raw, 'baseUrl', ''),
+        authHeader: readString(raw, 'authHeader', ''),
+        authValue: readString(raw, 'authValue', ''),
+      };
+    default: {
+      const _exhaustive: never = type as CredentialType as never;
+      throw new Error(`Unknown credential type: ${_exhaustive}`);
+    }
+  }
+}
+
 function migrateV2toV3(record: Record<string, unknown>): AutoNoteImporterSettings {
   const credentials = Array.isArray(record['credentials'])
-    ? (record['credentials'] as unknown[]).filter(isPlainRecord) as unknown as Credential[]
+    ? (record['credentials'] as unknown[])
+        .filter(isPlainRecord)
+        .map(buildCredentialFromRecord)
+        .filter((c): c is Credential => c !== undefined)
     : [];
   const rawConfigs = Array.isArray(record['configs'])
     ? (record['configs'] as unknown[]).filter(isPlainRecord)

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -23,7 +23,6 @@ function migrateConflictResolution(value: unknown): ConflictResolutionMode {
     return value as ConflictResolutionMode;
   }
   // v2 → v3 rename
-
   if (value === 'airtable-wins') {
     return 'remote-wins';
   }
@@ -106,9 +105,17 @@ function buildConfigFromRecord(
   };
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function migrateV2toV3(record: Record<string, unknown>): AutoNoteImporterSettings {
-  const credentials = Array.isArray(record['credentials']) ? record['credentials'] as Credential[] : [];
-  const rawConfigs = Array.isArray(record['configs']) ? record['configs'] as Record<string, unknown>[] : [];
+  const credentials = Array.isArray(record['credentials'])
+    ? (record['credentials'] as unknown[]).filter(isPlainRecord) as unknown as Credential[]
+    : [];
+  const rawConfigs = Array.isArray(record['configs'])
+    ? (record['configs'] as unknown[]).filter(isPlainRecord)
+    : [];
 
   const configs = rawConfigs.map(cfg => buildConfigFromRecord(cfg, generateId()));
 

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -12,14 +12,18 @@ import { generateId } from './object-utils';
 
 const CURRENT_VERSION = 3 as const;
 
+const VALID_CONFLICT_MODES: readonly ConflictResolutionMode[] = ['obsidian-wins', 'remote-wins', 'manual'];
+
 /**
  * Normalizes a possibly-legacy conflictResolution value to the current `ConflictResolutionMode`.
  * v2 used `'airtable-wins'`; v3 uses `'remote-wins'`. Unknown values fall back to `'manual'`.
  */
 function migrateConflictResolution(value: unknown): ConflictResolutionMode {
-  if (value === 'obsidian-wins' || value === 'remote-wins' || value === 'manual') {
-    return value;
+  if (typeof value === 'string' && (VALID_CONFLICT_MODES as readonly string[]).includes(value)) {
+    return value as ConflictResolutionMode;
   }
+  // v2 → v3 rename
+
   if (value === 'airtable-wins') {
     return 'remote-wins';
   }
@@ -41,7 +45,8 @@ function readAutoSyncComputedFields(record: Record<string, unknown>, fallback: b
  * Migrates settings data to the current version.
  *
  * - Returns null for null/undefined input (fresh install, no migration needed).
- * - Returns null if data is already at the current version.
+ * - Returns null if data is already at the current version OR a future version
+ *   (downgrades are refused; caller falls back to defaults to avoid corruption).
  * - v2 → v3: rename `autoSyncFormulas` → `autoSyncComputedFields` and `airtable-wins` → `remote-wins` per config; bump version.
  * - v1 / unknown → v3: convert flat legacy single-config layout to multi-config with current field names.
  *
@@ -54,29 +59,58 @@ export function migrateSettings(data: unknown): AutoNoteImporterSettings | null 
   }
 
   const record = data as Record<string, unknown>;
+  const versionRaw = record['version'];
+  const version = typeof versionRaw === 'number' ? versionRaw : 0;
 
-  if (record['version'] === CURRENT_VERSION) {
+  if (version >= CURRENT_VERSION) {
     return null;
   }
 
-  if (record['version'] === 2) {
+  if (version === 2) {
     return migrateV2toV3(record);
   }
 
   return migrateLegacyToV3(record);
 }
 
+function buildConfigFromRecord(
+  raw: Record<string, unknown>,
+  fallbackId: string,
+): ConfigEntry {
+  return {
+    id: typeof raw['id'] === 'string' ? raw['id'] : fallbackId,
+    name: typeof raw['name'] === 'string' ? raw['name'] : 'Default',
+    enabled: typeof raw['enabled'] === 'boolean' ? raw['enabled'] : true,
+    credentialId: typeof raw['credentialId'] === 'string' ? raw['credentialId'] : '',
+    baseId: typeof raw['baseId'] === 'string' ? raw['baseId'] : '',
+    tableId: typeof raw['tableId'] === 'string' ? raw['tableId'] : '',
+    viewId: typeof raw['viewId'] === 'string' ? raw['viewId'] : '',
+    folderPath: typeof raw['folderPath'] === 'string' ? raw['folderPath'] : '',
+    templatePath: typeof raw['templatePath'] === 'string' ? raw['templatePath'] : '',
+    filenameFieldName: typeof raw['filenameFieldName'] === 'string' ? raw['filenameFieldName'] : '',
+    subfolderFieldName: typeof raw['subfolderFieldName'] === 'string' ? raw['subfolderFieldName'] : '',
+    syncInterval: typeof raw['syncInterval'] === 'number' ? raw['syncInterval'] : 0,
+    allowOverwrite: typeof raw['allowOverwrite'] === 'boolean' ? raw['allowOverwrite'] : true,
+    bidirectionalSync: typeof raw['bidirectionalSync'] === 'boolean' ? raw['bidirectionalSync'] : false,
+    conflictResolution: migrateConflictResolution(raw['conflictResolution']),
+    watchForChanges: typeof raw['watchForChanges'] === 'boolean' ? raw['watchForChanges'] : false,
+    fileWatchDebounce: typeof raw['fileWatchDebounce'] === 'number' ? raw['fileWatchDebounce'] : 2000,
+    autoSyncComputedFields: readAutoSyncComputedFields(raw, false),
+    formulaSyncDelay: typeof raw['formulaSyncDelay'] === 'number' ? raw['formulaSyncDelay'] : 1500,
+    generateBasesFile: typeof raw['generateBasesFile'] === 'boolean' ? raw['generateBasesFile'] : false,
+    basesFileLocation: (raw['basesFileLocation'] === 'synced-folder' || raw['basesFileLocation'] === 'custom')
+      ? raw['basesFileLocation']
+      : 'vault-root',
+    basesCustomPath: typeof raw['basesCustomPath'] === 'string' ? raw['basesCustomPath'] : '',
+    basesRegenerateOnSync: typeof raw['basesRegenerateOnSync'] === 'boolean' ? raw['basesRegenerateOnSync'] : false,
+  };
+}
+
 function migrateV2toV3(record: Record<string, unknown>): AutoNoteImporterSettings {
   const credentials = Array.isArray(record['credentials']) ? record['credentials'] as Credential[] : [];
   const rawConfigs = Array.isArray(record['configs']) ? record['configs'] as Record<string, unknown>[] : [];
 
-  const configs = rawConfigs.map(cfg => {
-    const next: Record<string, unknown> = { ...cfg };
-    next['conflictResolution'] = migrateConflictResolution(cfg['conflictResolution']);
-    next['autoSyncComputedFields'] = readAutoSyncComputedFields(cfg, false);
-    delete next['autoSyncFormulas'];
-    return next as unknown as ConfigEntry;
-  });
+  const configs = rawConfigs.map(cfg => buildConfigFromRecord(cfg, generateId()));
 
   return {
     version: CURRENT_VERSION,
@@ -98,33 +132,7 @@ function migrateLegacyToV3(record: Record<string, unknown>): AutoNoteImporterSet
     apiKey: typeof record['apiKey'] === 'string' ? record['apiKey'] : '',
   };
 
-  const config: ConfigEntry = {
-    id: configId,
-    name: 'Default',
-    enabled: true,
-    credentialId,
-    baseId: typeof record['baseId'] === 'string' ? record['baseId'] : '',
-    tableId: typeof record['tableId'] === 'string' ? record['tableId'] : '',
-    viewId: typeof record['viewId'] === 'string' ? record['viewId'] : '',
-    folderPath: typeof record['folderPath'] === 'string' ? record['folderPath'] : '',
-    templatePath: typeof record['templatePath'] === 'string' ? record['templatePath'] : '',
-    filenameFieldName: typeof record['filenameFieldName'] === 'string' ? record['filenameFieldName'] : '',
-    subfolderFieldName: typeof record['subfolderFieldName'] === 'string' ? record['subfolderFieldName'] : '',
-    syncInterval: typeof record['syncInterval'] === 'number' ? record['syncInterval'] : 0,
-    allowOverwrite: typeof record['allowOverwrite'] === 'boolean' ? record['allowOverwrite'] : true,
-    bidirectionalSync: typeof record['bidirectionalSync'] === 'boolean' ? record['bidirectionalSync'] : false,
-    conflictResolution: migrateConflictResolution(record['conflictResolution']),
-    watchForChanges: typeof record['watchForChanges'] === 'boolean' ? record['watchForChanges'] : false,
-    fileWatchDebounce: typeof record['fileWatchDebounce'] === 'number' ? record['fileWatchDebounce'] : 2000,
-    autoSyncComputedFields: readAutoSyncComputedFields(record, false),
-    formulaSyncDelay: typeof record['formulaSyncDelay'] === 'number' ? record['formulaSyncDelay'] : 1500,
-    generateBasesFile: typeof record['generateBasesFile'] === 'boolean' ? record['generateBasesFile'] : false,
-    basesFileLocation: (record['basesFileLocation'] === 'synced-folder' || record['basesFileLocation'] === 'custom')
-      ? record['basesFileLocation']
-      : 'vault-root',
-    basesCustomPath: typeof record['basesCustomPath'] === 'string' ? record['basesCustomPath'] : '',
-    basesRegenerateOnSync: typeof record['basesRegenerateOnSync'] === 'boolean' ? record['basesRegenerateOnSync'] : false,
-  };
+  const config: ConfigEntry = buildConfigFromRecord({ ...record, id: configId, name: 'Default', credentialId }, configId);
 
   return {
     version: CURRENT_VERSION,

--- a/src/utils/settings-bridge.ts
+++ b/src/utils/settings-bridge.ts
@@ -37,3 +37,23 @@ export function findCredentialForConfig(
 ): Credential | undefined {
   return settings.credentials.find(c => c.id === config.credentialId);
 }
+
+/**
+ * Looks up a config by id. Returns `undefined` if not found.
+ */
+export function findConfigById(
+  settings: AutoNoteImporterSettings,
+  configId: string,
+): ConfigEntry | undefined {
+  return settings.configs.find(c => c.id === configId);
+}
+
+/**
+ * Builds a `Map<credentialId, Credential>` for O(1) lookups when iterating configs.
+ * Call once at the top of a settings-traversing operation and reuse.
+ */
+export function buildCredentialIndex(
+  settings: AutoNoteImporterSettings,
+): Map<string, Credential> {
+  return new Map(settings.credentials.map(c => [c.id, c]));
+}

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -152,6 +152,37 @@ describe('migrateSettings', () => {
       expect(result!.configs[0].conflictResolution).toBe('manual');
     });
 
+    it('drops malformed credentials and preserves valid variants', () => {
+      const v2 = {
+        version: 2,
+        credentials: [
+          // valid airtable
+          { id: 'c1', name: 'Air', type: 'airtable', apiKey: 'k' },
+          // valid notion (missing optional name → empty)
+          { id: 'c2', type: 'notion', integrationToken: 'tok' },
+          // valid seatable (missing serverUrl → empty fallback)
+          { id: 'c3', name: 'Sea', type: 'seatable', apiToken: 't' },
+          // missing id → dropped
+          { name: 'no-id', type: 'airtable', apiKey: 'x' },
+          // unknown type → dropped
+          { id: 'c5', name: 'bad', type: 'unknown-provider' },
+          // numeric id → dropped (type narrowing rejects)
+          { id: 99, name: 'numeric', type: 'airtable', apiKey: 'x' },
+        ],
+        configs: [],
+        activeConfigId: '', debugMode: false,
+      };
+      const result = migrateSettings(v2);
+      expect(result!.credentials).toHaveLength(3);
+      const ids = result!.credentials.map(c => c.id);
+      expect(ids).toEqual(['c1', 'c2', 'c3']);
+      // Defaults applied for missing fields
+      const c2 = result!.credentials.find(c => c.id === 'c2')!;
+      expect(c2.name).toBe('');
+      const c3 = result!.credentials.find(c => c.id === 'c3') as { type: 'seatable'; serverUrl: string };
+      expect(c3.serverUrl).toBe('');
+    });
+
     it('drops null/non-object elements inside a valid configs array', () => {
       const v2 = {
         version: 2,

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -152,6 +152,19 @@ describe('migrateSettings', () => {
       expect(result!.configs[0].conflictResolution).toBe('manual');
     });
 
+    it('drops null/non-object elements inside a valid configs array', () => {
+      const v2 = {
+        version: 2,
+        credentials: [],
+        configs: [null, 42, { id: 'c1', name: 'real', credentialId: '' }, undefined],
+        activeConfigId: '', debugMode: false,
+      };
+      const result = migrateSettings(v2);
+      expect(result!.configs).toHaveLength(1);
+      expect(result!.configs[0].id).toBe('c1');
+      expect(result!.configs[0].name).toBe('real');
+    });
+
     it('treats malformed configs/credentials arrays as empty', () => {
       const v2 = {
         version: 2,

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -151,5 +151,35 @@ describe('migrateSettings', () => {
       const result = migrateSettings(v2);
       expect(result!.configs[0].conflictResolution).toBe('manual');
     });
+
+    it('treats malformed configs/credentials arrays as empty', () => {
+      const v2 = {
+        version: 2,
+        credentials: null,
+        configs: 'not-an-array',
+        activeConfigId: '', debugMode: false,
+      };
+      const result = migrateSettings(v2);
+      expect(result!.version).toBe(3);
+      expect(result!.credentials).toEqual([]);
+      expect(result!.configs).toEqual([]);
+    });
+
+    it('defaults autoSyncComputedFields to false when both v2 and v3 fields are absent', () => {
+      const v2 = {
+        version: 2, credentials: [],
+        configs: [{ id: 'c', name: 'n', credentialId: '' }],
+        activeConfigId: '', debugMode: false,
+      };
+      const result = migrateSettings(v2);
+      expect(result!.configs[0].autoSyncComputedFields).toBe(false);
+    });
+  });
+
+  describe('future-version safety', () => {
+    it('returns null for version > current (refuses to downgrade)', () => {
+      const v99 = { version: 99, credentials: [], configs: [], activeConfigId: '', debugMode: false };
+      expect(migrateSettings(v99)).toBeNull();
+    });
   });
 });

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -162,10 +162,14 @@ describe('migrateSettings', () => {
           { id: 'c2', type: 'notion', integrationToken: 'tok' },
           // valid seatable (missing serverUrl → empty fallback)
           { id: 'c3', name: 'Sea', type: 'seatable', apiToken: 't' },
+          // valid supabase
+          { id: 'c4', name: 'Sup', type: 'supabase', projectUrl: 'https://x.supabase.co', apiKey: 'anon' },
+          // valid custom-api (missing authValue → empty fallback)
+          { id: 'c5', name: 'Custom', type: 'custom-api', baseUrl: 'https://api.test', authHeader: 'X-API-Key' },
           // missing id → dropped
           { name: 'no-id', type: 'airtable', apiKey: 'x' },
           // unknown type → dropped
-          { id: 'c5', name: 'bad', type: 'unknown-provider' },
+          { id: 'c-bad', name: 'bad', type: 'unknown-provider' },
           // numeric id → dropped (type narrowing rejects)
           { id: 99, name: 'numeric', type: 'airtable', apiKey: 'x' },
         ],
@@ -173,14 +177,20 @@ describe('migrateSettings', () => {
         activeConfigId: '', debugMode: false,
       };
       const result = migrateSettings(v2);
-      expect(result!.credentials).toHaveLength(3);
+      expect(result!.credentials).toHaveLength(5);
       const ids = result!.credentials.map(c => c.id);
-      expect(ids).toEqual(['c1', 'c2', 'c3']);
-      // Defaults applied for missing fields
+      expect(ids).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
+      // Defaults applied for missing fields across all variants
       const c2 = result!.credentials.find(c => c.id === 'c2')!;
       expect(c2.name).toBe('');
       const c3 = result!.credentials.find(c => c.id === 'c3') as { type: 'seatable'; serverUrl: string };
       expect(c3.serverUrl).toBe('');
+      const c4 = result!.credentials.find(c => c.id === 'c4') as { type: 'supabase'; projectUrl: string; apiKey: string };
+      expect(c4.projectUrl).toBe('https://x.supabase.co');
+      expect(c4.apiKey).toBe('anon');
+      const c5 = result!.credentials.find(c => c.id === 'c5') as { type: 'custom-api'; baseUrl: string; authHeader: string; authValue: string };
+      expect(c5.authValue).toBe('');
+      expect(c5.authHeader).toBe('X-API-Key');
     });
 
     it('drops null/non-object elements inside a valid configs array', () => {


### PR DESCRIPTION
## Summary
오늘 머지된 5개 PR (#62 #67 #68 #69 #70)의 net diff에 대한 **/simplify 3-agent 리뷰** + **/create-handbook 표준 대비 핸드북 audit** 결과를 반영.

## 1. /simplify 결과 적용

### Reuse — `findConfigById` + `buildCredentialIndex` 헬퍼 추출
- 8개 `addCommand` checkCallback이 동일한 `configs.find(c => c.id === configId)` 패턴 → `findConfigById(settings, id)` 헬퍼로 통일
- `saveSettings`가 `updateConfig` 루프(N개 config × M credentials)와 `getCommandFingerprint`에서 동일한 credential 검색을 두 번 반복 → `buildCredentialIndex(settings)` 1회 빌드 후 두 곳에서 공유. O(N×M) → O(N+M).
- `getCommandFingerprint(credIndex?)` optional 파라미터 패턴 — 외부 호출 시 fallback build, 효율 호출 시 재사용

### Quality — Migration 강건성
- `migrateV2toV3`의 `as unknown as ConfigEntry` 더블 캐스트 제거 → `buildConfigFromRecord(raw, fallbackId)` shared builder로 명시적 필드별 type-safe 추출. v2 path와 legacy path 모두 동일한 fallback 의미로 통일.
- `version >= CURRENT_VERSION` 가드 추가 (Quality #2: future-version downgrade 방지). v4+ 데이터를 만나면 `null` 반환해 caller가 default로 폴백 — corruption 회피.
- `migrateConflictResolution` 검증을 `VALID_CONFLICT_MODES` const 배열 + `includes()`로 (Quality #9: `a || b || c` 체인 대비 grep-friendly. 새 모드 추가 시 한 줄로 추적 가능).

### Quality — 코멘트 슬림화
- `registerCommandsForConfig` JSDoc 5줄 narrating → 2줄로. `getCommandFingerprint` 내부 동작에 대한 결합도 누설 단락 제거.

## 2. 새 robustness 테스트 (Quality #8)
| Case | Coverage |
|---|---|
| v2 doc with `configs: 'not-an-array'` and `credentials: null` | 빈 배열로 처리, version=3 |
| v2 doc with no `autoSyncFormulas` and no `autoSyncComputedFields` | `false` 폴백 |
| `version: 99` (future) | `migrateSettings` returns `null` (downgrade refused) |

## 3. 핸드북 audit + 업데이트 (private docs)

### Audit 결과 (vs `/create-handbook` 표준)
| 항목 | 표준 | 현재 | 평가 |
|---|---|---|---|
| 프로젝트 규모 | Medium (44 src files) | 핸드북 1163줄 | ~800줄 목표 +45% — 풍부한 패턴 정당 |
| Forward marker coverage | ~100% | 35/44 (79%) | 9 미마커 모두 barrel/index 정당 제외 → **실제 갭 0건** |
| 마커 네이밍 | `X.Y-slug` | 모두 부합 ✓ | |
| 섹션 크기 임계 | 400줄 | §9 = 434줄 (5-8% over) | 보더라인 — 500줄 도달 시 split |

### 핸드북 변경 (private docs repo에서 별도 commit 필요)
- §9.4: example을 `findConfigById` 사용으로 갱신, narrating 코멘트 트림
- §9.8: 새 헬퍼 (`findConfigById`, `buildCredentialIndex`) 표로 문서화 + fingerprint optional 파라미터 패턴
- §9.9: version 가드, `buildConfigFromRecord` shared builder, `VALID_CONFLICT_MODES` 패턴 명시

### Forward marker 갭 해소
- `src/types/config.types.ts`: `@handbook 9.8-multi-config-architecture` 마커 추가 (audit에서 발견)

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run` — **414 / 414 passed** (3 신규 robustness 테스트)
- [x] **실제 Obsidian e2e 16/16 PASS** (uppinote vault, 새 헬퍼 + migration 강건성 모두 회귀 없음)
- [x] Sync tags moved to HEAD (`test-sync` + `handbook-sync` → `2922315`)

## Skip — 별도 follow-up 가치
- **Quality #4 — 8개 `addCommand` 블록 통합 refactor**: 구조적 변경, single-concern PR로 진행이 리뷰 부담↓
- **Quality #5 — `(this.app as any).commands` 타입 캐스트**: pre-existing, 별도 정리
- **§9 분리 (`docs/handbook/09-essential-patterns.md`)**: 5-8% over, 500줄 도달 시 진행 (skill §3.3 "분리 후에도 마커 변경 불필요" — design-compatible)