### PR TITLE
fix: connection card render asymmetry on credential dropdown change

### DIFF
--- a/src/core/config-instance.ts
+++ b/src/core/config-instance.ts
@@ -34,6 +34,16 @@ export class ConfigInstance {
   readonly configId: string;
   credentialId: string;
 
+  /**
+   * The credential type this instance was constructed for. ConfigManager
+   * compares against the new credential's type on update; when they differ
+   * the instance is destroyed and re-created so a SeaTable→Airtable swap
+   * doesn't try to `reconfigure()` a SeaTableClient with an Airtable cred.
+   * Exposed as a field rather than a getter so unit-test mocks can leave
+   * it `undefined` and rely on ConfigManager's truthy guard.
+   */
+  readonly providerType: DatabaseProvider['providerType'];
+
   private app: App;
   private shared: SharedServices;
   private settings: LegacySettings;
@@ -64,6 +74,7 @@ export class ConfigInstance {
       this.rateLimiter,
       shared.getDebugMode(),
     );
+    this.providerType = this.databaseProvider.providerType;
 
     // 3. Create ConflictResolver
     this.conflictResolver = new ConflictResolver(this.settings, this.databaseProvider);

--- a/src/core/config-manager.ts
+++ b/src/core/config-manager.ts
@@ -101,6 +101,17 @@ export class ConfigManager {
     const instance = this.instances.get(configId);
 
     if (instance && config.enabled) {
+      // Credential-type change can't be handled by reconfigure() since each
+      // DatabaseProvider implementation narrows on its own credential variant
+      // (e.g. SeaTableClient throws when handed an Airtable credential).
+      // Re-create the instance from scratch so the right provider is built.
+      // The truthy guard tolerates mocked instances in unit tests where
+      // providerType isn't stubbed — production instances always expose it.
+      if (instance.providerType && instance.providerType !== credential.type) {
+        this.removeConfig(configId);
+        this.addConfig(config, credential);
+        return;
+      }
       instance.updateSettings(config, credential);
     } else if (instance && !config.enabled) {
       this.removeConfig(configId);

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -133,20 +133,27 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Summary card stack
     const cardStack = containerEl.createDiv({ cls: 'ani-card-stack' });
 
-    if (credential.type === 'airtable' && credential.apiKey) {
-      const connected = !!(config.baseId && config.tableId);
+    // The card renders by credential type alone — missing secrets just
+    // flip the badge to 'Setup required'. Previously the && apiKey / &&
+    // apiToken guard dropped the whole card when the new credential's
+    // secret was empty, which manifested as a one-way render asymmetry
+    // when the user switched credentials via the dropdown (the next
+    // display() call would only fire from an unrelated re-render — see
+    // issue #76).
+    if (credential.type === 'airtable') {
       const airtableCred = credential;
+      const connected = !!(airtableCred.apiKey && config.baseId && config.tableId);
       this.renderSummaryCard(cardStack, {
         sectionId: 'airtable-connection', icon: '\u{1F4E1}', title: 'Airtable Connection',
         summary: this.getConnectionSummary(config),
         badge: connected ? { status: 'ok', text: 'Connected' } : { status: 'off', text: 'Setup required' },
         renderContent: (c) => this.renderBaseSelector(c, config, airtableCred),
       });
-    } else if (credential.type === 'seatable' && credential.apiToken) {
+    } else if (credential.type === 'seatable') {
       // SeaTable's API token is base-specific, so the dtable_uuid is derived
       // from the credential at sync time — only tableId/viewId are user-supplied.
-      const connected = !!config.tableId;
       const seatableCred = credential;
+      const connected = !!(seatableCred.apiToken && config.tableId);
       this.renderSummaryCard(cardStack, {
         sectionId: 'seatable-connection', icon: '\u{1F4E1}', title: 'SeaTable Connection',
         summary: this.getConnectionSummary(config),

--- a/tests/core/config-manager.test.ts
+++ b/tests/core/config-manager.test.ts
@@ -177,6 +177,38 @@ describe('ConfigManager', () => {
       expect(instance.updateSettings).toHaveBeenCalledWith(updatedConfig, credential);
     });
 
+    it('should recreate instance when credential type changes', () => {
+      // Locks the #76 fix: a SeaTable→Airtable credential swap (or vice
+      // versa) destroys the old ConfigInstance and constructs a new one
+      // so the matching DatabaseProvider is built. Without this branch
+      // ConfigInstance.updateSettings would forward to
+      // SeaTableClient.reconfigure(airtableCred), which throws.
+      const config = createConfig({ id: 'cfg-1', enabled: true });
+      const airtableCred = createCredential({ id: 'cred-airtable', type: 'airtable' });
+
+      manager.addConfig(config, airtableCred);
+      const firstInstance = vi.mocked(ConfigInstance).mock.instances[0];
+      // Mock instances default to undefined providerType (handled by the
+      // truthy guard in updateConfig); production instances assign it
+      // from databaseProvider.providerType in the constructor.
+      Object.defineProperty(firstInstance, 'providerType', { value: 'airtable', configurable: true });
+
+      const seatableCred: Credential = {
+        id: 'cred-seatable',
+        name: 'Test SeaTable',
+        type: 'seatable',
+        apiToken: 'st-token',
+        serverUrl: 'https://cloud.seatable.io',
+      };
+      manager.updateConfig('cfg-1', config, seatableCred);
+
+      expect(firstInstance.destroy).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(ConfigInstance)).toHaveBeenCalledTimes(2);
+      // updateSettings on the original instance must not run — the
+      // whole point is to bypass reconfigure() for the cross-type case.
+      expect(firstInstance.updateSettings).not.toHaveBeenCalled();
+    });
+
     it('should remove instance when config is disabled', () => {
       const config = createConfig({ id: 'cfg-1', enabled: true });
       const credential = createCredential();

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -74,6 +74,12 @@ if (!ENV.baseId || !ENV.tableId) {
 // deterministic for assertions.
 const ENSURED_FIELDS = [
   { name: 'Name',        type: 'singleLineText' },
+  // Source column for Demo's stock 'Calculation' formula. Auto-ensured
+  // so the harness works on a freshly-created Demo base where this
+  // column wouldn't exist by default — without it, record creation
+  // fails with UNKNOWN_FIELD_NAME because we push 'Single line text'
+  // payloads into the formula's input.
+  { name: 'Single line text', type: 'singleLineText' },
   { name: 'E2ECount',    type: 'number', options: { precision: 0 } },
   {
     name: 'Status',
@@ -97,6 +103,11 @@ let multiConfigRecordIds = [];
 // target table — set in setup() so formula-dependent cases skip cleanly
 // if the column was renamed/removed.
 let hasCalField = false;
+// Whether the dedicated multi-config table exists on the target base.
+// Setup checks for MULTI_CONFIG_TABLE_ID; missing means we're running
+// against a base (e.g. a freshly-created Demo) where the user hasn't
+// added that table yet, so multi-config cases skip cleanly.
+let hasMultiConfigTable = false;
 
 // ---------------------------------------------------------------------------
 // Obsidian-side helpers (injected into eval expressions)
@@ -304,6 +315,11 @@ async function setup() {
 
   // Detect Demo's stock 'Calculation' formula field. Airtable's Meta
   // API can't create formula fields, so we rely on the seeded one.
+  // Verify the formula expression too — the column name alone matching
+  // isn't enough since a base may have a 'Calculation' formula that
+  // computes something different (e.g. {E2ECount}*0), in which case
+  // the assertions would silently break. Whitespace-normalized compare
+  // tolerates Airtable's rendering quirks around the curly-brace refs.
   const calcCheck = await run(`(async () => {
     ${HELPERS}
     const cfg = getConfig();
@@ -313,14 +329,43 @@ async function setup() {
     }).then(r => r.json());
     const tbl = (meta.tables || []).find(t => t.id === cfg.tableId);
     const calc = tbl?.fields?.find(f => f.name === ${JSON.stringify(CALCULATION_FIELD)} && f.type === 'formula');
-    return JSON.stringify({ found: !!calc });
+    const expected = ${JSON.stringify(`IF({${CALCULATION_SOURCE}}, {${CALCULATION_SOURCE}} & "${CALCULATION_SUFFIX}", "")`)};
+    const formula = calc?.options?.formula || '';
+    const norm = (s) => s.replace(/\\s+/g, '');
+    const formulaMatches = norm(formula) === norm(expected);
+    return JSON.stringify({ found: !!calc, formulaMatches, formula });
   })()`, 15000);
-  hasCalField = calcCheck.found;
+  hasCalField = calcCheck.found && calcCheck.formulaMatches;
   if (!hasCalField) {
-    log(`  ⚠️  Demo's stock "${CALCULATION_FIELD}" formula field not detected on the target table.`);
-    log('     Add a formula column with the seeded formula:');
+    if (!calcCheck.found) {
+      log(`  ⚠️  Demo's stock "${CALCULATION_FIELD}" formula field not detected on the target table.`);
+    } else {
+      log(`  ⚠️  "${CALCULATION_FIELD}" formula expression doesn't match the harness contract.`);
+      log(`     Got:      ${calcCheck.formula}`);
+    }
+    log('     Add or update the formula column to:');
     log(`       IF({${CALCULATION_SOURCE}}, {${CALCULATION_SOURCE}} & "${CALCULATION_SUFFIX}", "")`);
     log('     Calculation-dependent test cases will be skipped until then.');
+  }
+
+  // Detect dedicated multi-config table. Without it we skip multi-config
+  // suites instead of failing — a freshly-created Demo base wouldn't have
+  // it, and table creation via Meta API would leak across runs.
+  const multiCheck = await run(`(async () => {
+    ${HELPERS}
+    const cfg = getConfig();
+    const cred = getCredential();
+    const meta = await fetch('https://api.airtable.com/v0/meta/bases/' + cfg.baseId + '/tables', {
+      headers: { 'Authorization': 'Bearer ' + cred.apiKey },
+    }).then(r => r.json());
+    const tbl = (meta.tables || []).find(t => t.id === '${MULTI_CONFIG_TABLE_ID}');
+    return JSON.stringify({ found: !!tbl });
+  })()`, 15000);
+  hasMultiConfigTable = multiCheck.found;
+  if (!hasMultiConfigTable) {
+    log(`  ⚠️  Multi-config table '${MULTI_CONFIG_TABLE_ID}' not present on this base.`);
+    log('     Multi-config test cases will be skipped. Add a table named E2E-MultiConfig with');
+    log('     fields Name (text), Value (number), Tag (singleSelect) to enable them.');
   }
 
   log('=== Setup: Create test records ===');
@@ -955,6 +1000,7 @@ async function cleanupMultiConfig() {
     });
 
     await test('multi-config / independent sync', async () => {
+      if (!hasMultiConfigTable) return { skip: true, detail: `multi-config table '${MULTI_CONFIG_TABLE_ID}' missing — see setup notes` };
       // Setup: add second config and create records in second table
       const mcSetup = await run(`(async () => {
         ${HELPERS}
@@ -1061,6 +1107,7 @@ async function cleanupMultiConfig() {
     });
 
     await test('multi-config / folder isolation', async () => {
+      if (!hasMultiConfigTable) return { skip: true, detail: `multi-config table '${MULTI_CONFIG_TABLE_ID}' missing — see setup notes` };
       const r = await run(`(async () => {
         ${HELPERS}
         const p = getPlugin();

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -266,6 +266,67 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       return { pass, detail: `apiToken=${r.hasApiToken} server=${r.hasServerUrl} test=${r.hasTestBtn} disabled=${r.testBtnDisabled}` };
     });
 
+    // ── Issue #76: connection card refresh on credential dropdown change ──
+
+    await test('connection card / cred dropdown change renders the new card bidirectionally (#76)', async () => {
+      // Regression guard: switching the e2e config between SeaTable and
+      // Airtable credentials must swap the connection card immediately.
+      // Pre-fix the && apiKey / && apiToken guard dropped the card when
+      // the new credential's secret was empty, so this test pins both
+      // directions plus the empty-secret rendering path.
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const fakeAirtableId = 'e2e-fake-airtable-' + Date.now();
+        const savedCreds = [...p.settings.credentials];
+        p.settings.credentials.push({
+          id: fakeAirtableId,
+          name: 'Fake Airtable',
+          type: 'airtable',
+          apiKey: '',
+        });
+        const cfg = getActiveConfig();
+        const originalCredId = cfg.credentialId;
+
+        cfg.credentialId = '${E2E_CRED_ID}';
+        await p.saveSettings();
+        await rerenderTab();
+        const stStart = allCardInfos().find(c => c.title === 'SeaTable Connection');
+
+        cfg.credentialId = fakeAirtableId;
+        await p.saveSettings();
+        await rerenderTab();
+        const atAfter = allCardInfos().find(c => c.title === 'Airtable Connection');
+        const noStAfter = !allCardInfos().some(c => c.title === 'SeaTable Connection');
+
+        cfg.credentialId = '${E2E_CRED_ID}';
+        await p.saveSettings();
+        await rerenderTab();
+        const stEnd = allCardInfos().find(c => c.title === 'SeaTable Connection');
+        const noAtEnd = !allCardInfos().some(c => c.title === 'Airtable Connection');
+
+        cfg.credentialId = originalCredId;
+        p.settings.credentials = savedCreds;
+        await p.saveSettings();
+
+        return JSON.stringify({
+          stStartOk: !!stStart,
+          atAfterOk: !!atAfter,
+          atAfterBadge: atAfter?.badge || '',
+          atAfterIsOff: !!atAfter?.isOff,
+          noStAfterOk: noStAfter,
+          stEndOk: !!stEnd,
+          noAtEndOk: noAtEnd,
+        });
+      })()`, 15000);
+      const pass = r.stStartOk && r.atAfterOk && r.atAfterBadge === 'Setup required'
+        && r.atAfterIsOff && r.noStAfterOk && r.stEndOk && r.noAtEndOk;
+      return {
+        pass,
+        detail: `st→at→st: stStart=${r.stStartOk} atAfter=${r.atAfterOk} (badge="${r.atAfterBadge}",off=${r.atAfterIsOff}) noStAfter=${r.noStAfterOk} stEnd=${r.stEndOk} noAtEnd=${r.noAtEndOk}`,
+      };
+    });
+
     // ── Cleanup ──────────────────────────────────────────────────
 
     log('\n=== Cleanup ===');


### PR DESCRIPTION
## Summary

- Fix v0.9.0 regression where switching the config's credential dropdown rendered the new connection card **only one way** (Airtable → SeaTable, not the reverse).
- Address two distinct root causes: (1) UI render branch over-guarded with `&& <secret>`, (2) `ConfigManager.updateConfig` calling `DatabaseProvider.reconfigure()` across credential types, which throws inside provider impls.

## Root cause

The issue's hypothesis (the `&& apiKey` / `&& apiToken` guard) was a **first-order symptom**. The deeper cause: `saveSettings → ConfigManager.updateConfig` propagates a credential-type change to the existing `ConfigInstance`'s `DatabaseProvider.reconfigure()`. `SeaTableClient.reconfigure` narrows on `credential.type === 'seatable'`, so an `airtable` cred reaches it and throws. That throw rejects the `await saveSettings()` in `renderConfigHeader.onChange`, so `debounceDisplay()` never fires and the card never re-renders. New e2e case (`run-seatable-settings-e2e.mjs`) initially failed with `SeaTableClient cannot be reconfigured with a airtable credential` — exposing this exact path.

## Changes

### Code (commit `9eb0881`)
- `src/ui/settings-tab.ts:136` — Card renders by `credential.type` alone. Missing secret → `'Setup required'` badge instead of dropping the card. The `renderContent` callbacks (`renderBaseSelector`, `renderSeaTableConnection`) handle empty secrets gracefully (try/catch and plain text inputs respectively).
- `src/core/config-manager.ts:updateConfig` — Compare `instance.providerType` with the new `credential.type`. On mismatch, `removeConfig` + `addConfig` so a fresh provider is built. Truthy guard tolerates mocked instances in unit tests where `providerType` isn't stubbed.
- `src/core/config-instance.ts` — Expose `providerType` as a `readonly public field` (initialized from `databaseProvider.providerType` in the constructor) instead of a getter, so unit-test mocks leave it `undefined` rather than throwing on `this.databaseProvider`.

### Tests (commit `9eb0881`)
- `tests/e2e/run-seatable-settings-e2e.mjs` — New case: `connection card / cred dropdown change renders the new card bidirectionally (#76)`. Injects a fake Airtable cred (empty `apiKey`) alongside the SeaTable e2e cred, then toggles `cfg.credentialId` SeaTable → Airtable → SeaTable, asserting the matching card title appears each time and the empty-apiKey side shows `'Setup required'`. Closes the regression hole.

### E2E harness self-bootstrap (commit `1c7c005`)
The Crawling base used previously hit the public-API-call quota; switched to a Demo base. Three harness improvements so e2e survives any reasonable starting schema:
- `ENSURED_FIELDS` adds `Single line text` (auto-ensured via Meta API) — previously assumed the user pre-created it.
- `hasCalField` now also validates the formula expression matches `IF({Single line text}, {Single line text} & " - added text", "")` (whitespace-normalized). A name-only match would silently break formula assertions.
- New `hasMultiConfigTable` flag — multi-config cases skip when `MULTI_CONFIG_TABLE_ID` (Crawling-era hardcoded ID) isn't on the active base.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (no new warnings)
- [x] `npx vitest run` — 519/519 PASS
- [x] `npm run test:e2e` (Airtable Demo base) — 22/22 (15 PASS + 7 skip for missing schema)
- [x] `npm run test:settings` — 44/44 PASS
- [x] `npm run test:seatable` — 14/14 PASS
- [x] `npm run test:seatable:settings` — **11/11 PASS including the new #76 case**

Closes #76