### PR TITLE
refactor: align batchUpdate limit-guard with SyncResult contract

### DIFF
--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -23,7 +23,7 @@ import type {
   ConfigEntry,
   CredentialType,
 } from '../types';
-import { BATCH_LIMIT_ERROR, buildBatchFailures, buildLegacySettings, extractApiErrorDetails } from '../utils';
+import { formatBatchLimitError, buildBatchFailures, buildLegacySettings, extractApiErrorDetails } from '../utils';
 import { airtableFieldMapper } from './airtable-field-mapper';
 import { RateLimiter } from './rate-limiter';
 
@@ -223,10 +223,6 @@ export class AirtableClient implements DatabaseProvider {
     }
   }
 
-  /**
-   * Batch updates multiple records in Airtable.
-   * Automatically handles the 10-record limit per batch.
-   */
   async batchUpdate(updates: BatchUpdate[]): Promise<SyncResult[]> {
     this.validateSettings();
 
@@ -235,7 +231,7 @@ export class AirtableClient implements DatabaseProvider {
     }
 
     if (updates.length > AIRTABLE_BATCH_SIZE) {
-      return buildBatchFailures(updates, BATCH_LIMIT_ERROR(AIRTABLE_BATCH_SIZE));
+      return buildBatchFailures(updates, formatBatchLimitError(AIRTABLE_BATCH_SIZE));
     }
 
     try {

--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -235,7 +235,11 @@ export class AirtableClient implements DatabaseProvider {
     }
 
     if (updates.length > AIRTABLE_BATCH_SIZE) {
-      throw new Error(`Maximum ${AIRTABLE_BATCH_SIZE} records allowed per batch update`);
+      return updates.map(update => ({
+        success: false as const,
+        recordId: update.recordId,
+        error: `Maximum ${AIRTABLE_BATCH_SIZE} records allowed per batch update`,
+      }));
     }
 
     try {

--- a/src/services/airtable-client.ts
+++ b/src/services/airtable-client.ts
@@ -23,7 +23,7 @@ import type {
   ConfigEntry,
   CredentialType,
 } from '../types';
-import { buildLegacySettings, extractApiErrorDetails } from '../utils';
+import { BATCH_LIMIT_ERROR, buildBatchFailures, buildLegacySettings, extractApiErrorDetails } from '../utils';
 import { airtableFieldMapper } from './airtable-field-mapper';
 import { RateLimiter } from './rate-limiter';
 
@@ -235,11 +235,7 @@ export class AirtableClient implements DatabaseProvider {
     }
 
     if (updates.length > AIRTABLE_BATCH_SIZE) {
-      return updates.map(update => ({
-        success: false as const,
-        recordId: update.recordId,
-        error: `Maximum ${AIRTABLE_BATCH_SIZE} records allowed per batch update`,
-      }));
+      return buildBatchFailures(updates, BATCH_LIMIT_ERROR(AIRTABLE_BATCH_SIZE));
     }
 
     try {
@@ -260,11 +256,7 @@ export class AirtableClient implements DatabaseProvider {
 
       if (response.status !== 200) {
         const errorDetails = extractApiErrorDetails(response);
-        return updates.map(update => ({
-          success: false as const,
-          recordId: update.recordId,
-          error: `Failed to batch update Airtable records: ${errorDetails}`
-        }));
+        return buildBatchFailures(updates, `Failed to batch update Airtable records: ${errorDetails}`);
       }
 
       const json = response.json;
@@ -274,11 +266,7 @@ export class AirtableClient implements DatabaseProvider {
         updatedFields: record.fields,
       }));
     } catch (error) {
-      return updates.map(update => ({
-        success: false as const,
-        recordId: update.recordId,
-        error: error instanceof Error ? error.message : "Unknown error occurred"
-      }));
+      return buildBatchFailures(updates, error instanceof Error ? error.message : "Unknown error occurred");
     }
   }
 }

--- a/src/services/seatable-client.ts
+++ b/src/services/seatable-client.ts
@@ -286,7 +286,11 @@ export class SeaTableClient implements DatabaseProvider {
     if (updates.length === 0) return [];
 
     if (updates.length > SEATABLE_BATCH_SIZE) {
-      throw new Error(`Maximum ${SEATABLE_BATCH_SIZE} records allowed per batch update`);
+      return updates.map(u => ({
+        success: false as const,
+        recordId: u.recordId,
+        error: `Maximum ${SEATABLE_BATCH_SIZE} records allowed per batch update`,
+      }));
     }
 
     try {

--- a/src/services/seatable-client.ts
+++ b/src/services/seatable-client.ts
@@ -37,7 +37,7 @@ import type {
   SeaTableCredential,
   SyncResult,
 } from '../types';
-import { BATCH_LIMIT_ERROR, buildBatchFailures, extractApiErrorDetails, normalizeServerUrl } from '../utils';
+import { formatBatchLimitError, buildBatchFailures, extractApiErrorDetails, normalizeServerUrl } from '../utils';
 import { seatableFieldMapper } from './seatable-field-mapper';
 import { RateLimiter } from './rate-limiter';
 
@@ -286,7 +286,7 @@ export class SeaTableClient implements DatabaseProvider {
     if (updates.length === 0) return [];
 
     if (updates.length > SEATABLE_BATCH_SIZE) {
-      return buildBatchFailures(updates, BATCH_LIMIT_ERROR(SEATABLE_BATCH_SIZE));
+      return buildBatchFailures(updates, formatBatchLimitError(SEATABLE_BATCH_SIZE));
     }
 
     try {

--- a/src/services/seatable-client.ts
+++ b/src/services/seatable-client.ts
@@ -37,7 +37,7 @@ import type {
   SeaTableCredential,
   SyncResult,
 } from '../types';
-import { extractApiErrorDetails, normalizeServerUrl } from '../utils';
+import { BATCH_LIMIT_ERROR, buildBatchFailures, extractApiErrorDetails, normalizeServerUrl } from '../utils';
 import { seatableFieldMapper } from './seatable-field-mapper';
 import { RateLimiter } from './rate-limiter';
 
@@ -286,11 +286,7 @@ export class SeaTableClient implements DatabaseProvider {
     if (updates.length === 0) return [];
 
     if (updates.length > SEATABLE_BATCH_SIZE) {
-      return updates.map(u => ({
-        success: false as const,
-        recordId: u.recordId,
-        error: `Maximum ${SEATABLE_BATCH_SIZE} records allowed per batch update`,
-      }));
+      return buildBatchFailures(updates, BATCH_LIMIT_ERROR(SEATABLE_BATCH_SIZE));
     }
 
     try {
@@ -307,11 +303,7 @@ export class SeaTableClient implements DatabaseProvider {
 
       if (response.status !== 200) {
         const errorDetails = extractApiErrorDetails(response);
-        return updates.map(u => ({
-          success: false as const,
-          recordId: u.recordId,
-          error: `Failed to batch update SeaTable rows: ${errorDetails}`,
-        }));
+        return buildBatchFailures(updates, `Failed to batch update SeaTable rows: ${errorDetails}`);
       }
 
       // SeaTable's PUT /rows/ returns `{success: true}` without echoing
@@ -323,8 +315,7 @@ export class SeaTableClient implements DatabaseProvider {
         updatedFields: u.fields,
       }));
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error occurred';
-      return updates.map(u => ({ success: false as const, recordId: u.recordId, error: message }));
+      return buildBatchFailures(updates, error instanceof Error ? error.message : 'Unknown error occurred');
     }
   }
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -86,11 +86,16 @@ export interface DatabaseProvider {
    * Updates multiple records in a single batch.
    *
    * Failure contract: this method always resolves to a `SyncResult[]` with
-   * one entry per requested update, including for guard-rail failures like
-   * exceeding `capabilities.batchUpdateMaxSize` or HTTP non-2xx responses.
-   * Implementations must not `throw` for input or response failures — wrap
-   * the failure into per-record `{ success: false, recordId, error }` so
-   * callers handle one shape regardless of the cause. See handbook §6.1.
+   * one entry per requested update for input-side guards (e.g. exceeding
+   * `capabilities.batchUpdateMaxSize`) and per-call API response failures
+   * (HTTP non-2xx, network errors). Implementations must not `throw` for
+   * those — wrap each failure into per-record `{ success: false, recordId,
+   * error }` so callers handle one shape regardless of cause.
+   *
+   * Configuration errors (missing API key, unset table ID, etc.) are a
+   * separate category — the up-front `validateSettings()` / `validateConfig()`
+   * checks may still throw, since misconfiguration is a wiring bug rather
+   * than a per-call failure. See handbook §6.1.
    */
   batchUpdate(updates: BatchUpdate[]): Promise<SyncResult[]>;
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -82,6 +82,16 @@ export interface DatabaseProvider {
   fetchNotes(): Promise<RemoteNote[]>;
   fetchRecord(recordId: string): Promise<RemoteNote | null>;
   updateRecord(recordId: string, fields: Record<string, unknown>): Promise<SyncResult>;
+  /**
+   * Updates multiple records in a single batch.
+   *
+   * Failure contract: this method always resolves to a `SyncResult[]` with
+   * one entry per requested update, including for guard-rail failures like
+   * exceeding `capabilities.batchUpdateMaxSize` or HTTP non-2xx responses.
+   * Implementations must not `throw` for input or response failures — wrap
+   * the failure into per-record `{ success: false, recordId, error }` so
+   * callers handle one shape regardless of the cause. See handbook §6.1.
+   */
   batchUpdate(updates: BatchUpdate[]): Promise<SyncResult[]>;
 
   /**

--- a/src/utils/api-errors.ts
+++ b/src/utils/api-errors.ts
@@ -7,7 +7,7 @@
  * so the helper checks each in priority order and falls back to the raw
  * response text or the HTTP status as a last resort.
  *
- * Also hosts the shared `buildBatchFailures` / `BATCH_LIMIT_ERROR` helpers
+ * Also hosts the shared `buildBatchFailures` / `formatBatchLimitError` helpers
  * that every `DatabaseProvider.batchUpdate()` failure path goes through —
  * keeps the per-record SyncResult[] shape consistent across providers.
  * See handbook §6.1 "Uniform failure shape".
@@ -53,7 +53,7 @@ export function normalizeServerUrl(url: string | undefined, fallback: string): s
   return (url || fallback).trim().replace(/\/+$/, '');
 }
 
-export const BATCH_LIMIT_ERROR = (maxSize: number): string =>
+export const formatBatchLimitError = (maxSize: number): string =>
   `Maximum ${maxSize} records allowed per batch update`;
 
 export function buildBatchFailures(updates: BatchUpdate[], error: string): SyncResult[] {

--- a/src/utils/api-errors.ts
+++ b/src/utils/api-errors.ts
@@ -7,10 +7,17 @@
  * so the helper checks each in priority order and falls back to the raw
  * response text or the HTTP status as a last resort.
  *
+ * Also hosts the shared `buildBatchFailures` / `BATCH_LIMIT_ERROR` helpers
+ * that every `DatabaseProvider.batchUpdate()` failure path goes through —
+ * keeps the per-record SyncResult[] shape consistent across providers.
+ * See handbook §6.1 "Uniform failure shape".
+ *
  * @handbook 6.1-error-handling
  * @handbook 4.4-provider-abstraction
  * @tested tests/utils/api-errors.test.ts
  */
+
+import type { BatchUpdate, SyncResult } from '../types/database.types';
 
 interface ApiErrorBody {
   error?: string | { message?: string };
@@ -44,4 +51,15 @@ export function extractApiErrorDetails(response: { status: number; json?: unknow
 
 export function normalizeServerUrl(url: string | undefined, fallback: string): string {
   return (url || fallback).trim().replace(/\/+$/, '');
+}
+
+export const BATCH_LIMIT_ERROR = (maxSize: number): string =>
+  `Maximum ${maxSize} records allowed per batch update`;
+
+export function buildBatchFailures(updates: BatchUpdate[], error: string): SyncResult[] {
+  return updates.map(u => ({
+    success: false as const,
+    recordId: u.recordId,
+    error,
+  }));
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,4 +27,6 @@ export {
   extractApiErrorMessage,
   extractApiErrorDetails,
   normalizeServerUrl,
+  buildBatchFailures,
+  BATCH_LIMIT_ERROR,
 } from './api-errors';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,5 +28,5 @@ export {
   extractApiErrorDetails,
   normalizeServerUrl,
   buildBatchFailures,
-  BATCH_LIMIT_ERROR,
+  formatBatchLimitError,
 } from './api-errors';

--- a/tests/services/airtable-client.test.ts
+++ b/tests/services/airtable-client.test.ts
@@ -9,6 +9,7 @@ import type { LegacySettings, AirtableCredential, ConfigEntry, Credential } from
 import { DEFAULT_LEGACY_SETTINGS, DEFAULT_CONFIG_ENTRY } from '../../src/types';
 import { AIRTABLE_BATCH_SIZE } from '../../src/constants';
 import { RateLimiter } from '../../src/services/rate-limiter';
+import { BATCH_LIMIT_ERROR } from '../../src/utils/api-errors';
 import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
@@ -199,7 +200,7 @@ describe('AirtableClient', () => {
       expect(results[0]).toMatchObject({
         success: false,
         recordId: 'rec0',
-        error: `Maximum ${AIRTABLE_BATCH_SIZE} records allowed per batch update`,
+        error: BATCH_LIMIT_ERROR(AIRTABLE_BATCH_SIZE),
       });
       expect(mockRequestUrl).not.toHaveBeenCalled();
     });

--- a/tests/services/airtable-client.test.ts
+++ b/tests/services/airtable-client.test.ts
@@ -9,7 +9,7 @@ import type { LegacySettings, AirtableCredential, ConfigEntry, Credential } from
 import { DEFAULT_LEGACY_SETTINGS, DEFAULT_CONFIG_ENTRY } from '../../src/types';
 import { AIRTABLE_BATCH_SIZE } from '../../src/constants';
 import { RateLimiter } from '../../src/services/rate-limiter';
-import { BATCH_LIMIT_ERROR } from '../../src/utils/api-errors';
+import { formatBatchLimitError } from '../../src/utils/api-errors';
 import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
@@ -200,7 +200,7 @@ describe('AirtableClient', () => {
       expect(results[0]).toMatchObject({
         success: false,
         recordId: 'rec0',
-        error: BATCH_LIMIT_ERROR(AIRTABLE_BATCH_SIZE),
+        error: formatBatchLimitError(AIRTABLE_BATCH_SIZE),
       });
       expect(mockRequestUrl).not.toHaveBeenCalled();
     });

--- a/tests/services/airtable-client.test.ts
+++ b/tests/services/airtable-client.test.ts
@@ -186,14 +186,22 @@ describe('AirtableClient', () => {
       expect(results[0]).toEqual({ success: true, recordId: 'rec1', updatedFields: { Name: 'A' } });
     });
 
-    it('should throw when exceeding batch size', async () => {
+    it('should return per-record failures when exceeding batch size', async () => {
       const updates = Array.from({ length: AIRTABLE_BATCH_SIZE + 1 }, (_, i) => ({
         recordId: `rec${i}`,
         fields: {},
       }));
 
-      await expect(client.batchUpdate(updates))
-        .rejects.toThrow(`Maximum ${AIRTABLE_BATCH_SIZE} records allowed`);
+      const results = await client.batchUpdate(updates);
+
+      expect(results).toHaveLength(updates.length);
+      expect(results.every(r => !r.success)).toBe(true);
+      expect(results[0]).toMatchObject({
+        success: false,
+        recordId: 'rec0',
+        error: `Maximum ${AIRTABLE_BATCH_SIZE} records allowed per batch update`,
+      });
+      expect(mockRequestUrl).not.toHaveBeenCalled();
     });
 
     it('should return failure for all records on non-200', async () => {

--- a/tests/services/seatable-client.test.ts
+++ b/tests/services/seatable-client.test.ts
@@ -13,7 +13,7 @@ import type {
 import { DEFAULT_CONFIG_ENTRY } from '../../src/types';
 import { SEATABLE_BATCH_SIZE } from '../../src/constants';
 import { RateLimiter } from '../../src/services/rate-limiter';
-import { BATCH_LIMIT_ERROR } from '../../src/utils/api-errors';
+import { formatBatchLimitError } from '../../src/utils/api-errors';
 import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
@@ -409,7 +409,7 @@ describe('SeaTableClient', () => {
       expect(results[0]).toMatchObject({
         success: false,
         recordId: 'r0',
-        error: BATCH_LIMIT_ERROR(SEATABLE_BATCH_SIZE),
+        error: formatBatchLimitError(SEATABLE_BATCH_SIZE),
       });
       expect(mockRequestUrl).not.toHaveBeenCalled();
     });

--- a/tests/services/seatable-client.test.ts
+++ b/tests/services/seatable-client.test.ts
@@ -13,6 +13,7 @@ import type {
 import { DEFAULT_CONFIG_ENTRY } from '../../src/types';
 import { SEATABLE_BATCH_SIZE } from '../../src/constants';
 import { RateLimiter } from '../../src/services/rate-limiter';
+import { BATCH_LIMIT_ERROR } from '../../src/utils/api-errors';
 import { requestUrl } from 'obsidian';
 
 const mockRequestUrl = vi.mocked(requestUrl);
@@ -408,7 +409,7 @@ describe('SeaTableClient', () => {
       expect(results[0]).toMatchObject({
         success: false,
         recordId: 'r0',
-        error: `Maximum ${SEATABLE_BATCH_SIZE} records allowed per batch update`,
+        error: BATCH_LIMIT_ERROR(SEATABLE_BATCH_SIZE),
       });
       expect(mockRequestUrl).not.toHaveBeenCalled();
     });

--- a/tests/services/seatable-client.test.ts
+++ b/tests/services/seatable-client.test.ts
@@ -395,13 +395,22 @@ describe('SeaTableClient', () => {
       ]);
     });
 
-    it('should throw when exceeding batch size', async () => {
+    it('should return per-record failures when exceeding batch size', async () => {
       const updates = Array.from({ length: SEATABLE_BATCH_SIZE + 1 }, (_, i) => ({
         recordId: `r${i}`,
         fields: {},
       }));
-      await expect(client.batchUpdate(updates))
-        .rejects.toThrow(`Maximum ${SEATABLE_BATCH_SIZE} records allowed`);
+
+      const results = await client.batchUpdate(updates);
+
+      expect(results).toHaveLength(updates.length);
+      expect(results.every(r => !r.success)).toBe(true);
+      expect(results[0]).toMatchObject({
+        success: false,
+        recordId: 'r0',
+        error: `Maximum ${SEATABLE_BATCH_SIZE} records allowed per batch update`,
+      });
+      expect(mockRequestUrl).not.toHaveBeenCalled();
     });
 
     it('should return failure for all records on non-200', async () => {

--- a/tests/utils/api-errors.test.ts
+++ b/tests/utils/api-errors.test.ts
@@ -8,7 +8,10 @@ import {
   extractApiErrorMessage,
   extractApiErrorDetails,
   normalizeServerUrl,
+  buildBatchFailures,
+  BATCH_LIMIT_ERROR,
 } from '../../src/utils/api-errors';
+import type { BatchUpdate } from '../../src/types/database.types';
 
 describe('extractApiErrorMessage', () => {
   it('returns body.error_msg first (SeaTable shape)', () => {
@@ -107,5 +110,48 @@ describe('normalizeServerUrl', () => {
   it('also strips a trailing slash from the fallback when url is missing', () => {
     expect(normalizeServerUrl(undefined, 'https://example.com/'))
       .toBe('https://example.com');
+  });
+});
+
+describe('BATCH_LIMIT_ERROR', () => {
+  it('formats the canonical batch-size message', () => {
+    expect(BATCH_LIMIT_ERROR(10)).toBe('Maximum 10 records allowed per batch update');
+    expect(BATCH_LIMIT_ERROR(1000)).toBe('Maximum 1000 records allowed per batch update');
+  });
+});
+
+describe('buildBatchFailures', () => {
+  const updates: BatchUpdate[] = [
+    { recordId: 'a', fields: { Name: 'A' } },
+    { recordId: 'b', fields: { Name: 'B' } },
+  ];
+
+  it('produces one failure entry per update with the same error string', () => {
+    const results = buildBatchFailures(updates, 'boom');
+
+    expect(results).toEqual([
+      { success: false, recordId: 'a', error: 'boom' },
+      { success: false, recordId: 'b', error: 'boom' },
+    ]);
+  });
+
+  it('preserves recordId order', () => {
+    const results = buildBatchFailures(updates, 'x');
+
+    expect(results.map(r => r.recordId)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(buildBatchFailures([], 'unused')).toEqual([]);
+  });
+
+  it('narrows to the discriminated-union failure variant', () => {
+    const [first] = buildBatchFailures(updates, 'oops');
+
+    // success: false → SyncResult should expose `error`, not `updatedFields`
+    expect(first.success).toBe(false);
+    if (!first.success) {
+      expect(first.error).toBe('oops');
+    }
   });
 });

--- a/tests/utils/api-errors.test.ts
+++ b/tests/utils/api-errors.test.ts
@@ -9,7 +9,7 @@ import {
   extractApiErrorDetails,
   normalizeServerUrl,
   buildBatchFailures,
-  BATCH_LIMIT_ERROR,
+  formatBatchLimitError,
 } from '../../src/utils/api-errors';
 import type { BatchUpdate } from '../../src/types/database.types';
 
@@ -113,10 +113,10 @@ describe('normalizeServerUrl', () => {
   });
 });
 
-describe('BATCH_LIMIT_ERROR', () => {
+describe('formatBatchLimitError', () => {
   it('formats the canonical batch-size message', () => {
-    expect(BATCH_LIMIT_ERROR(10)).toBe('Maximum 10 records allowed per batch update');
-    expect(BATCH_LIMIT_ERROR(1000)).toBe('Maximum 1000 records allowed per batch update');
+    expect(formatBatchLimitError(10)).toBe('Maximum 10 records allowed per batch update');
+    expect(formatBatchLimitError(1000)).toBe('Maximum 1000 records allowed per batch update');
   });
 });
 


### PR DESCRIPTION
## Summary
- Align `DatabaseProvider.batchUpdate()` failure contract — size-limit guard now returns `SyncResult[]` failures (one per requested record) instead of throwing, matching the HTTP-failure and catch-block paths.
- Extract `buildBatchFailures` + `BATCH_LIMIT_ERROR` helpers in `src/utils/api-errors.ts` so all 6 failure sites across both clients share one shape and one wording.

## Changes

### Code
- `src/types/database.types.ts` — JSDoc on `batchUpdate` documents the failure contract.
- `src/services/{airtable,seatable}-client.ts` — guard returns `SyncResult[]` failures; 6 sites delegate to `buildBatchFailures()`.
- `src/utils/api-errors.ts` — new helpers; the `success: false as const` discriminant burden is centralized.

### Tests
- `tests/services/{airtable,seatable}-client.test.ts` — old `.rejects.toThrow` cases rewritten to verify the `SyncResult[]` shape and `mockRequestUrl` not being called; assertions reference `BATCH_LIMIT_ERROR(...)` so any wording drift surfaces immediately.
- `tests/utils/api-errors.test.ts` — 5 new cases for the two helpers.

### Docs
Handbook updated in the private docs repo (commits `9ae6327` + `75862a9`):
- §6.1 "Uniform failure shape" — canonical pattern + good/bad example.
- §6.1 "Cross-provider error extraction" — helper responsibility table.
- §9.6 Batch Processing — batch ceiling cross-link.
- §4.4 step 2 of "Adding a new provider" — contract enforced for future providers.

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (no new warnings; 3 pre-existing unrelated warnings)
- [x] `npx vitest run` — 519/519 PASS
- [ ] `npm run test:e2e` (Airtable cloud verification)
- [ ] `npm run test:seatable` (SeaTable cloud verification)

Closes #75