### PR TITLE
test: extract shared e2e harness helpers module

### DIFF
--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -66,13 +66,20 @@ export function buildSyncHarnessHelpers({ pluginId, e2eCfgId }) {
       return inst.enqueueSyncRequest(mode, scope);
     }
 
-    function waitForCache(file, key, val, maxWait = 3000) {
-      return new Promise((resolve) => {
+    // Bumped from 3s → 5s after a flaky case where metadataCache lagged
+    // behind a vault.modify() under bidirectional+autoSyncComputedFields
+    // load. Throws on timeout instead of silently returning so callers
+    // surface the cache-staleness instead of pushing the prior value.
+    function waitForCache(file, key, val, maxWait = 5000) {
+      return new Promise((resolve, reject) => {
         const start = Date.now();
         (function check() {
           const fm = app.metadataCache.getFileCache(file)?.frontmatter;
           if (fm && String(fm[key]) === String(val)) return resolve(true);
-          if (Date.now() - start > maxWait) return resolve(false);
+          if (Date.now() - start > maxWait) {
+            const seen = fm && key in fm ? JSON.stringify(fm[key]) : '<unset>';
+            return reject(new Error('waitForCache timeout: ' + key + ' expected=' + JSON.stringify(val) + ' seen=' + seen));
+          }
           setTimeout(check, 100);
         })();
       });

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -1,0 +1,219 @@
+/**
+ * Shared Obsidian-side helper builders for E2E harnesses.
+ *
+ * The harnesses inject these helpers into the Obsidian plugin runtime via
+ * CDP `Runtime.evaluate`, so we cannot ship them as a normal ESM module the
+ * runtime calls into. Instead each builder returns a JS string that the
+ * harness concatenates with its provider-specific helpers and the test
+ * expression, then evaluates as a single block.
+ *
+ * Two builders cover the surface used by all four harnesses:
+ *
+ * - {@link buildSyncHarnessHelpers}: helpers for sync harnesses
+ *   (run-e2e.mjs, run-seatable-e2e.mjs). Defines a `getConfig()` that
+ *   resolves the dedicated e2e config by ID, plus the standard sync
+ *   utilities — file I/O wait helpers, frontmatter mutation, and queue
+ *   delegation.
+ *
+ * - {@link buildSettingsHarnessHelpers}: helpers for settings-tab harnesses
+ *   (run-settings-e2e.mjs, run-seatable-settings-e2e.mjs). Defines tab
+ *   open/rerender + summary-card querying. Each settings harness layers
+ *   its own `getActiveConfig` / `getSeaConfig` on top.
+ *
+ * The non-string helper {@link buildConfigExpr} stays a regular ESM export —
+ * it runs in the harness Node process to assemble assignment lines, never
+ * inside the Obsidian runtime.
+ */
+
+/**
+ * Build the helper string for sync harnesses (run-e2e.mjs, run-seatable-e2e.mjs).
+ *
+ * @param {object} opts
+ * @param {string} opts.pluginId  Plugin ID (e.g. 'auto-note-importer').
+ * @param {string} opts.e2eCfgId  Dedicated e2e config ID — `getConfig()`
+ *                                resolves to this, falling back to the first
+ *                                config when the e2e setup hasn't run yet.
+ * @returns {string} JS source ready to inject into a CDP `Runtime.evaluate`.
+ */
+export function buildSyncHarnessHelpers({ pluginId, e2eCfgId }) {
+  return `
+    function getPlugin() { return app.plugins.plugins['${pluginId}']; }
+
+    function getConfig() {
+      const p = getPlugin();
+      return p.settings.configs.find(c => c.id === '${e2eCfgId}') || p.settings.configs[0];
+    }
+
+    function getCredential(config) {
+      const p = getPlugin();
+      const cfg = config || getConfig();
+      return p.settings.credentials.find(c => c.id === cfg.credentialId);
+    }
+
+    function getInstance(config) {
+      const p = getPlugin();
+      const cfg = config || getConfig();
+      return p.configManager.getInstance(cfg.id);
+    }
+
+    function setMode(mode, autoFormula, config) {
+      const cfg = config || getConfig();
+      const cred = getCredential(cfg);
+      cfg.conflictResolution = mode;
+      if (autoFormula !== undefined) cfg.autoSyncComputedFields = autoFormula;
+      getInstance(cfg).updateSettings(cfg, cred);
+    }
+
+    async function enqueueSync(mode, scope, config) {
+      const cfg = config || getConfig();
+      const inst = getInstance(cfg);
+      if (!inst) throw new Error('No ConfigInstance for ' + cfg.id);
+      return inst.enqueueSyncRequest(mode, scope);
+    }
+
+    function waitForCache(file, key, val, maxWait = 3000) {
+      return new Promise((resolve) => {
+        const start = Date.now();
+        (function check() {
+          const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+          if (fm && String(fm[key]) === String(val)) return resolve(true);
+          if (Date.now() - start > maxWait) return resolve(false);
+          setTimeout(check, 100);
+        })();
+      });
+    }
+
+    async function openAndActivate(path) {
+      const file = app.vault.getAbstractFileByPath(path);
+      if (!file) throw new Error('No file at ' + path);
+      const leaf = app.workspace.getLeaf(false);
+      await leaf.openFile(file);
+      await new Promise(r => setTimeout(r, 800));
+      return file;
+    }
+
+    async function modifyField(file, key, value) {
+      let content = await app.vault.read(file);
+      const re = new RegExp('^' + key + ':.*$', 'm');
+      const line = key + ': ' + (typeof value === 'string' && /[:#\\-]/.test(value) ? JSON.stringify(value) : value);
+      if (re.test(content)) {
+        content = content.replace(re, line);
+      } else {
+        content = content.replace(/^---\\n([\\s\\S]*?)\\n---/, (_, body) => '---\\n' + body + '\\n' + line + '\\n---');
+      }
+      await app.vault.modify(file, content);
+      await waitForCache(file, key, value);
+    }
+  `;
+}
+
+/**
+ * Build the helper string for settings-tab harnesses (run-settings-e2e.mjs,
+ * run-seatable-settings-e2e.mjs).
+ *
+ * @param {object} opts
+ * @param {string} opts.pluginId  Plugin ID (e.g. 'auto-note-importer').
+ * @returns {string} JS source ready to inject into a CDP `Runtime.evaluate`.
+ */
+export function buildSettingsHarnessHelpers({ pluginId }) {
+  return `
+    function getPlugin() { return app.plugins.plugins['${pluginId}']; }
+
+    function getSettingsTab() {
+      return app.setting.pluginTabs.find(t => t.id === '${pluginId}');
+    }
+
+    async function openSettingsTab() {
+      app.setting.open();
+      await new Promise(r => setTimeout(r, 200));
+      const tab = getSettingsTab();
+      if (!tab) throw new Error('Plugin settings tab not found');
+      app.setting.openTab(tab);
+      tab.display();
+      await new Promise(r => setTimeout(r, 400));
+      return tab;
+    }
+
+    async function rerenderTab() {
+      const tab = getSettingsTab();
+      if (tab) tab.display();
+      await new Promise(r => setTimeout(r, 300));
+      return tab;
+    }
+
+    function getContainer() {
+      return getSettingsTab()?.containerEl;
+    }
+
+    function queryCards(container) {
+      const el = container || getContainer();
+      return Array.from(el.querySelectorAll('.ani-summary-card'));
+    }
+
+    function cardInfo(card) {
+      return {
+        title: card.querySelector('.ani-card-title')?.textContent || '',
+        summary: card.querySelector('.ani-card-summary')?.textContent || '',
+        badge: card.querySelector('.ani-card-badge')?.textContent || '',
+        isOk: !!card.querySelector('.ani-card-badge-ok'),
+        isOff: !!card.querySelector('.ani-card-badge-off'),
+        expanded: card.classList.contains('is-expanded'),
+      };
+    }
+
+    function allCardInfos(container) {
+      return queryCards(container).map(c => cardInfo(c));
+    }
+  `;
+}
+
+/**
+ * Assemble `cfg.<key> = <value>;` lines from an overrides object. Used by
+ * both settings harnesses to generate inline assignments inside their
+ * `setConfigAndQuery` helper. Stays a regular ESM export — the result is
+ * a string literal pasted into the eval block, but the building runs in
+ * the Node-side harness, not inside Obsidian.
+ *
+ * @param {Record<string, unknown>} overrides
+ * @returns {string}
+ */
+export function buildConfigExpr(overrides) {
+  return Object.entries(overrides)
+    .map(([key, value]) => {
+      const v = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'`
+        : typeof value === 'boolean' ? String(value)
+        : value;
+      return `cfg.${key} = ${v};`;
+    })
+    .join('\n      ');
+}
+
+/**
+ * Build the canonical `setConfigAndQuery` helper used by both settings
+ * harnesses. Each harness keeps its own `getActiveConfig` definition (the
+ * fixture strategy differs — Airtable settings reuses the user's active
+ * config, SeaTable settings injects a dedicated e2e config and marks it
+ * active) but the resolution name is the same, so the rest of the body is
+ * identical. Factory parameters are the harness's `HELPERS` string and
+ * `run()` function.
+ *
+ * @param {object} opts
+ * @param {string} opts.helpers   Composed HELPERS string (factory output + provider-specific).
+ * @param {(expr: string, timeoutMs?: number) => Promise<unknown>} opts.run
+ *                                The harness's CDP eval wrapper.
+ * @returns {(overrides: Record<string, unknown>) => Promise<unknown>}
+ */
+export function makeSetConfigAndQuery({ helpers, run }) {
+  return async function setConfigAndQuery(overrides) {
+    const assignments = buildConfigExpr(overrides);
+    return run(`(async () => {
+      ${helpers}
+      const p = getPlugin();
+      const cfg = getActiveConfig();
+      ${assignments}
+      await p.saveSettings();
+      await rerenderTab();
+      return JSON.stringify(allCardInfos());
+    })()`, 10000);
+  };
+}

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -1,29 +1,24 @@
 /**
- * Shared Obsidian-side helper builders for E2E harnesses.
+ * Shared E2E harness helpers — used by every harness under tests/e2e/.
  *
- * The harnesses inject these helpers into the Obsidian plugin runtime via
- * CDP `Runtime.evaluate`, so we cannot ship them as a normal ESM module the
- * runtime calls into. Instead each builder returns a JS string that the
- * harness concatenates with its provider-specific helpers and the test
- * expression, then evaluates as a single block.
+ * Two flavors live in this module:
  *
- * Two builders cover the surface used by all four harnesses:
+ * 1. **String factories** ({@link buildSyncHarnessHelpers},
+ *    {@link buildSettingsHarnessHelpers}) — return JS source that the
+ *    harness concatenates with its provider-specific inline helpers and
+ *    the test expression, then evaluates inside the Obsidian plugin
+ *    runtime via CDP `Runtime.evaluate`. We can't ship these as regular
+ *    ESM functions because the harness Node process can't reach into
+ *    Obsidian's plugin scope.
  *
- * - {@link buildSyncHarnessHelpers}: helpers for sync harnesses
- *   (run-e2e.mjs, run-seatable-e2e.mjs). Defines a `getConfig()` that
- *   resolves the dedicated e2e config by ID, plus the standard sync
- *   utilities — file I/O wait helpers, frontmatter mutation, and queue
- *   delegation.
- *
- * - {@link buildSettingsHarnessHelpers}: helpers for settings-tab harnesses
- *   (run-settings-e2e.mjs, run-seatable-settings-e2e.mjs). Defines tab
- *   open/rerender + summary-card querying. Each settings harness layers
- *   its own `getActiveConfig` / `getSeaConfig` on top.
- *
- * The non-string helper {@link buildConfigExpr} stays a regular ESM export —
- * it runs in the harness Node process to assemble assignment lines, never
- * inside the Obsidian runtime.
+ * 2. **Node-side ESM utilities** ({@link createTestHarness},
+ *    {@link makeSetConfigAndQuery}, {@link buildConfigEntry},
+ *    {@link buildConfigExpr}) — run in the harness Node process. They
+ *    own the test runner scaffolding, ConfigEntry default merging, and
+ *    config-mutation expression assembly. Output strings get spliced
+ *    into the eval block, but the assembly itself happens here.
  */
+import { evalInObsidian } from './cdp-helpers.mjs';
 
 /**
  * Build the helper string for sync harnesses (run-e2e.mjs, run-seatable-e2e.mjs).
@@ -177,6 +172,101 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
  * @param {Record<string, unknown>} overrides
  * @returns {string}
  */
+/**
+ * Build a per-harness test runner with shared `run` / `test` / `log`
+ * scaffolding. Returns the four pieces every harness used to redeclare
+ * verbatim. The `targetId` reference goes through a getter so each
+ * harness can resolve `findPageTarget()` lazily after construction.
+ *
+ * `skipSupported: true` enables the sync-harness convention where a test
+ * fn returns `{ skip: true, detail }` to mark the case as skipped (not
+ * failed) — used by `run-e2e.mjs` for formula-dependent assertions when
+ * the Calculation column is missing.
+ *
+ * @param {object} opts
+ * @param {() => string | undefined} opts.getTargetId
+ *   Returns the resolved CDP target ID. Called inside `run`, so the
+ *   harness can assign `targetId` after `findPageTarget()` resolves.
+ * @param {boolean} [opts.skipSupported=false]
+ *   When true, `test` honors `{ skip: true }` returns from the test fn.
+ */
+export function createTestHarness({ getTargetId, skipSupported = false }) {
+  const results = [];
+  const log = (msg) => console.log(msg);
+
+  const run = async (expr, timeout) => {
+    const r = await evalInObsidian(getTargetId(), expr, timeout);
+    if (r && typeof r === 'object' && r.__error) throw new Error(r.__error);
+    return r;
+  };
+
+  const test = async (name, fn) => {
+    log(`\n=== ${name} ===`);
+    try {
+      const result = await fn();
+      if (skipSupported && result?.skip) {
+        results.push({ test: name, pass: true, skip: true, detail: result.detail || 'skipped' });
+        log(`SKIP - ${result.detail || 'skipped'}`);
+        return;
+      }
+      const { pass, detail } = result;
+      results.push({ test: name, pass, detail: detail || 'ok' });
+      log(pass ? 'PASS' : `FAIL - ${detail}`);
+    } catch (e) {
+      results.push({ test: name, pass: false, detail: e.message });
+      log(`FAIL - ${e.message}`);
+    }
+  };
+
+  return { results, log, run, test };
+}
+
+/**
+ * Build a ConfigEntry object with project defaults, merging the supplied
+ * overrides on top. The 19 default fields kept the three e2e harnesses
+ * with near-identical literal blocks; this factory collapses them so
+ * each harness only specifies what differs (id / name / credentialId /
+ * tableId / folderPath, plus per-suite knobs like bidirectionalSync).
+ *
+ * The returned plain object is meant to be `JSON.stringify`'d into the
+ * eval block — it doesn't reference any plugin runtime values.
+ *
+ * Defaults track `DEFAULT_CONFIG_ENTRY` in `src/types/config.types.ts`;
+ * adding a new field there means updating this default too. The e2e
+ * suites surface mismatches at runtime since unset booleans/numbers
+ * change observable behavior.
+ *
+ * @param {Partial<Record<string, unknown>>} overrides
+ */
+export function buildConfigEntry(overrides = {}) {
+  return {
+    id: '',
+    name: '',
+    enabled: true,
+    credentialId: '',
+    baseId: '',
+    tableId: '',
+    viewId: '',
+    folderPath: '',
+    templatePath: '',
+    filenameFieldName: 'Name',
+    subfolderFieldName: '',
+    syncInterval: 0,
+    allowOverwrite: true,
+    bidirectionalSync: false,
+    conflictResolution: 'manual',
+    watchForChanges: false,
+    fileWatchDebounce: 2000,
+    autoSyncComputedFields: false,
+    formulaSyncDelay: 1500,
+    generateBasesFile: false,
+    basesFileLocation: 'vault-root',
+    basesCustomPath: '',
+    basesRegenerateOnSync: false,
+    ...overrides,
+  };
+}
+
 export function buildConfigExpr(overrides) {
   return Object.entries(overrides)
     .map(([key, value]) => {

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -163,16 +163,6 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
 }
 
 /**
- * Assemble `cfg.<key> = <value>;` lines from an overrides object. Used by
- * both settings harnesses to generate inline assignments inside their
- * `setConfigAndQuery` helper. Stays a regular ESM export — the result is
- * a string literal pasted into the eval block, but the building runs in
- * the Node-side harness, not inside Obsidian.
- *
- * @param {Record<string, unknown>} overrides
- * @returns {string}
- */
-/**
  * Build a per-harness test runner with shared `run` / `test` / `log`
  * scaffolding. Returns the four pieces every harness used to redeclare
  * verbatim. The `targetId` reference goes through a getter so each
@@ -231,10 +221,12 @@ export function createTestHarness({ getTargetId, skipSupported = false }) {
  * The returned plain object is meant to be `JSON.stringify`'d into the
  * eval block — it doesn't reference any plugin runtime values.
  *
- * Defaults track `DEFAULT_CONFIG_ENTRY` in `src/types/config.types.ts`;
- * adding a new field there means updating this default too. The e2e
- * suites surface mismatches at runtime since unset booleans/numbers
- * change observable behavior.
+ * Defaults track `DEFAULT_CONFIG_ENTRY` in `src/types/config.types.ts`,
+ * with one intentional deviation: `filenameFieldName` defaults to `'Name'`
+ * here (vs `''` upstream) because every e2e suite needs a non-empty
+ * filename field to identify records. Adding a new field upstream means
+ * updating this default too — the e2e suites surface mismatches at
+ * runtime since unset booleans/numbers change observable behavior.
  *
  * @param {Partial<Record<string, unknown>>} overrides
  */
@@ -267,6 +259,16 @@ export function buildConfigEntry(overrides = {}) {
   };
 }
 
+/**
+ * Assemble `cfg.<key> = <value>;` lines from an overrides object. Used by
+ * both settings harnesses to generate inline assignments inside their
+ * `setConfigAndQuery` helper. Stays a regular ESM export — the result is
+ * a string literal pasted into the eval block, but the building runs in
+ * the Node-side harness, not inside Obsidian.
+ *
+ * @param {Record<string, unknown>} overrides
+ * @returns {string}
+ */
 export function buildConfigExpr(overrides) {
   return Object.entries(overrides)
     .map(([key, value]) => {

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -180,9 +180,20 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
 export function buildConfigExpr(overrides) {
   return Object.entries(overrides)
     .map(([key, value]) => {
-      const v = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'`
-        : typeof value === 'boolean' ? String(value)
-        : value;
+      // String literals need both backslash and single-quote escapes so
+      // values like Windows-style paths or quoted text survive the eval
+      // round-trip intact. Other scalars (boolean / number) stringify
+      // safely on their own; the JSON.stringify catch-all covers any
+      // remaining shape (null / object / array) — without it those
+      // would degrade to `null` / `[object Object]` in the eval'd code.
+      let v;
+      if (typeof value === 'string') {
+        v = `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+      } else if (typeof value === 'boolean' || typeof value === 'number') {
+        v = String(value);
+      } else {
+        v = JSON.stringify(value);
+      }
       return `cfg.${key} = ${v};`;
     })
     .join('\n      ');

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -1053,7 +1053,7 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
-        const cfg1 = getConfig(0);
+        const cfg1 = getConfig();
         const cfg2 = p.settings.configs.find(c => c.id === '${MULTI_CONFIG_ID}');
         if (!cfg2) return JSON.stringify({ pass: false, detail: 'Second config not found' });
 
@@ -1094,7 +1094,7 @@ async function test(name, fn) {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
-        const cfg1 = getConfig(0);
+        const cfg1 = getConfig();
         const cfg2 = p.settings.configs.find(c => c.id === '${MULTI_CONFIG_ID}');
         if (!cfg2) return JSON.stringify({ pass: false, detail: 'Second config not found' });
 

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -238,6 +238,11 @@ async function setup() {
       tableId: ENV.tableId,
       folderPath: ENV.folderPath,
       bidirectionalSync: true,
+      // Default 1500ms wasn't enough for Airtable Cloud's formula
+      // recompute under bidirectional+autoSyncComputedFields=true,
+      // making the post-push pull see the prior 'Single line text'
+      // value reflected in Calculation. Extra headroom for cloud lag.
+      formulaSyncDelay: 5000,
     }))});
 
     await p.saveSettings();
@@ -957,7 +962,11 @@ async function cleanupMultiConfig() {
         const cfg = getConfig();
         const cred = getCredential();
 
-        // Add second config
+        // Multi-config secondary cfg. credentialId / baseId reference
+        // the e2e cfg's resolved values at eval time, so this stays
+        // inline rather than going through buildConfigEntry (which
+        // pre-stringifies at Node-side and can't see plugin runtime
+        // variables).
         const secondConfig = {
           id: '${MULTI_CONFIG_ID}',
           name: 'E2E Multi',

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -33,6 +33,7 @@
 
 import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
+import { buildSyncHarnessHelpers } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -101,27 +102,9 @@ let hasCalField = false;
 // Obsidian-side helpers (injected into eval expressions)
 // ---------------------------------------------------------------------------
 
-const HELPERS = `
-  function waitForCache(file, key, val, maxWait = 3000) {
-    return new Promise((resolve) => {
-      const start = Date.now();
-      (function check() {
-        const fm = app.metadataCache.getFileCache(file)?.frontmatter;
-        if (fm && String(fm[key]) === String(val)) return resolve(true);
-        if (Date.now() - start > maxWait) return resolve(false);
-        setTimeout(check, 100);
-      })();
-    });
-  }
-
-  async function openAndActivate(path) {
-    const file = app.vault.getAbstractFileByPath(path);
-    const leaf = app.workspace.getLeaf(false);
-    await leaf.openFile(file);
-    await new Promise(r => setTimeout(r, 800));
-    return file;
-  }
-
+const HELPERS = buildSyncHarnessHelpers({ pluginId: PLUGIN_ID, e2eCfgId: E2E_AT_CFG_ID }) + `
+  // Airtable-specific: replace E2ECount value via in-place regex (avoids
+  // the JSON.stringify quoting modifyField applies for non-numerics).
   async function modifyCount(file, newCount) {
     let content = await app.vault.read(file);
     content = content.replace(/E2ECount: \\d+/, 'E2ECount: ' + newCount);
@@ -129,25 +112,10 @@ const HELPERS = `
     await waitForCache(file, 'E2ECount', newCount);
   }
 
-  /**
-   * Generic frontmatter field editor. Replaces an existing 'key: value'
-   * line in-place, or appends one before the closing --- if absent.
-   * Strings containing colon/hash/hyphen are JSON.stringify-quoted to
-   * keep YAML happy.
-   */
-  async function modifyField(file, key, value) {
-    let content = await app.vault.read(file);
-    const re = new RegExp('^' + key + ':.*$', 'm');
-    const line = key + ': ' + (typeof value === 'string' && /[:#\\-]/.test(value) ? JSON.stringify(value) : value);
-    if (re.test(content)) {
-      content = content.replace(re, line);
-    } else {
-      content = content.replace(/^---\\n([\\s\\S]*?)\\n---/, (_, body) => '---\\n' + body + '\\n' + line + '\\n---');
-    }
-    await app.vault.modify(file, content);
-    await waitForCache(file, key, value);
-  }
-
+  // Airtable-specific: idempotent column creation via Meta API. Skips
+  // formula/rollup/lookup (the API rejects those — pre-add them via the
+  // Airtable UI). Returns { added, skipped, unsupported } so callers can
+  // downgrade computed-field cases gracefully.
   async function ensureFields(required) {
     const cfg = getConfig();
     const cred = getCredential();
@@ -205,39 +173,7 @@ const HELPERS = `
     return { added, skipped, unsupported };
   }
 
-  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
-
-  // Default getConfig() returns the dedicated e2e config (added during
-  // setup). Pass an explicit numeric index only if you really need the
-  // user's first non-e2e config — none of our suites do.
-  function getConfig(idx) {
-    const p = getPlugin();
-    if (idx === undefined) {
-      return p.settings.configs.find(c => c.id === '${E2E_AT_CFG_ID}') || p.settings.configs[0];
-    }
-    return p.settings.configs[idx];
-  }
-
-  function getCredential(config) {
-    const p = getPlugin();
-    const cfg = config || getConfig();
-    return p.settings.credentials.find(c => c.id === cfg.credentialId);
-  }
-
-  function getInstance(config) {
-    const p = getPlugin();
-    const cfg = config || getConfig();
-    return p.configManager.getInstance(cfg.id);
-  }
-
-  function setMode(mode, autoFormula, config) {
-    const cfg = config || getConfig();
-    const cred = getCredential(cfg);
-    cfg.conflictResolution = mode;
-    if (autoFormula !== undefined) cfg.autoSyncComputedFields = autoFormula;
-    getInstance(cfg).updateSettings(cfg, cred);
-  }
-
+  // Airtable-specific: single-record GET against the data API.
   async function fetchRecord(recordId, config) {
     const cfg = config || getConfig();
     const cred = getCredential(cfg);
@@ -246,12 +182,6 @@ const HELPERS = `
       { headers: { 'Authorization': 'Bearer ' + cred.apiKey } }
     );
     return (await resp.json()).fields;
-  }
-
-  async function enqueueSync(mode, scope, config) {
-    const cfg = config || getConfig();
-    const inst = getInstance(cfg);
-    return inst.enqueueSyncRequest(mode, scope);
   }
 `;
 

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -31,9 +31,9 @@
  *   CDP_TARGET_ID=<id> node tests/e2e/run-e2e.mjs       # specify CDP page target
  */
 
-import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+import { findPageTarget } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
-import { buildSyncHarnessHelpers } from './obsidian-helpers.mjs';
+import { buildSyncHarnessHelpers, buildConfigEntry, createTestHarness } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -189,16 +189,11 @@ const HELPERS = buildSyncHarnessHelpers({ pluginId: PLUGIN_ID, e2eCfgId: E2E_AT_
 // Test runner
 // ---------------------------------------------------------------------------
 
-const results = [];
 let targetId;
-
-function log(msg) { console.log(msg); }
-
-async function run(expr, timeout) {
-  const r = await evalInObsidian(targetId, expr, timeout);
-  if (r && typeof r === 'object' && r.__error) throw new Error(r.__error);
-  return r;
-}
+const { results, log, run, test } = createTestHarness({
+  getTargetId: () => targetId,
+  skipSupported: true,
+});
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -235,31 +230,15 @@ async function setup() {
       apiKey: sourceCred.apiKey,
     });
 
-    p.settings.configs.push({
-      id: cfgId,
+    p.settings.configs.push(${JSON.stringify(buildConfigEntry({
+      id: E2E_AT_CFG_ID,
       name: 'E2E Airtable Cfg',
-      enabled: true,
-      credentialId: credId,
-      baseId: ${JSON.stringify(ENV.baseId)},
-      tableId: ${JSON.stringify(ENV.tableId)},
-      viewId: '',
-      folderPath: ${JSON.stringify(ENV.folderPath)},
-      templatePath: '',
-      filenameFieldName: 'Name',
-      subfolderFieldName: '',
-      syncInterval: 0,
-      allowOverwrite: true,
+      credentialId: E2E_AT_CRED_ID,
+      baseId: ENV.baseId,
+      tableId: ENV.tableId,
+      folderPath: ENV.folderPath,
       bidirectionalSync: true,
-      conflictResolution: 'manual',
-      watchForChanges: false,
-      fileWatchDebounce: 2000,
-      autoSyncComputedFields: false,
-      formulaSyncDelay: 1500,
-      generateBasesFile: false,
-      basesFileLocation: 'vault-root',
-      basesCustomPath: '',
-      basesRegenerateOnSync: false,
-    });
+    }))});
 
     await p.saveSettings();
     return JSON.stringify({ ok: true });
@@ -487,24 +466,6 @@ async function cleanupMultiConfig() {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-async function test(name, fn) {
-  log(`\n=== ${name} ===`);
-  try {
-    const result = await fn();
-    if (result?.skip) {
-      results.push({ test: name, pass: true, skip: true, detail: result.detail || 'skipped' });
-      log(`SKIP - ${result.detail || 'skipped'}`);
-      return;
-    }
-    const { pass, detail } = result;
-    results.push({ test: name, pass, detail });
-    log(pass ? 'PASS' : `FAIL - ${detail}`);
-  } catch (e) {
-    results.push({ test: name, pass: false, detail: e.message });
-    log(`FAIL - ${e.message}`);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Main

--- a/tests/e2e/run-seatable-e2e.mjs
+++ b/tests/e2e/run-seatable-e2e.mjs
@@ -95,15 +95,19 @@ let testRowIds = [];
 // ---------------------------------------------------------------------------
 
 const HELPERS = buildSyncHarnessHelpers({ pluginId: PLUGIN_ID, e2eCfgId: E2E_CFG_ID }) + `
-  // SeaTable Base-Token exchange. Caches nothing — each helper that needs
-  // it calls exchangeBaseToken() fresh. Acceptable for e2e since per-test
-  // overhead is dominated by the actual sync work.
+  // SeaTable Base-Token exchange with cross-eval cache to dodge
+  // rate-limit and connection-pool exhaustion. The base-token has
+  // a 3-day TTL so the cache stays valid for the entire e2e
+  // session. globalThis persists across every run() eval block,
+  // unlike module-local consts which the eval wrapper rebuilds.
   async function exchangeBaseToken() {
+    if (globalThis.__e2eSeaTableToken__) return globalThis.__e2eSeaTableToken__;
     const cred = getCredential();
     const url = cred.serverUrl.replace(/\\/+$/, '') + '/api/v2.1/dtable/app-access-token/';
     const r = await fetch(url, { headers: { 'Authorization': 'Token ' + cred.apiToken } });
     if (!r.ok) throw new Error('Base-Token exchange failed: HTTP ' + r.status);
-    return await r.json();
+    globalThis.__e2eSeaTableToken__ = await r.json();
+    return globalThis.__e2eSeaTableToken__;
   }
 
   function buildBaseUrl(tok, path) {

--- a/tests/e2e/run-seatable-e2e.mjs
+++ b/tests/e2e/run-seatable-e2e.mjs
@@ -42,9 +42,9 @@
  *   node tests/e2e/run-seatable-e2e.mjs --cleanup    # also deletes rows
  */
 
-import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+import { findPageTarget } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
-import { buildSyncHarnessHelpers } from './obsidian-helpers.mjs';
+import { buildSyncHarnessHelpers, buildConfigEntry, createTestHarness } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -201,30 +201,8 @@ const HELPERS = buildSyncHarnessHelpers({ pluginId: PLUGIN_ID, e2eCfgId: E2E_CFG
 // Test runner
 // ---------------------------------------------------------------------------
 
-const results = [];
 let targetId;
-
-function log(msg) { console.log(msg); }
-
-async function run(expr, timeout) {
-  const r = await evalInObsidian(targetId, expr, timeout);
-  if (r && typeof r === 'object' && r.__error) {
-    throw new Error(r.__error);
-  }
-  return r;
-}
-
-async function test(name, fn) {
-  log(`\n=== ${name} ===`);
-  try {
-    const { pass, detail } = await fn();
-    results.push({ test: name, pass, detail: detail || 'ok' });
-    log(pass ? 'PASS' : `FAIL - ${detail}`);
-  } catch (e) {
-    results.push({ test: name, pass: false, detail: e.message });
-    log(`FAIL - ${e.message}`);
-  }
-}
+const { results, log, run, test } = createTestHarness({ getTargetId: () => targetId });
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -253,31 +231,15 @@ async function setup() {
       serverUrl: ${JSON.stringify(ENV.serverUrl)},
     });
 
-    p.settings.configs.push({
-      id: cfgId,
+    p.settings.configs.push(${JSON.stringify(buildConfigEntry({
+      id: E2E_CFG_ID,
       name: 'E2E SeaTable Cfg',
-      enabled: true,
-      credentialId: credId,
-      baseId: '',
-      tableId: ${JSON.stringify(ENV.tableId)},
-      viewId: ${JSON.stringify(ENV.viewId)},
-      folderPath: ${JSON.stringify(ENV.folderPath)},
-      templatePath: '',
-      filenameFieldName: 'Name',
-      subfolderFieldName: '',
-      syncInterval: 0,
-      allowOverwrite: true,
+      credentialId: E2E_CRED_ID,
+      tableId: ENV.tableId,
+      viewId: ENV.viewId,
+      folderPath: ENV.folderPath,
       bidirectionalSync: true,
-      conflictResolution: 'manual',
-      watchForChanges: false,
-      fileWatchDebounce: 2000,
-      autoSyncComputedFields: false,
-      formulaSyncDelay: 1500,
-      generateBasesFile: false,
-      basesFileLocation: 'vault-root',
-      basesCustomPath: '',
-      basesRegenerateOnSync: false,
-    });
+    }))});
 
     await p.saveSettings();
     return JSON.stringify({ ok: true });

--- a/tests/e2e/run-seatable-e2e.mjs
+++ b/tests/e2e/run-seatable-e2e.mjs
@@ -44,6 +44,7 @@
 
 import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
+import { buildSyncHarnessHelpers } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -93,34 +94,12 @@ let testRowIds = [];
 // Obsidian-side helpers (injected into eval expressions)
 // ---------------------------------------------------------------------------
 
-const HELPERS = `
-  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
-
-  function getSeaConfig() {
-    const p = getPlugin();
-    return p.settings.configs.find(c => c.id === '${E2E_CFG_ID}');
-  }
-
-  function getSeaCredential() {
-    const p = getPlugin();
-    return p.settings.credentials.find(c => c.id === '${E2E_CRED_ID}');
-  }
-
-  function getInstance(config) {
-    const p = getPlugin();
-    return p.configManager.getInstance((config || getSeaConfig()).id);
-  }
-
-  function setMode(mode, autoFormula) {
-    const cfg = getSeaConfig();
-    const cred = getSeaCredential();
-    cfg.conflictResolution = mode;
-    if (autoFormula !== undefined) cfg.autoSyncComputedFields = autoFormula;
-    getInstance().updateSettings(cfg, cred);
-  }
-
+const HELPERS = buildSyncHarnessHelpers({ pluginId: PLUGIN_ID, e2eCfgId: E2E_CFG_ID }) + `
+  // SeaTable Base-Token exchange. Caches nothing — each helper that needs
+  // it calls exchangeBaseToken() fresh. Acceptable for e2e since per-test
+  // overhead is dominated by the actual sync work.
   async function exchangeBaseToken() {
-    const cred = getSeaCredential();
+    const cred = getCredential();
     const url = cred.serverUrl.replace(/\\/+$/, '') + '/api/v2.1/dtable/app-access-token/';
     const r = await fetch(url, { headers: { 'Authorization': 'Token ' + cred.apiToken } });
     if (!r.ok) throw new Error('Base-Token exchange failed: HTTP ' + r.status);
@@ -141,8 +120,11 @@ const HELPERS = `
     return await r.json();
   }
 
+  // SeaTable-specific: idempotent column creation. SeaTable's API Gateway
+  // doesn't expose a usable DELETE /columns/, so columns added persist on
+  // the base after the run — intentional.
   async function ensureColumns(required) {
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
     const meta = await fetchMetadata();
     const tbl = meta.metadata.tables.find(t => t._id === cfg.tableId);
     if (!tbl) throw new Error('Target table ' + cfg.tableId + ' not found in metadata');
@@ -169,7 +151,7 @@ const HELPERS = `
   }
 
   async function insertRows(rows) {
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
     const tok = await exchangeBaseToken();
     const r = await fetch(buildBaseUrl(tok, 'rows/'), {
       method: 'POST',
@@ -181,7 +163,7 @@ const HELPERS = `
   }
 
   async function fetchRowFromSeaTable(rowId) {
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
     const tok = await exchangeBaseToken();
     const url = buildBaseUrl(tok, 'rows/' + rowId + '/?table_id=' + encodeURIComponent(cfg.tableId) + '&convert_keys=true');
     const r = await fetch(url, { headers: { 'Authorization': 'Bearer ' + tok.access_token } });
@@ -192,7 +174,7 @@ const HELPERS = `
 
   async function deleteRows(rowIds) {
     if (!rowIds || rowIds.length === 0) return;
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
     const tok = await exchangeBaseToken();
     await fetch(buildBaseUrl(tok, 'rows/'), {
       method: 'DELETE',
@@ -202,7 +184,7 @@ const HELPERS = `
   }
 
   async function resetRowsToInitial(rowIds, initial) {
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
     const tok = await exchangeBaseToken();
     await fetch(buildBaseUrl(tok, 'rows/'), {
       method: 'PUT',
@@ -212,52 +194,6 @@ const HELPERS = `
         updates: rowIds.map((rid, i) => ({ row_id: rid, row: initial[i] })),
       }),
     });
-  }
-
-  function waitForCache(file, key, val, maxWait = 3000) {
-    return new Promise((resolve) => {
-      const start = Date.now();
-      (function check() {
-        const fm = app.metadataCache.getFileCache(file)?.frontmatter;
-        if (fm && String(fm[key]) === String(val)) return resolve(true);
-        if (Date.now() - start > maxWait) return resolve(false);
-        setTimeout(check, 100);
-      })();
-    });
-  }
-
-  async function openAndActivate(path) {
-    const file = app.vault.getAbstractFileByPath(path);
-    if (!file) throw new Error('No file at ' + path);
-    const leaf = app.workspace.getLeaf(false);
-    await leaf.openFile(file);
-    await new Promise(r => setTimeout(r, 800));
-    return file;
-  }
-
-  /**
-   * Replace a frontmatter line in-place. Supports any scalar value (text,
-   * number, boolean, ISO date). For unsupported keys, falls back to
-   * appending a new line at the end of the frontmatter block.
-   */
-  async function modifyField(file, key, value) {
-    let content = await app.vault.read(file);
-    const re = new RegExp('^' + key + ':.*$', 'm');
-    const line = key + ': ' + (typeof value === 'string' && /[:#\\-]/.test(value) ? JSON.stringify(value) : value);
-    if (re.test(content)) {
-      content = content.replace(re, line);
-    } else {
-      // Append before the closing --- of frontmatter
-      content = content.replace(/^---\\n([\\s\\S]*?)\\n---/, (_, body) => '---\\n' + body + '\\n' + line + '\\n---');
-    }
-    await app.vault.modify(file, content);
-    await waitForCache(file, key, value);
-  }
-
-  async function enqueueSync(mode, scope, config) {
-    const inst = getInstance(config);
-    if (!inst) throw new Error('No ConfigInstance for ' + (config || getSeaConfig()).id);
-    await inst.enqueueSyncRequest(mode, scope);
   }
 `;
 
@@ -394,7 +330,7 @@ async function cleanup() {
   await run(`(async () => {
     ${HELPERS}
     const p = getPlugin();
-    const cfg = getSeaConfig();
+    const cfg = getConfig();
 
     await deleteRows(${JSON.stringify(testRowIds)});
 
@@ -441,7 +377,7 @@ async function cleanup() {
         ${HELPERS}
         await enqueueSync('pull', 'all');
         await new Promise(r => setTimeout(r, 6000));
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const files = app.vault.getFiles().filter(f =>
           f.path.startsWith(cfg.folderPath + '/') && f.extension === 'md'
         );
@@ -455,7 +391,7 @@ async function cleanup() {
     await test('pull / current refetches single note', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = await openAndActivate(cfg.folderPath + '/E2E-ST-Pull.md');
         await enqueueSync('pull', 'current');
         await new Promise(r => setTimeout(r, 4000));
@@ -475,7 +411,7 @@ async function cleanup() {
       // formula). System fields (_locked, _ctime, …) must be stripped.
       const r = await run(`(async () => {
         ${HELPERS}
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Pull.md');
         const fm = app.metadataCache.getFileCache(file)?.frontmatter || {};
         const leakedSystemKey = Object.keys(fm).some(k => k.startsWith('_'));
@@ -508,7 +444,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'Count', 555);
         await enqueueSync('push', 'all');
@@ -525,7 +461,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'Description', 'updated long-text');
         await enqueueSync('push', 'all');
@@ -542,7 +478,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'DueDate', '2027-01-15');
         await enqueueSync('push', 'all');
@@ -560,7 +496,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'Done', true);
         await enqueueSync('push', 'all');
@@ -577,7 +513,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'Status', 'Done');
         await enqueueSync('push', 'all');
@@ -596,7 +532,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('remote-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Pull.md');
         await modifyField(file, 'Count', 9999);
         await enqueueSync('push', 'all');
@@ -613,7 +549,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('manual');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Push.md');
         await modifyField(file, 'Count', 7777);
         await enqueueSync('push', 'all');
@@ -631,7 +567,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', true);
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = await openAndActivate(cfg.folderPath + '/E2E-ST-Bidir.md');
         await modifyField(file, 'Count', 450);
         await enqueueSync('bidirectional', 'all');
@@ -655,7 +591,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins', false);
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Bidir.md');
         const beforeFm = app.metadataCache.getFileCache(file)?.frontmatter || {};
         const oldCal = beforeFm.Cal;
@@ -682,7 +618,7 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         setMode('obsidian-wins');
-        const cfg = getSeaConfig();
+        const cfg = getConfig();
         const file = app.vault.getAbstractFileByPath(cfg.folderPath + '/E2E-ST-Pull.md');
         // Local Cal value is a formula; the user might "edit" it manually.
         await modifyField(file, 'Cal', 1);
@@ -702,8 +638,8 @@ async function cleanup() {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
-        const cfg = getSeaConfig();
-        const cred = getSeaCredential();
+        const cfg = getConfig();
+        const cred = getCredential();
 
         const before = app.vault.getFiles().filter(f => f.extension === 'base');
         for (const f of before) await app.vault.delete(f);

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -16,6 +16,7 @@
 
 import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
+import { buildSettingsHarnessHelpers, makeSetConfigAndQuery } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -37,10 +38,11 @@ const ENV = {
 // Obsidian-side helpers
 // ---------------------------------------------------------------------------
 
-const HELPERS = `
-  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
-
-  function getSeaConfig() {
+const HELPERS = buildSettingsHarnessHelpers({ pluginId: PLUGIN_ID }) + `
+  // SeaTable settings tests inject a dedicated e2e config keyed by
+  // E2E_CFG_ID so the user's existing configs stay untouched. The setup
+  // helper resets prior runs idempotently and marks the new config active.
+  function getActiveConfig() {
     const p = getPlugin();
     return p.settings.configs.find(c => c.id === '${E2E_CFG_ID}');
   }
@@ -87,52 +89,6 @@ const HELPERS = `
     });
     p.settings.activeConfigId = '${E2E_CFG_ID}';
   }
-
-  function getSettingsTab() {
-    return app.setting.pluginTabs.find(t => t.id === '${PLUGIN_ID}');
-  }
-
-  async function openSettingsTab() {
-    app.setting.open();
-    await new Promise(r => setTimeout(r, 200));
-    const tab = getSettingsTab();
-    if (!tab) throw new Error('Plugin settings tab not found');
-    app.setting.openTab(tab);
-    tab.display();
-    await new Promise(r => setTimeout(r, 400));
-    return tab;
-  }
-
-  async function rerenderTab() {
-    const tab = getSettingsTab();
-    if (tab) tab.display();
-    await new Promise(r => setTimeout(r, 300));
-    return tab;
-  }
-
-  function getContainer() {
-    return getSettingsTab()?.containerEl;
-  }
-
-  function queryCards(container) {
-    const el = container || getContainer();
-    return Array.from(el.querySelectorAll('.ani-summary-card'));
-  }
-
-  function cardInfo(card) {
-    return {
-      title: card.querySelector('.ani-card-title')?.textContent || '',
-      summary: card.querySelector('.ani-card-summary')?.textContent || '',
-      badge: card.querySelector('.ani-card-badge')?.textContent || '',
-      isOk: !!card.querySelector('.ani-card-badge-ok'),
-      isOff: !!card.querySelector('.ani-card-badge-off'),
-      expanded: card.classList.contains('is-expanded'),
-    };
-  }
-
-  function allCardInfos(container) {
-    return queryCards(container).map(c => cardInfo(c));
-  }
 `;
 
 // ---------------------------------------------------------------------------
@@ -162,29 +118,7 @@ async function test(name, fn) {
   }
 }
 
-function buildConfigExpr(overrides) {
-  return Object.entries(overrides)
-    .map(([key, value]) => {
-      const v = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'`
-        : typeof value === 'boolean' ? String(value)
-        : value;
-      return `cfg.${key} = ${v};`;
-    })
-    .join('\n      ');
-}
-
-async function setConfigAndQuery(overrides) {
-  const assignments = buildConfigExpr(overrides);
-  return run(`(async () => {
-    ${HELPERS}
-    const p = getPlugin();
-    const cfg = getSeaConfig();
-    ${assignments}
-    await p.saveSettings();
-    await rerenderTab();
-    return JSON.stringify(allCardInfos());
-  })()`, 10000);
-}
+const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -14,9 +14,9 @@
  *   node tests/e2e/run-seatable-settings-e2e.mjs
  */
 
-import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+import { findPageTarget } from './cdp-helpers.mjs';
 import { loadEnv } from './load-env.mjs';
-import { buildSettingsHarnessHelpers, makeSetConfigAndQuery } from './obsidian-helpers.mjs';
+import { buildSettingsHarnessHelpers, makeSetConfigAndQuery, buildConfigEntry, createTestHarness } from './obsidian-helpers.mjs';
 
 loadEnv();
 
@@ -62,31 +62,13 @@ const HELPERS = buildSettingsHarnessHelpers({ pluginId: PLUGIN_ID }) + `
       apiToken: ${JSON.stringify(ENV.apiToken)},
       serverUrl: ${JSON.stringify(ENV.serverUrl)},
     });
-    p.settings.configs.push({
-      id: '${E2E_CFG_ID}',
+    p.settings.configs.push(${JSON.stringify(buildConfigEntry({
+      id: E2E_CFG_ID,
       name: 'E2E SeaTable Settings Cfg',
-      enabled: true,
-      credentialId: '${E2E_CRED_ID}',
-      baseId: '',
-      tableId: ${JSON.stringify(ENV.tableId)},
-      viewId: '',
+      credentialId: E2E_CRED_ID,
+      tableId: ENV.tableId,
       folderPath: 'SeaTable-E2E-Settings',
-      templatePath: '',
-      filenameFieldName: 'Name',
-      subfolderFieldName: '',
-      syncInterval: 0,
-      allowOverwrite: true,
-      bidirectionalSync: false,
-      conflictResolution: 'manual',
-      watchForChanges: false,
-      fileWatchDebounce: 2000,
-      autoSyncComputedFields: false,
-      formulaSyncDelay: 1500,
-      generateBasesFile: false,
-      basesFileLocation: 'vault-root',
-      basesCustomPath: '',
-      basesRegenerateOnSync: false,
-    });
+    }))});
     p.settings.activeConfigId = '${E2E_CFG_ID}';
   }
 `;
@@ -95,29 +77,8 @@ const HELPERS = buildSettingsHarnessHelpers({ pluginId: PLUGIN_ID }) + `
 // Test runner
 // ---------------------------------------------------------------------------
 
-const results = [];
 let targetId;
-
-function log(msg) { console.log(msg); }
-
-async function run(expr, timeout) {
-  const r = await evalInObsidian(targetId, expr, timeout);
-  if (r && typeof r === 'object' && r.__error) throw new Error(r.__error);
-  return r;
-}
-
-async function test(name, fn) {
-  log(`\n=== ${name} ===`);
-  try {
-    const { pass, detail } = await fn();
-    results.push({ test: name, pass, detail: detail || 'ok' });
-    log(pass ? 'PASS' : `FAIL - ${detail}`);
-  } catch (e) {
-    results.push({ test: name, pass: false, detail: e.message });
-    log(`FAIL - ${e.message}`);
-  }
-}
-
+const { results, log, run, test } = createTestHarness({ getTargetId: () => targetId });
 const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -15,6 +15,7 @@
  */
 
 import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
+import { buildSettingsHarnessHelpers, makeSetConfigAndQuery } from './obsidian-helpers.mjs';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -26,62 +27,13 @@ const PLUGIN_ID = 'auto-note-importer';
 // Obsidian-side helpers
 // ---------------------------------------------------------------------------
 
-const HELPERS = `
-  function getPlugin() { return app.plugins.plugins['${PLUGIN_ID}']; }
-
+const HELPERS = buildSettingsHarnessHelpers({ pluginId: PLUGIN_ID }) + `
+  // Airtable settings tests run against the user's currently active config
+  // (no dedicated e2e config gets injected).
   function getActiveConfig() {
     const p = getPlugin();
     const id = p.settings.activeConfigId;
     return p.settings.configs.find(c => c.id === id) || p.settings.configs[0];
-  }
-
-  function getConfig(idx = 0) { return getPlugin().settings.configs[idx]; }
-
-  function getSettingsTab() {
-    return app.setting.pluginTabs.find(t => t.id === '${PLUGIN_ID}');
-  }
-
-  async function openSettingsTab() {
-    app.setting.open();
-    await new Promise(r => setTimeout(r, 200));
-    const tab = getSettingsTab();
-    if (!tab) throw new Error('Plugin settings tab not found');
-    app.setting.openTab(tab);
-    tab.display();
-    await new Promise(r => setTimeout(r, 400));
-    return tab;
-  }
-
-  async function rerenderTab() {
-    const tab = getSettingsTab();
-    if (tab) tab.display();
-    await new Promise(r => setTimeout(r, 300));
-    return tab;
-  }
-
-  function getContainer() {
-    const tab = getSettingsTab();
-    return tab?.containerEl;
-  }
-
-  function queryCards(container) {
-    const el = container || getContainer();
-    return Array.from(el.querySelectorAll('.ani-summary-card'));
-  }
-
-  function cardInfo(card) {
-    return {
-      title: card.querySelector('.ani-card-title')?.textContent || '',
-      summary: card.querySelector('.ani-card-summary')?.textContent || '',
-      badge: card.querySelector('.ani-card-badge')?.textContent || '',
-      isOk: !!card.querySelector('.ani-card-badge-ok'),
-      isOff: !!card.querySelector('.ani-card-badge-off'),
-      expanded: card.classList.contains('is-expanded'),
-    };
-  }
-
-  function allCardInfos(container) {
-    return queryCards(container).map(c => cardInfo(c));
   }
 `;
 
@@ -110,34 +62,7 @@ async function test(name, fn) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helper: set config fields and re-render settings tab
-// ---------------------------------------------------------------------------
-
-function buildConfigExpr(overrides) {
-  return Object.entries(overrides)
-    .map(([key, value]) => {
-      const v = typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'`
-        : typeof value === 'boolean' ? String(value)
-        : value;
-      return `cfg.${key} = ${v};`;
-    })
-    .join('\n      ');
-}
-
-async function setConfigAndQuery(overrides) {
-  const assignments = buildConfigExpr(overrides);
-  return run(`(async () => {
-    ${HELPERS}
-    const p = getPlugin();
-    const cfg = getActiveConfig();
-    ${assignments}
-    await p.saveSettings();
-    await rerenderTab();
-    const infos = allCardInfos();
-    return JSON.stringify(infos);
-  })()`, 10000);
-}
+const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -774,19 +774,21 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       return { pass, detail: `testBtn=${r.hasTestBtn} disabled=${r.testBtnDisabled} save=${r.hasSaveBtn} cancel=${r.hasCancelBtn}` };
     });
 
-    await test('credential / edit form rejects non-airtable credentials', async () => {
+    await test('credential / edit form rejects unsupported credential types', async () => {
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();
-        // Inject a fake seatable credential temporarily
-        const fakeId = 'e2e-fake-seatable-' + Date.now();
+        // Inject a fake credential of an unsupported type. Supabase is in
+        // CREDENTIAL_TYPES but has no registered form renderer yet, so it
+        // exercises the "Edit not supported" fallback (provider-aware UI).
+        const fakeId = 'e2e-fake-unsupported-' + Date.now();
         const savedCreds = [...p.settings.credentials];
         p.settings.credentials.push({
           id: fakeId,
-          name: 'Fake SeaTable',
-          type: 'seatable',
-          apiToken: 'x',
-          serverUrl: 'https://cloud.seatable.io',
+          name: 'Fake Supabase',
+          type: 'supabase',
+          projectUrl: 'https://example.supabase.co',
+          apiKey: 'x',
         });
 
         await openSettingsTab();
@@ -810,7 +812,12 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       return { pass, detail: `editNotSupported=${r.hasEditNotSupported}` };
     });
 
-    await test('credential / non-airtable type shows Not yet supported and disabled Save', async () => {
+    await test('credential / unsupported type shows Not yet supported and disabled Save', async () => {
+      // Picks `supabase` — defined in CREDENTIAL_TYPES but no registered
+      // form renderer, so the dropdown still lists it but the form falls
+      // back to the "Not yet supported" placeholder (§4.4 provider-aware
+      // settings UI). Switch to a different unsupported type if Supabase
+      // ever ships.
       const r = await run(`(async () => {
         ${HELPERS}
         await openSettingsTab();
@@ -820,7 +827,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         await new Promise(r => setTimeout(r, 300));
 
         const select = c.querySelector('.ani-credential-edit select');
-        select.value = 'seatable';
+        select.value = 'supabase';
         select.dispatchEvent(new Event('change'));
         await new Promise(r => setTimeout(r, 400));
 

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -14,8 +14,8 @@
  *   node tests/e2e/run-settings-e2e.mjs
  */
 
-import { findPageTarget, evalInObsidian } from './cdp-helpers.mjs';
-import { buildSettingsHarnessHelpers, makeSetConfigAndQuery } from './obsidian-helpers.mjs';
+import { findPageTarget } from './cdp-helpers.mjs';
+import { buildSettingsHarnessHelpers, makeSetConfigAndQuery, createTestHarness } from './obsidian-helpers.mjs';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -41,27 +41,8 @@ const HELPERS = buildSettingsHarnessHelpers({ pluginId: PLUGIN_ID }) + `
 // Test runner
 // ---------------------------------------------------------------------------
 
-const results = [];
 let targetId;
-
-function log(msg) { console.log(msg); }
-
-async function run(expr, timeout) {
-  return evalInObsidian(targetId, expr, timeout);
-}
-
-async function test(name, fn) {
-  log(`\n=== ${name} ===`);
-  try {
-    const { pass, detail } = await fn();
-    results.push({ test: name, pass, detail: detail || 'ok' });
-    log(pass ? 'PASS' : `FAIL - ${detail}`);
-  } catch (e) {
-    results.push({ test: name, pass: false, detail: e.message });
-    log(`FAIL - ${e.message}`);
-  }
-}
-
+const { results, log, run, test } = createTestHarness({ getTargetId: () => targetId });
 const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract ~250 LOC of duplicated helper code from 4 E2E harnesses into `tests/e2e/obsidian-helpers.mjs` (factory builders + utilities).
- Unify naming so the shared `setConfigAndQuery` helper can be a factory: `getSeaConfig` → `getActiveConfig` (settings harness) and `getSeaConfig`/`getSeaCredential` → `getConfig`/`getCredential` (sync harness, 16 call sites).

## Changes

### New module
`tests/e2e/obsidian-helpers.mjs` exports four pieces:
- `buildSyncHarnessHelpers({ pluginId, e2eCfgId })` — JS source string with 9 sync helpers (`getPlugin`, `getConfig`, `getCredential`, `getInstance`, `setMode`, `enqueueSync`, `waitForCache`, `openAndActivate`, `modifyField`).
- `buildSettingsHarnessHelpers({ pluginId })` — JS source string with 8 settings-tab helpers (`getSettingsTab`, `openSettingsTab`, `rerenderTab`, `getContainer`, `queryCards`, `cardInfo`, `allCardInfos`, plus `getPlugin`).
- `makeSetConfigAndQuery({ helpers, run })` — regular ESM factory returning the per-test settings mutation function.
- `buildConfigExpr(overrides)` — regular ESM utility for `cfg.<key> = <value>;` line assembly.

### Harness updates
Each harness imports the relevant factory, concatenates with provider-specific inline helpers (Airtable: `modifyCount` / `ensureFields` / `fetchRecord`; SeaTable sync: `exchangeBaseToken` / `buildBaseUrl` / `fetchMetadata` / `ensureColumns` / `insertRows` / `fetchRowFromSeaTable` / `deleteRows` / `resetRowsToInitial`; SeaTable settings: `ensureSeaCredentialAndConfig`).

The escape level inside the moved `modifyField` regex was kept at single-backslash (`\\n`, `\\s`, `\\S`) — outer template literal collapses it once, then plugin runtime parses the regex literal.

## LOC delta
| File | Before | After | Δ |
|:---|---:|---:|---:|
| run-e2e.mjs | 1230 | 1160 | -70 |
| run-seatable-e2e.mjs | 759 | 695 | -64 |
| run-settings-e2e.mjs | 999 | 924 | -75 |
| run-seatable-settings-e2e.mjs | 413 | 347 | -66 |
| obsidian-helpers.mjs (new) | — | 219 | +219 |
| **net** | **3401** | **3345** | **-56** |

The headline is not the -56 LOC but **4-way duplication → 1-way definition** — next provider harness should reuse helpers and save ~80 LOC outright.

## Test plan
- [x] `node --check` on all 5 e2e files
- [x] `npx vitest run` — 519/519 PASS (e2e is cloud-gated, unit suite unaffected)
- [ ] `npm run test:e2e` (Airtable cloud)
- [ ] `npm run test:settings` (Airtable settings)
- [ ] `npm run test:seatable` (SeaTable cloud)
- [ ] `npm run test:seatable:settings` (SeaTable settings)

Closes #74