### PR TITLE
docs: refresh README + CLAUDE.md for 0.9.0 multi-provider release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,82 +8,116 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run build    # TypeScript check + production build
 npm run dev      # Development mode with watch
 npm run lint     # ESLint for src/*.ts files
+npm test         # Vitest unit tests (watch)
+npm run test:run # Vitest unit tests (one-shot)
+
+# E2E (require Obsidian running with --remote-debugging-port=9222)
+npm run test:e2e            # Airtable sync e2e
+npm run test:e2e:settings   # Airtable settings UI e2e
+npm run test:e2e:full       # Build + deploy + run Airtable sync e2e
+npm run test:e2e:seatable          # SeaTable sync e2e (.env required)
+npm run test:e2e:seatable:settings # SeaTable settings UI e2e
+npm run test:e2e:seatable:full     # Build + deploy + run SeaTable e2e
 ```
 
 ## Architecture Overview
 
-This is an Obsidian plugin that syncs notes bidirectionally between Airtable and Obsidian.
+This is an Obsidian plugin that syncs notes bidirectionally between **remote databases (Airtable, SeaTable; Supabase / Notion / Custom API tracked in epic #11)** and your Obsidian vault. Higher layers operate on the provider-agnostic `DatabaseProvider` interface — adding a new provider is documented in handbook §4.4.
 
 ### Module Structure (`src/`)
 
 ```
 src/
-├── main.ts              # Plugin entry point, service orchestration
-├── types/               # Type definitions
-│   ├── settings.types.ts    # Settings interface, DEFAULT_SETTINGS
-│   ├── airtable.types.ts    # RemoteNote, SyncResult, BatchUpdate
-│   └── sync.types.ts        # SyncMode, SyncScope, SyncRequest
-├── constants/           # Constants
-│   ├── api.ts               # AIRTABLE_BATCH_SIZE, RATE_LIMIT_INTERVAL_MS
-│   └── field-types.ts       # SUPPORTED_FIELD_TYPES, READ_ONLY_FIELD_TYPES
-├── services/            # External service integration
-│   ├── airtable-client.ts   # API client (fetchNotes, batchUpdate)
-│   ├── rate-limiter.ts      # Request throttling (200ms interval)
-│   └── field-cache.ts       # Airtable field metadata cache
-├── core/                # Business logic
-│   ├── sync-queue.ts        # Queue-based sync management
-│   └── conflict-resolver.ts # Conflict resolution logic
-├── builders/            # Content generation
-│   └── note-builder.ts      # Template parsing, markdown generation
-├── file-operations/     # File system operations
-│   ├── file-watcher.ts      # Change detection (2s debounce)
-│   └── frontmatter-parser.ts # YAML frontmatter parsing
-├── ui/                  # UI components
-│   ├── settings-tab.ts      # Settings panel
-│   └── suggest/             # Autocomplete components
-└── utils/               # Utilities
-    ├── sanitizers.ts        # File/folder name sanitization
-    ├── yaml-formatter.ts    # YAML value formatting
-    └── object-utils.ts      # Object utilities
+├── main.ts                          # Plugin entry point, service orchestration
+├── types/                           # Type definitions
+│   ├── settings.types.ts                # AutoNoteImporterSettings, LegacySettings, DEFAULT_SETTINGS
+│   ├── config.types.ts                  # ConfigEntry (per-config sync settings), SharedServices
+│   ├── credential.types.ts              # CredentialType union + AirtableCredential / SeaTableCredential / etc.
+│   ├── database.types.ts                # DatabaseProvider interface, RemoteNote, SyncResult, ProviderCapabilities
+│   ├── field-types.types.ts             # StandardFieldType + FieldTypeMapper
+│   ├── provider-settings.types.ts       # CredentialFormRenderer (settings-tab plugin point)
+│   ├── airtable.types.ts                # Airtable-specific (AirtableField, AirtableBase, AirtableTable, AirtableView)
+│   └── sync.types.ts                    # SyncMode, SyncScope, SyncRequest
+├── constants/                       # Constants
+│   ├── api.ts                           # AIRTABLE_* / SEATABLE_* / RATE_LIMIT_INTERVAL_MS / retry knobs
+│   └── system-fields.ts                 # SYSTEM_FIELDS, isSystemField (frontmatter-reserved)
+├── services/                        # External service integration
+│   ├── airtable-client.ts               # Airtable DatabaseProvider impl (REST API)
+│   ├── airtable-field-mapper.ts         # Airtable type → StandardFieldType
+│   ├── airtable-credential-form.ts      # Airtable settings form + connection test
+│   ├── seatable-client.ts               # SeaTable DatabaseProvider impl (API Gateway v2 + Base-Token caching)
+│   ├── seatable-field-mapper.ts         # SeaTable type → StandardFieldType
+│   ├── seatable-credential-form.ts      # SeaTable settings form + connection test
+│   ├── provider-registry.ts             # Factory + mapper + form-renderer registry by CredentialType
+│   ├── rate-limiter.ts                  # Per-credential request throttling + 429 retry + transient retry
+│   └── field-cache.ts                   # Airtable field metadata cache (Meta API)
+├── core/                            # Business logic
+│   ├── sync-orchestrator.ts             # processSyncRequest (pull / push / bidirectional)
+│   ├── conflict-resolver.ts             # detectConflicts + resolve by mode
+│   ├── sync-queue.ts                    # Queue-based sync (dedup + merge)
+│   ├── config-instance.ts               # Per-config service stack
+│   └── config-manager.ts                # ConfigInstance lifecycle
+├── builders/                        # Content generation
+│   ├── note-builder.ts                  # Template parsing, markdown generation
+│   └── bases-file-generator.ts          # Obsidian Bases (.base) generator
+├── file-operations/                 # File system operations
+│   ├── file-watcher.ts                  # Change detection (debounced)
+│   └── frontmatter-parser.ts            # YAML frontmatter (read/inject + read-only filter)
+├── ui/                              # UI components
+│   ├── settings-tab.ts                  # Settings panel (multi-config, provider-aware cards)
+│   └── suggest/                         # Folder/file autocomplete
+└── utils/                           # Utilities
+    ├── sanitizers.ts                    # File/folder name sanitization
+    ├── yaml-formatter.ts                # YAML value formatting (Bases-aware)
+    ├── object-utils.ts                  # Deep equality, generateId
+    ├── settings-bridge.ts               # ConfigEntry + Credential → LegacySettings
+    ├── migration.ts                     # Settings v1 → v3 migration
+    ├── validation.ts                    # Folder overlap validation
+    └── api-errors.ts                    # Cross-provider API error extraction + URL normalization
 ```
 
 ### Key Classes
 
-- **`DatabaseProvider`** - Provider-agnostic interface for remote databases (see handbook §4.4)
-- **`AirtableClient`** - First concrete `DatabaseProvider` impl; Airtable REST API with rate limiting
-- **`ProviderRegistry`** - Credential-type → provider factory lookup (`createProvider()`)
-- **`SyncQueue`** - Prevents concurrent syncs, merges duplicate requests
-- **`FileWatcher`** - Detects file changes, triggers sync with debounce
-- **`FrontmatterParser`** - Extracts/filters fields from YAML frontmatter
-- **`ConflictResolver`** - Handles sync conflicts based on resolution mode
+- **`DatabaseProvider`** — Provider-agnostic interface for remote databases (handbook §4.4)
+- **`AirtableClient` / `SeaTableClient`** — Concrete `DatabaseProvider` impls
+- **`ProviderRegistry`** — `CredentialType → factory` lookup (`createProvider()` + `getFieldTypeMapper()` + `getCredentialFormRenderer()`)
+- **`ConfigManager` / `ConfigInstance`** — Multi-config orchestration; per-config service stack (handbook §9.8)
+- **`SyncOrchestrator`** — `processSyncRequest(mode, scope)` — central pull/push/bidirectional coordinator
+- **`SyncQueue`** — Dedup + merge sequential sync requests; `enqueueSyncRequest` returns the queue's promise so e2e can await completion
+- **`FileWatcher`** — Detects file changes with debounce
+- **`FrontmatterParser`** — Read-only field filter via the active provider's `FieldTypeMapper`
+- **`ConflictResolver`** — Detect/resolve based on `obsidian-wins` / `remote-wins` / `manual`
 
 ### Sync Flow
 
-1. **From remote**: `DatabaseProvider.fetchNotes()` → `createNoteFromRemote()` → writes `.md` with `primaryField`
-2. **To remote**: `FileWatcher` detects changes → `SyncQueue.enqueue()` → `DatabaseProvider.batchUpdate()`
-3. **Bidirectional**: Push to remote → wait for server-side computation → pull back computed values
+1. **From remote**: `DatabaseProvider.fetchNotes()` → builder writes `.md` with `primaryField` (the remote record id)
+2. **To remote**: `FileWatcher` detects change → `SyncQueue.enqueue()` → `SyncOrchestrator.pushFiles()` → `DatabaseProvider.batchUpdate()`
+3. **Bidirectional**: push to remote → wait `formulaSyncDelay` (server-side computation) → pull back computed values
 
 ### Key Design Decisions
 
-- `primaryField` in frontmatter is always the Airtable record ID (immutable identifier)
-- Read-only fields (formulas, rollups, lookups) are filtered out via `isReadOnlyFieldType()`
-- Conflict resolution modes: `obsidian-wins`, `airtable-wins`, `manual`
-- Services receive settings updates via `updateSettings()` method
-- FileWatcher is reconfigured on settings change (no reload needed for `watchForChanges`)
-- Commands use `checkCallback` pattern to hide when `bidirectionalSync` is disabled
+- `primaryField` in frontmatter is always the **remote record id** (provider-agnostic immutable identifier)
+- Read-only fields (formula / rollup / lookup / `_ctime` / etc.) are filtered out via `FieldTypeMapper.isReadOnly()` — fail-closed for unknown types
+- Conflict resolution modes: `obsidian-wins`, `remote-wins`, `manual` (renamed from `airtable-wins` in #64)
+- Services receive settings updates via `updateSettings()` — `ConfigInstance.updateSettings()` propagates to all owned services
+- `FileWatcher` is reconfigured on settings change (no reload needed for `watchForChanges`)
+- Commands use `checkCallback` pattern to hide push/bidirectional commands when `bidirectionalSync` is disabled
+- User-facing labels (status bar, command names, settings) derive from `CREDENTIAL_TYPE_LABELS[credential.type]` — never hardcode `"Airtable"` in shared render methods
 
 ### Available Commands
 
+Command titles include the provider label (e.g. `Sync current note from Airtable` / `Sync current note from SeaTable`) — derived dynamically per active config.
+
 | Command | Always Available |
 |:---|:---|
-| Sync current note from Airtable | ✅ |
-| Sync all notes from Airtable | ✅ |
-| Sync current/modified/all to Airtable | ❌ (requires bidirectionalSync) |
-| Bidirectional sync current/modified/all | ❌ (requires bidirectionalSync) |
+| Sync current note from {provider} | ✅ |
+| Sync all notes from {provider} | ✅ |
+| Sync current/modified/all to {provider} | ❌ (requires `bidirectionalSync`) |
+| Bidirectional sync current/modified/all | ❌ (requires `bidirectionalSync`) |
 
 ## Documentation
 
-- `docs/ENGINEERING_HANDBOOK.md` - 코딩 컨벤션, 스타일 가이드, 아키텍처, 디자인 시스템, 코드 스탠다드, 거버넌스, 프로젝트 고유 패턴
+- `docs/ENGINEERING_HANDBOOK.md` — 코딩 컨벤션, 스타일 가이드, 아키텍처, 디자인 시스템, 코드 스탠다드, 거버넌스, 프로젝트 고유 패턴 (`.private/docs` symlink로 별도 repo에서 관리)
 
 ## Coding Conventions
 
@@ -94,6 +128,12 @@ Code ↔ Docs 양방향 링크 시스템:
 - **Docs → Code**: `<!-- @code {file} -->` (핸드북에 마커)
 - **검색**: `grep -r "@handbook" src/` / `grep -r "@code" docs/`
 
+### Code ↔ Tests Bidirectional Links
+
+- **Code → Tests**: `@tested {path}` (e2e harness는 `e2e:` prefix)
+- **Tests → Code**: `@covers {path}`
+- **Sync**: `/update-test-map` (test-sync 태그 기반)
+
 ### Quick Reference
 
 | Topic | Handbook Section |
@@ -102,10 +142,10 @@ Code ↔ Docs 양방향 링크 시스템:
 | Import order | 2.2 |
 | Module structure | 4.1 |
 | Sync architecture | 4.2 |
-| Provider abstraction | 4.4 |
+| Provider abstraction (multi-DB) | 4.4 |
 | StatusBar abstraction | 5.3 |
-| Error handling | 6.1 |
-| State management | 6.2 |
+| Error handling (api-errors util) | 6.1 |
+| State management (SyncQueue) | 6.2 |
 | Input validation | 7.1 |
 | Read-only field protection | 7.3 |
 | Git/PR rules | 8 |
@@ -115,10 +155,10 @@ Code ↔ Docs 양방향 링크 시스템:
 | Conflict resolution | 9.5 |
 | API patterns | 9.6 |
 | Multi-config architecture | 9.8 |
-| Settings migration | 9.9 |
+| Settings migration (v1 → v3) | 9.9 |
 | Folder overlap validation | 9.10 |
 | Bases file generation | 9.11 |
 
 ## Commit Guidelines
 
-See `.claude/commit-guidelines.md` - uses conventional commits **without** Claude metadata.
+See `.claude/commit-guidelines.md` — uses conventional commits **without** Claude metadata.

--- a/README.md
+++ b/README.md
@@ -4,161 +4,173 @@
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/uppinote20/obsidian-auto-note-importer?sort=semver)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/uppinote20/obsidian-auto-note-importer/total)
 
-Import and sync notes bidirectionally between Airtable and your Obsidian vault with smart field mapping and organization features.
+Import and sync notes bidirectionally between **Airtable**, **SeaTable**, and your Obsidian vault with smart field mapping and organization features. Built on a provider-agnostic core; more databases (Supabase, Notion, Custom API) tracked in [#11](https://github.com/uppinote20/obsidian-auto-note-importer/issues/11).
 
 ## ✨ Key Features
 
-- **Bidirectional Sync**: Sync notes from Airtable to Obsidian and back
-- **Formula & Relation Support**: Auto-fetch computed values after syncing to Airtable
-- **Conflict Resolution**: Choose how to handle concurrent edits (Obsidian wins, Airtable wins, or manual)
-- **Smart Field Selection**: Dropdown-based field selection with type validation
-- **Subfolder Organization**: Automatically organize notes into subfolders based on field values
-- **Safe File Naming**: Compatible field types (Text, Select, Number, Formula) for filenames
-- **Template Support**: Customize note format with powerful template system
-- **Obsidian Bases Compatible**: Optimized YAML properties for table/card views
-- **Automated Syncing**: Manual sync, scheduled intervals, or automatic on file change
+- **Multiple Databases**: Airtable and SeaTable supported today; pluggable provider architecture for more
+- **Bidirectional Sync**: Sync notes from your remote database to Obsidian and back
+- **Multi-Config**: Run several sync configurations (different bases / tables / folders) side-by-side
+- **Computed-Field Support**: Auto-fetch formula / rollup / lookup / link-formula values after pushing
+- **Conflict Resolution**: `Manual`, `Obsidian wins`, `Remote wins` modes
+- **Smart Field Selection**: Type-aware dropdowns; provider-specific safe-for-filename whitelist
+- **Subfolder Organization**: Auto-organize notes into subfolders based on a field value
+- **Safe File Naming**: Per-provider validation (text / select / number / formula / auto-number)
+- **Template Support**: `{{fieldName}}` placeholders with nested-property access
+- **Obsidian Bases Compatible**: YAML output tuned for table/card views
+- **Automated Syncing**: Manual sync, scheduled intervals, or auto on file change
 - **Zero Coding Required**: Point-and-click setup with intuitive UI
 
 ## 📦 Installation
 
 1. Open Obsidian
-2. Go to **Settings > Community plugins > Browse**
+2. Go to **Settings → Community plugins → Browse**
 3. Search for "**Auto Note Importer**" and install it
 4. Enable the plugin
-5. Configure your Airtable settings
+5. Add a credential for your provider (Airtable PAT or SeaTable API Token), then configure a sync configuration
 
 ## 🚀 Quick Start
 
-### 1. Get Airtable Personal Access Token
+### 1. Get Your Provider Credentials
 
-1. Go to [Airtable Tokens page](https://airtable.com/create/tokens)
+#### Airtable
+
+1. Visit the [Airtable Tokens page](https://airtable.com/create/tokens)
 2. Click **Create new token**
 3. Select scopes:
-   - `data.records:read` - Required for importing notes
-   - `data.records:write` - Required for bidirectional sync
-   - `schema.bases:read` - Required for field selection
-4. Select your bases and click **Create token**
-5. Copy the token and paste it in plugin settings
+   - `data.records:read` — required for importing
+   - `data.records:write` — required for bidirectional sync
+   - `schema.bases:read` — required for field selection
+4. Choose your bases and click **Create token**
+5. Copy the Personal Access Token
 
-### 2. Configure Plugin
+#### SeaTable
 
-1. **Airtable PAT**: Enter your Personal Access Token
-2. **Select Base**: Choose from your available bases
-3. **Select Table**: Pick the table to sync
-4. **Filename Field**: Choose field for note names (Text/Select/Number only)
-5. **Subfolder Field**: Optional - organize notes by field value
-6. **Destination**: Set folder location for imported notes
-7. **Template**: Optional - customize note format
+1. Open your SeaTable Base → **More options (⋯) → Advanced settings → API Tokens → Add API Token**
+2. Pick **Read and write** permission
+3. Copy the API Token (it is base-specific)
+4. Note your server URL (default: `https://cloud.seatable.io`; self-hosted users use their own host)
+
+### 2. Configure the Plugin
+
+1. Open **Settings → Auto Note Importer**
+2. **Add credential** — pick the provider type (Airtable / SeaTable) and paste your token
+3. The connection card adapts to your selected credential. Fill in:
+   - **Airtable**: Base → Table → View (optional) → Filename / Subfolder fields
+   - **SeaTable**: Table ID → View ID (optional) → Filename / Subfolder column names
+4. **Destination folder** in your vault
+5. **Template** — optional `{{fieldName}}` template
+6. **Bidirectional sync** — toggle if you want changes flowing both ways
+
+You can have multiple configurations (e.g. one for Airtable, one for SeaTable, or two SeaTable bases) — switch between them with the tab bar at the top of the settings panel.
 
 ### 3. Sync Notes
 
-Use Command Palette (Ctrl/Cmd + P) to access sync commands:
+Use Command Palette (Ctrl/Cmd + P). Each command is labeled with the active config's provider:
 
 | Command | Description |
 |:---|:---|
-| **Sync current note from Airtable** | Refresh current note from Airtable |
-| **Sync all notes from Airtable** | Import/update all notes from Airtable |
-| **Sync current note to Airtable** | Push current note changes to Airtable* |
-| **Sync modified notes to Airtable** | Push all pending changes to Airtable* |
-| **Sync all notes to Airtable** | Push all notes to Airtable* |
-| **Bidirectional sync current note** | Sync to Airtable, then fetch formula results* |
-| **Bidirectional sync modified notes** | Sync modified notes with formula refresh* |
-| **Bidirectional sync all notes** | Full bidirectional sync with formulas* |
+| **Sync current note from {provider}** | Refresh current note from the remote database |
+| **Sync all notes from {provider}** | Import / update all notes |
+| **Sync current note to {provider}** \* | Push current note changes |
+| **Sync modified notes to {provider}** \* | Push pending changes |
+| **Sync all notes to {provider}** \* | Push every note |
+| **Bidirectional sync current note** \* | Push, wait for formulas, then pull |
+| **Bidirectional sync modified notes** \* | Same for modified notes |
+| **Bidirectional sync all notes** \* | Same for all notes |
 
-*Commands marked with * require **Enable bidirectional sync** to be turned on. They are hidden from Command Palette when disabled.
+\* Commands marked with \* require **Enable bidirectional sync** to be turned on. They are hidden from Command Palette when disabled.
 
-- **Auto**: Set sync interval in minutes (0 = manual only)
-- **Watch**: Enable file change detection for automatic sync
+You can also schedule syncs:
+
+- **Sync interval**: minutes (0 = manual only)
+- **Watch for changes**: detect file edits and queue automatic sync
 
 ## ⚙️ Settings Guide
 
-### Basic Settings
+### Per-Configuration Basics
 
 | Setting | Description |
 |:---|:---|
-| **Airtable Personal Access Token** | Your Airtable PAT for API access |
-| **Select Base** | Choose Airtable base (auto-populated from PAT) |
-| **Select Table** | Choose table within base |
-| **Filename Field** | Field to use for note filenames (safe types only) |
-| **Subfolder Field** | Field to organize notes into subfolders (optional) |
+| **Credential** | Pick a registered credential (Airtable / SeaTable) |
+| **Base / Table / View** (Airtable) | Selectable from your base via the Meta API |
+| **Table / View ID** (SeaTable) | Identifiers from your SeaTable base — auto-derived dropdowns are tracked in [#73](https://github.com/uppinote20/obsidian-auto-note-importer/issues/73) |
+| **Filename Field** | Field used for note filenames (safe types only) |
+| **Subfolder Field** | Optional — organize notes into subfolders |
 | **New File Location** | Destination folder in your vault |
-| **Template File** | Custom template for note format (optional) |
+| **Template File** | Custom template (optional) |
 | **Sync Interval** | Auto-sync frequency in minutes (0 = disabled) |
 | **Allow Overwrite** | Update existing notes vs skip duplicates |
 
-### Bidirectional Sync Settings
+### Bidirectional Sync
 
 | Setting | Description |
 |:---|:---|
-| **Enable bidirectional sync** | Allow syncing changes from Obsidian back to Airtable |
-| **Conflict resolution** | How to handle conflicts: Manual, Obsidian wins, or Airtable wins |
-| **Watch for file changes** | Automatically detect and queue changes for sync |
-| **Auto-sync formulas** | Fetch computed formula/relation results after syncing |
-| **Formula sync delay** | Wait time (ms) for Airtable to compute formulas (default: 1500) |
+| **Enable bidirectional sync** | Allow Obsidian → remote pushes |
+| **Conflict resolution** | `Manual`, `Obsidian wins`, `Remote wins` |
+| **Watch for file changes** | Auto-detect Obsidian edits and queue sync |
+| **Auto-sync computed fields** | After push, fetch formulas / rollups / lookups |
+| **Computed-field sync delay** | ms to wait for the remote to recompute (default: 1500) |
 
 ### Supported Field Types
 
-**✅ Safe for Filenames & Subfolders:**
-- Single line text
-- Single select
-- Number
-- Formula (validated for filename compatibility)
+The plugin maps each provider's native types to a normalized taxonomy (`text` / `number` / `date` / `boolean` / `single-select` / `multi-select` / `attachment` / `link` / `computed` / `system`). Each provider's `FieldTypeMapper` decides which types are filename-safe and which are read-only (excluded from push) — fail-closed for unknown types.
 
-**❌ Not Supported for Filenames:**
-- Email, URL, Phone (special characters)
-- Date, Time (formatting issues)
-- Multiple select (unpredictable results)
-- Attachment, User (complex data types)
+#### Airtable
 
-**🔒 Read-only Fields (synced from Airtable only):**
-- Formula, Rollup, Count, Lookup
-- Created time, Last modified time
-- Created by, Last modified by
-- Auto number
+**✅ Safe for Filenames & Subfolders:** `singleLineText`, `singleSelect`, `number`, `formula`
 
-*Unsupported fields are automatically hidden in dropdowns to prevent errors.*
+**🔒 Read-only (synced from Airtable only):** `formula`, `rollup`, `count`, `lookup`, `externalSyncSource`, `aiText`, `button`, `createdTime`, `lastModifiedTime`, `createdBy`, `lastModifiedBy`, `autoNumber`
 
-**📋 [Complete Field Type Reference →](examples/airtable-field-types.md)**
+**📋 [Complete Airtable Field Type Reference →](examples/airtable-field-types.md)**
+
+#### SeaTable
+
+**✅ Safe for Filenames & Subfolders:** `text`, `single-select`, `number`, `auto-number`, `formula`
+
+**🔒 Read-only (synced from SeaTable only):** `formula`, `link-formula`, `button`, `ctime`, `mtime`, `creator`, `last-modifier`, `auto-number`
+
+Unsupported / read-only fields are automatically hidden in dropdowns to prevent push errors.
 
 ## 🔄 How It Works
 
 ### Unique Identification
-Each note gets a unique `primaryField` (Airtable record ID) in frontmatter to prevent duplicates and enable proper sync tracking.
+Each note carries the remote record id in the `primaryField` frontmatter key — the immutable handle the sync pipeline uses to match notes back to their remote row.
 
 ### File Naming Logic
-1. Use selected **Filename Field** if available and non-empty
-2. Fallback to **Airtable record ID** for guaranteed unique, safe filename
+1. Use the selected **Filename Field** if present and non-empty
+2. Fallback to the **remote record id**
 3. All filenames are sanitized for cross-platform compatibility
 
 ### Subfolder Organization
 - **With Subfolder Field**: `destination/field-value/note.md`
 - **Without Subfolder Field**: `destination/note.md`
-- Supports nested folders (e.g., "Category/Subcategory")
+- Supports nested folders (e.g. "Category/Subcategory")
 - Recursive duplicate detection across all subfolders
 
 ### Bidirectional Sync Flow
 
 ```
-┌─────────────┐     Push      ┌─────────────┐
-│   Obsidian  │ ───────────▶  │   Airtable  │
-│   (Notes)   │               │  (Database) │
-│             │  ◀───────────  │             │
-└─────────────┘     Pull      └─────────────┘
+┌─────────────┐     Push      ┌──────────────┐
+│   Obsidian  │ ───────────▶  │   Remote DB  │
+│   (Notes)   │               │  (Airtable / │
+│             │  ◀───────────  │   SeaTable)  │
+└─────────────┘     Pull      └──────────────┘
 ```
 
-1. **Obsidian → Airtable**: Edit frontmatter fields in Obsidian, sync pushes changes
-2. **Formula Computation**: Airtable computes formulas, rollups, and relations
-3. **Airtable → Obsidian**: Pull back computed values to update notes
+1. **Obsidian → Remote**: edit frontmatter, sync pushes writable fields
+2. **Server-side computation**: the remote computes formulas / rollups / link-formulas
+3. **Remote → Obsidian**: pull back computed values to update notes
 
 ### Conflict Resolution
 
-When the same field is modified in both Obsidian and Airtable:
+When the same field is modified in both Obsidian and the remote:
 
 | Mode | Behavior |
 |:---|:---|
-| **Manual** | Show notification, skip conflicted fields |
-| **Obsidian wins** | Overwrite Airtable with Obsidian values |
-| **Airtable wins** | Keep Airtable values, ignore Obsidian changes |
+| **Manual** | Show notification, skip conflicting fields |
+| **Obsidian wins** | Overwrite the remote with Obsidian values |
+| **Remote wins** | Keep remote values, ignore Obsidian changes |
 
 ## 📝 Template Usage
 
@@ -186,51 +198,45 @@ created: "{{Created time}}"
 
 **Advanced Features:**
 - **Nested Access**: `{{Attachment.0.url}}`, `{{User.name}}`
-- **Multi-line Support**: Automatic YAML block scalar formatting
+- **Multi-line Support**: Automatic YAML block-scalar formatting
 - **Bases Optimization**: Proper YAML types for table/card views
 
 **📝 [Template Examples & Best Practices →](examples/template-examples.md)**
 
 ## 🔗 Obsidian Bases Integration
 
-This plugin creates Bases-compatible YAML frontmatter with proper data types for seamless table/card view editing. Import your notes, enable the Bases plugin, and create a database from your imported folder for powerful data management workflows.
+This plugin emits Bases-compatible YAML frontmatter with proper data types for seamless table/card view editing. Import your notes, enable the Bases plugin, and create a database from the imported folder for powerful data management workflows.
 
 ## 📊 Example Workflows
 
 ### One-way Import
-1. **Collect Data**: Use automation tools (n8n, Zapier) to gather content
-2. **Store in Airtable**: Organize and process your data
-3. **Import to Obsidian**: Use this plugin to create structured notes
-4. **Organize Automatically**: Subfolder structure based on your data
-5. **Manage in Bases**: View and edit in table/card format
+1. **Collect data** with automation tools (n8n, Zapier, Apps Script)
+2. **Store** in Airtable or SeaTable
+3. **Import** to Obsidian via this plugin
+4. **Organize** automatically using Subfolder Field
+5. **Manage** in Obsidian Bases (table/card view)
 
 ### Bidirectional Workflow
-1. **Import from Airtable**: Pull records as Obsidian notes
-2. **Edit in Obsidian**: Modify frontmatter fields (status, tags, notes)
-3. **Sync to Airtable**: Push changes back to update the database
-4. **Formula Updates**: Airtable computes formulas and relations
-5. **Pull Results**: Fetch computed values back to Obsidian
+1. **Import** records as Obsidian notes
+2. **Edit** frontmatter fields in Obsidian (status, tags, notes)
+3. **Push** changes back to the remote
+4. **Compute** formulas / rollups / link-formulas server-side
+5. **Pull** computed values back into Obsidian
 
 ## 🛠️ Troubleshooting
 
 **Common Issues:**
-- **No fields showing**: Check PAT permissions and base/table selection
-- **Sync fails**: Verify network connection and Airtable credentials
-- **File naming errors**: Ensure selected field type is supported
-- **Missing subfolders**: Check subfolder field value isn't empty
-- **Bidirectional sync not working**: Ensure PAT has `data.records:write` permission
-- **Formulas not updating**: Increase formula sync delay in settings
-- **Conflicts detected**: Check conflict resolution mode in settings
+- **No fields showing**: re-check token permissions and base/table selection
+- **Sync fails**: verify network connection and credentials
+- **File naming errors**: confirm the selected field type is supported (per-provider whitelist)
+- **Missing subfolders**: check the subfolder field value isn't empty
+- **Bidirectional sync not working**: ensure write permissions (Airtable PAT `data.records:write`; SeaTable token "Read and write")
+- **Formulas not updating**: increase the computed-field sync delay
+- **Conflicts detected**: check conflict resolution mode
 
-**Field Selection Tips:**
-- Use descriptive text fields for filenames
-- Choose categorical fields for subfolder organization
-- Formula fields work for filenames but are validated for compatibility
-
-**Bidirectional Sync Tips:**
-- Read-only fields (formulas, rollups) are automatically excluded from push
-- Use "Obsidian wins" mode for faster sync (skips conflict detection)
-- Increase formula sync delay for complex Airtable formulas
+**Provider-specific Tips:**
+- **Airtable**: read-only fields (formulas, rollups) are auto-excluded from push. Use **Obsidian wins** for faster sync (skips conflict detection).
+- **SeaTable**: API tokens are base-specific. Each token grants access to exactly one base — get a separate token per base. Self-hosted users override `Server URL` per credential.
 
 ## ☕ Support
 


### PR DESCRIPTION
## Summary
- 0.9.0에서 SeaTable provider가 추가됐지만 두 first-touch 문서(README.md / CLAUDE.md)가 0.7.0 시점 그대로였음. 외부와 내부 양쪽을 동시에 갱신.
- 코드 변경 0; 빌드 영향 없음.

## Changes

### `CLAUDE.md`
- Architecture overview 첫 줄을 multi-provider로 generalize (Airtable + SeaTable; future providers tracked in #11).
- `src/` tree를 0.9.0 실제 구조로 재작성 — `services/{seatable-*, provider-registry}`, `core/{config-instance, config-manager, sync-orchestrator}`, `utils/{settings-bridge, migration, validation, api-errors}`, `constants/system-fields`, `types/{config, credential, database, field-types, provider-settings}` 모두 노출.
- Key Classes에 `SeaTableClient`, `ConfigManager` / `ConfigInstance`, `SyncOrchestrator` 추가.
- Conflict resolution 모드 표기를 `airtable-wins` → `remote-wins`로 정정 (#64에서 변경됨).
- Available Commands를 `{provider}` placeholder로 동적 라벨화.
- Build & Development Commands에 e2e 4종(Airtable / SeaTable × sync / settings) 추가.
- Code ↔ Tests bidirectional links 섹션 추가 (test-sync 태그 흐름 안내).

### `README.md`
- Hero 문장 + Key Features를 multi-provider로 갱신, future providers를 #11 링크로 외화.
- "Get Airtable PAT" 블록을 "Get Your Provider Credentials" + Airtable / SeaTable subsection으로 분리. SeaTable의 base-specific token, default server URL, self-hosted 옵션을 첫 화면에 노출.
- Configure Plugin 단계를 "add credential → connection card는 type에 따라 자동 적응"으로 재서술. Multi-config 운영을 명시.
- Commands 표를 `from {provider}`로 동적 라벨화.
- Settings Guide를 per-config 기준으로 재구성. SeaTable Table/View ID dropdown TODO를 #73으로 외화.
- Bidirectional flow diagram을 "Remote DB (Airtable / SeaTable)"로 변경.
- Conflict Resolution 표의 "Airtable wins" 행을 "Remote wins"로 정정.
- Supported Field Types를 두 provider로 분할 + `StandardFieldType` taxonomy 한 줄 설명 추가.
- Troubleshooting에 provider-specific 팁 섹션 추가 (SeaTable token base-specific, self-hosted 등).

## Test plan
- [x] `npm run build` (TS check + esbuild) OK
- [x] CLAUDE.md / README.md 모두 valid markdown
- [x] @handbook / @code 마커 카운트 변동 없음 — docs only
- [ ] (선택) Obsidian plugin 설치 페이지에 README 미리보기 한번 확인

## Notes
- handbook 본문(`docs/ENGINEERING_HANDBOOK.md`)은 `.private/docs` symlink 별도 repo에서 이미 갱신됨; 이 PR은 두 first-touch 파일만 다룬다.
- 별도 buggy 코드 추가 없음 — review는 빠르게 진행 가능.