### PR TITLE
feat: metadata-driven dropdowns for SeaTable settings UI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@
 import { Plugin, normalizePath } from "obsidian";
 import type { AutoNoteImporterSettings, ConfigEntry, SharedServices } from './types';
 import { DEFAULT_SETTINGS, CREDENTIAL_TYPE_LABELS } from './types';
-import { FieldCache } from './services';
+import { FieldCache, SeaTableMetadataCache } from './services';
 import { ConfigManager } from './core';
 import { FrontmatterParser } from './file-operations';
 import { AutoNoteImporterSettingTab } from './ui';
@@ -29,6 +29,7 @@ export default class AutoNoteImporterPlugin extends Plugin {
 
   configManager!: ConfigManager;
   fieldCache!: FieldCache;
+  seatableMetadataCache!: SeaTableMetadataCache;
   private commandFingerprint = '';
 
   async onload() {
@@ -42,10 +43,12 @@ export default class AutoNoteImporterPlugin extends Plugin {
    */
   private initializeServices(): void {
     this.fieldCache = new FieldCache();
+    this.seatableMetadataCache = new SeaTableMetadataCache();
 
     const shared: SharedServices = {
       rateLimiters: new Map(),
       fieldCache: this.fieldCache,
+      seatableMetadataCache: this.seatableMetadataCache,
       frontmatterParser: new FrontmatterParser(this.app),
       statusBarFactory: () => this.addStatusBarItem(),
       getDebugMode: () => this.settings.debugMode,
@@ -54,7 +57,12 @@ export default class AutoNoteImporterPlugin extends Plugin {
     this.configManager = new ConfigManager(this.app, shared);
     this.configManager.initialize(this.settings.configs, this.settings.credentials);
 
-    this.settingTab = new AutoNoteImporterSettingTab(this.app, this, this.fieldCache);
+    this.settingTab = new AutoNoteImporterSettingTab(
+      this.app,
+      this,
+      this.fieldCache,
+      this.seatableMetadataCache,
+    );
     this.addSettingTab(this.settingTab);
   }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,7 @@
 export { RateLimiter } from './rate-limiter';
 export { FieldCache } from './field-cache';
+export { SeaTableMetadataCache } from './seatable-metadata-cache';
+export type { SeaTableTable, SeaTableColumn, SeaTableView } from './seatable-metadata-cache';
 export { AirtableClient } from './airtable-client';
 export { SeaTableClient } from './seatable-client';
 export {

--- a/src/services/seatable-metadata-cache.ts
+++ b/src/services/seatable-metadata-cache.ts
@@ -68,6 +68,13 @@ interface RawMetadataTable {
 export class SeaTableMetadataCache {
   private cachedTokens: Map<string, CachedToken> = new Map();
   private cachedTables: Map<string, SeaTableTable[]> = new Map();
+  /**
+   * Promises currently fetching tables for a credential. Lets concurrent
+   * `fetchTables` callers (e.g. two rapid `display()` re-renders before
+   * the first network round-trip finishes) share a single in-flight
+   * request instead of racing duplicate token + metadata exchanges.
+   */
+  private inFlightTables: Map<string, Promise<SeaTableTable[]>> = new Map();
 
   /**
    * Drop everything cached for a given credential — used by the settings
@@ -76,23 +83,38 @@ export class SeaTableMetadataCache {
   clearForCred(credentialId: string): void {
     this.cachedTokens.delete(credentialId);
     this.cachedTables.delete(credentialId);
+    this.inFlightTables.delete(credentialId);
   }
 
   /** Wipe all cached metadata + tokens. */
   clear(): void {
     this.cachedTokens.clear();
     this.cachedTables.clear();
+    this.inFlightTables.clear();
   }
 
   /**
    * Fetch and cache the table metadata (tables + columns + views) for a
    * SeaTable credential. Returns the same array shape on repeat calls
-   * until {@link clearForCred} or {@link clear} is invoked.
+   * until {@link clearForCred} or {@link clear} is invoked. Concurrent
+   * calls share a single in-flight request.
    */
   async fetchTables(credential: SeaTableCredential): Promise<SeaTableTable[]> {
     const cached = this.cachedTables.get(credential.id);
     if (cached) return cached;
+    const existing = this.inFlightTables.get(credential.id);
+    if (existing) return existing;
 
+    const promise = this.fetchTablesUncached(credential);
+    this.inFlightTables.set(credential.id, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inFlightTables.delete(credential.id);
+    }
+  }
+
+  private async fetchTablesUncached(credential: SeaTableCredential): Promise<SeaTableTable[]> {
     const token = await this.getBaseToken(credential);
     const url = this.buildDtableUrl(token, 'metadata/');
     const r = await fetch(url, {

--- a/src/services/seatable-metadata-cache.ts
+++ b/src/services/seatable-metadata-cache.ts
@@ -1,0 +1,173 @@
+/**
+ * SeaTable metadata cache used by the settings UI.
+ *
+ * Mirrors the role `FieldCache` plays for Airtable: keep tables / columns
+ * / views handy for dropdown rendering without re-hitting the API every
+ * time the settings tab re-renders. SeaTable adds one wrinkle — the
+ * Base-Token exchange is also cached, since metadata calls need it and
+ * doing it lazily inside `fetchMetadata` keeps callers from juggling two
+ * round trips. Both caches are keyed by `credential.id` so swapping
+ * credentials evicts cleanly.
+ *
+ * Direct `fetch()` calls (instead of plumbing through `SeaTableClient`)
+ * are intentional: settings-tab needs metadata before any
+ * `ConfigInstance` exists for that credential, and Obsidian's
+ * `requestUrl` and the browser `fetch` produce equivalent results for
+ * SeaTable's CORS-enabled endpoints. The token refresh margin matches
+ * `SeaTableClient` so the two never diverge by more than a few seconds.
+ *
+ * @handbook 9.7-field-cache
+ * @tested tests/services/seatable-metadata-cache.test.ts
+ */
+
+import {
+  SEATABLE_BASE_TOKEN_REFRESH_MARGIN_MS,
+  SEATABLE_BASE_TOKEN_TTL_MS,
+  SEATABLE_DEFAULT_SERVER_URL,
+} from '../constants';
+import type { SeaTableCredential } from '../types';
+import { extractApiErrorDetails, normalizeServerUrl } from '../utils';
+
+interface BaseTokenResponse {
+  access_token: string;
+  dtable_uuid: string;
+  dtable_server?: string;
+}
+
+interface CachedToken extends BaseTokenResponse {
+  /** UNIX ms when this cached entry should be refreshed. */
+  refreshAt: number;
+  /** Resolved API gateway base for `/api/v2/dtables/<uuid>/...` calls. */
+  gatewayBase: string;
+}
+
+export interface SeaTableColumn {
+  name: string;
+  type: string;
+}
+
+export interface SeaTableView {
+  id: string;
+  name: string;
+}
+
+export interface SeaTableTable {
+  id: string;
+  name: string;
+  columns: SeaTableColumn[];
+  views: SeaTableView[];
+}
+
+interface RawMetadataTable {
+  _id: string;
+  name: string;
+  columns?: Array<{ name?: string; type?: string }>;
+  views?: Array<{ _id?: string; name?: string }>;
+}
+
+export class SeaTableMetadataCache {
+  private cachedTokens: Map<string, CachedToken> = new Map();
+  private cachedTables: Map<string, SeaTableTable[]> = new Map();
+
+  /**
+   * Drop everything cached for a given credential — used by the settings
+   * tab's Refresh button, and on credential edit/delete.
+   */
+  clearForCred(credentialId: string): void {
+    this.cachedTokens.delete(credentialId);
+    this.cachedTables.delete(credentialId);
+  }
+
+  /** Wipe all cached metadata + tokens. */
+  clear(): void {
+    this.cachedTokens.clear();
+    this.cachedTables.clear();
+  }
+
+  /**
+   * Fetch and cache the table metadata (tables + columns + views) for a
+   * SeaTable credential. Returns the same array shape on repeat calls
+   * until {@link clearForCred} or {@link clear} is invoked.
+   */
+  async fetchTables(credential: SeaTableCredential): Promise<SeaTableTable[]> {
+    const cached = this.cachedTables.get(credential.id);
+    if (cached) return cached;
+
+    const token = await this.getBaseToken(credential);
+    const url = this.buildDtableUrl(token, 'metadata/');
+    const r = await fetch(url, {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Failed to fetch SeaTable metadata: ${extractApiErrorDetails({
+          status: r.status,
+          json: await r.json().catch(() => undefined),
+        })}`,
+      );
+    }
+    const json = (await r.json()) as { metadata?: { tables?: RawMetadataTable[] } };
+    const rawTables = json.metadata?.tables ?? [];
+    const tables: SeaTableTable[] = rawTables.map(t => ({
+      id: t._id,
+      name: t.name,
+      columns: (t.columns ?? [])
+        .filter(c => typeof c.name === 'string' && typeof c.type === 'string')
+        .map(c => ({ name: c.name as string, type: c.type as string })),
+      views: (t.views ?? [])
+        .filter(v => typeof v._id === 'string' && typeof v.name === 'string')
+        .map(v => ({ id: v._id as string, name: v.name as string })),
+    }));
+    this.cachedTables.set(credential.id, tables);
+    return tables;
+  }
+
+  /**
+   * Lookup helper for a single table from the cached metadata. Returns
+   * `undefined` when {@link fetchTables} hasn't run yet or the table id
+   * isn't on the base.
+   */
+  getTable(credentialId: string, tableId: string): SeaTableTable | undefined {
+    return this.cachedTables.get(credentialId)?.find(t => t.id === tableId);
+  }
+
+  /**
+   * Exchange the API-Token for a short-lived Base-Token. Mirrors the
+   * caching policy in `SeaTableClient.getBaseToken` — refresh ~5 min
+   * before the 3-day TTL so clock skew can't trip us up.
+   */
+  private async getBaseToken(credential: SeaTableCredential): Promise<CachedToken> {
+    const cached = this.cachedTokens.get(credential.id);
+    if (cached && Date.now() < cached.refreshAt) return cached;
+
+    const serverUrl = normalizeServerUrl(credential.serverUrl, SEATABLE_DEFAULT_SERVER_URL);
+    const url = `${serverUrl}/api/v2.1/dtable/app-access-token/`;
+    const r = await fetch(url, {
+      headers: { Authorization: `Token ${credential.apiToken}` },
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Failed to obtain SeaTable Base-Token: ${extractApiErrorDetails({
+          status: r.status,
+          json: await r.json().catch(() => undefined),
+        })}`,
+      );
+    }
+    const body = (await r.json()) as BaseTokenResponse;
+    if (!body.access_token || !body.dtable_uuid) {
+      throw new Error('SeaTable Base-Token response missing access_token or dtable_uuid');
+    }
+    const gatewayBase = normalizeServerUrl(body.dtable_server, serverUrl);
+    const token: CachedToken = {
+      ...body,
+      gatewayBase,
+      refreshAt: Date.now() + SEATABLE_BASE_TOKEN_TTL_MS - SEATABLE_BASE_TOKEN_REFRESH_MARGIN_MS,
+    };
+    this.cachedTokens.set(credential.id, token);
+    return token;
+  }
+
+  private buildDtableUrl(token: CachedToken, path: string): string {
+    return `${token.gatewayBase}/api/v2/dtables/${token.dtable_uuid}/${path}`;
+  }
+}

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -7,11 +7,13 @@
 import type { ConflictResolutionMode, BasesFileLocation } from './settings.types';
 import type { RateLimiter } from '../services/rate-limiter';
 import type { FieldCache } from '../services/field-cache';
+import type { SeaTableMetadataCache } from '../services/seatable-metadata-cache';
 import type { FrontmatterParser } from '../file-operations/frontmatter-parser';
 
 export interface SharedServices {
   rateLimiters: Map<string, RateLimiter>;
   fieldCache: FieldCache;
+  seatableMetadataCache: SeaTableMetadataCache;
   frontmatterParser: FrontmatterParser;
   statusBarFactory: () => HTMLElement;
   getDebugMode: () => boolean;

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -45,6 +45,14 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private fieldCache: FieldCache;
   private seatableMetadataCache: SeaTableMetadataCache;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Bumped on each `display()` so async render callbacks (e.g. SeaTable
+   * metadata fetch) can detect that the DOM they captured has been
+   * superseded — without this they'd populate a detached element and
+   * leave the visible card body blank.
+   */
+  private renderGeneration = 0;
   private editingCredentialId: string | null = null;
   private addingCredential = false;
   private addingCredentialType: CredentialType = 'airtable';
@@ -112,6 +120,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   display(): void {
+    this.renderGeneration++;
     const { containerEl } = this;
     containerEl.empty();
 
@@ -805,9 +814,29 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       return;
     }
 
+    // Cold-cache loading hint — replaced by either renderSeaTableDropdowns
+    // (success) or renderSeaTableTextFallback (failure) once the fetch
+    // settles. Without this the card body sits blank for a beat.
+    const loadingHint = containerEl.createEl('p', {
+      cls: 'ani-credential-desc',
+      text: 'Loading SeaTable metadata…',
+    });
+
+    // Capture the current render generation so a subsequent display()
+    // (tab switch / cred edit) can mark our callback as stale and skip
+    // populating a detached DOM node. Without this guard the new render
+    // coexists with our zombie callback and the visible card body
+    // appears blank until another re-render kicks in.
+    const gen = this.renderGeneration;
     void this.seatableMetadataCache.fetchTables(credential).then(
-      tables => this.renderSeaTableDropdowns(containerEl, config, credential, tables),
+      tables => {
+        if (this.renderGeneration !== gen) return;
+        loadingHint.remove();
+        this.renderSeaTableDropdowns(containerEl, config, credential, tables);
+      },
       err => {
+        if (this.renderGeneration !== gen) return;
+        loadingHint.remove();
         new Notice(`Auto Note Importer: Failed to load SeaTable metadata. ${err.message || err}`);
         this.renderSeaTableTextFallback(containerEl, config);
       },
@@ -882,6 +911,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         });
       });
 
+    // Subfolder allows every column type intentionally — date / formula /
+    // single-select are all reasonable subfolder grouping keys, and we
+    // sanitize the value before using it as a path. Filename is filtered
+    // to filename-safe types because OS filename rules are stricter.
     new Setting(containerEl)
       .setName('Subfolder field (optional)')
       .setDesc('Column used for subfolder organization. Leave empty for a flat layout.')

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -15,11 +15,13 @@ import { App, PluginSettingTab, Setting, Notice, setIcon } from "obsidian";
 import type { ExtraButtonComponent, Plugin } from "obsidian";
 import {
   FieldCache,
+  SeaTableMetadataCache,
   getFieldTypeMapper,
   hasFieldTypeMapper,
   getCredentialFormRenderer,
   hasCredentialFormRenderer,
 } from '../services';
+import type { SeaTableTable } from '../services';
 import type { CredentialFormState, CredentialFormRenderer } from '../types';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, AirtableCredential, SeaTableCredential, CredentialType, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { DEFAULT_CONFIG_ENTRY, CREDENTIAL_TYPES, CREDENTIAL_TYPE_LABELS } from '../types';
@@ -41,6 +43,7 @@ export interface SettingsPlugin extends Plugin {
 export class AutoNoteImporterSettingTab extends PluginSettingTab {
   plugin: SettingsPlugin;
   private fieldCache: FieldCache;
+  private seatableMetadataCache: SeaTableMetadataCache;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private editingCredentialId: string | null = null;
   private addingCredential = false;
@@ -52,10 +55,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private pendingDeleteConfigId: string | null = null;
   private pendingDeleteCredentialId: string | null = null;
 
-  constructor(app: App, plugin: SettingsPlugin, fieldCache: FieldCache) {
+  constructor(
+    app: App,
+    plugin: SettingsPlugin,
+    fieldCache: FieldCache,
+    seatableMetadataCache: SeaTableMetadataCache,
+  ) {
     super(app, plugin);
     this.plugin = plugin;
     this.fieldCache = fieldCache;
+    this.seatableMetadataCache = seatableMetadataCache;
   }
 
   /**
@@ -786,11 +795,118 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setDesc(`No field type mapper registered for ${credential.type}.`);
       return;
     }
-    const mapper = getFieldTypeMapper(credential.type);
 
+    // Try to load metadata so dropdowns can replace ID-text inputs.
+    // If the API token isn't set yet (or fetch fails), fall back to
+    // text inputs so the user can still configure manually — same
+    // graceful-degrade contract as Airtable's renderBaseSelector.
+    if (!credential.apiToken) {
+      this.renderSeaTableTextFallback(containerEl, config);
+      return;
+    }
+
+    void this.seatableMetadataCache.fetchTables(credential).then(
+      tables => this.renderSeaTableDropdowns(containerEl, config, credential, tables),
+      err => {
+        new Notice(`Auto Note Importer: Failed to load SeaTable metadata. ${err.message || err}`);
+        this.renderSeaTableTextFallback(containerEl, config);
+      },
+    );
+  }
+
+  private renderSeaTableDropdowns(
+    containerEl: HTMLElement,
+    config: ConfigEntry,
+    credential: SeaTableCredential,
+    tables: SeaTableTable[],
+  ): void {
+    const mapper = getFieldTypeMapper(credential.type);
+    containerEl.empty();
     containerEl.createEl('p', {
       cls: 'ani-credential-desc',
-      text: 'SeaTable identifies tables, views, and columns by ID. Find them in your Base under Settings → Tables, Views, and Columns.',
+      text: 'Pick the table, view, and columns to sync. The dropdowns are populated from your SeaTable base metadata.',
+    });
+
+    const selectedTable = tables.find(t => t.id === config.tableId);
+
+    new Setting(containerEl)
+      .setName('Table')
+      .setDesc('Required. The SeaTable table to sync.')
+      .addDropdown(dropdown => {
+        dropdown.addOption('', '-- Select table --');
+        for (const t of tables) dropdown.addOption(t.id, t.name);
+        dropdown.setValue(config.tableId);
+        dropdown.onChange(async (value) => {
+          config.tableId = value;
+          // Table change invalidates view + field selections, since they're
+          // table-scoped on the SeaTable side.
+          config.viewId = '';
+          config.filenameFieldName = '';
+          config.subfolderFieldName = '';
+          await this.plugin.saveSettings();
+          this.debounceDisplay();
+        });
+      })
+      .addExtraButton(button => this.configureRefreshButton(button, 'Refresh metadata', () => {
+        this.seatableMetadataCache.clearForCred(credential.id);
+      }));
+
+    new Setting(containerEl)
+      .setName('View (optional)')
+      .setDesc('Filter synced rows by a SeaTable view. Leave empty to sync the entire table.')
+      .addDropdown(dropdown => {
+        dropdown.addOption('', '-- All rows (no view filter) --');
+        for (const v of selectedTable?.views ?? []) dropdown.addOption(v.id, v.name);
+        dropdown.setValue(config.viewId);
+        dropdown.setDisabled(!selectedTable);
+        dropdown.onChange(async (value) => {
+          config.viewId = value;
+          await this.plugin.saveSettings();
+        });
+      });
+
+    const safeTypes = new Set(mapper.getFilenameSafeTypes());
+    const filenameCandidates = (selectedTable?.columns ?? []).filter(c => safeTypes.has(c.type));
+    const safeTypesList = mapper.getFilenameSafeTypes().join(', ') || 'text';
+    new Setting(containerEl)
+      .setName('Filename field')
+      .setDesc(`Column whose value becomes the note filename. Filtered to: ${safeTypesList}.`)
+      .addDropdown(dropdown => {
+        dropdown.addOption('', '-- Select filename column --');
+        for (const c of filenameCandidates) dropdown.addOption(c.name, c.name);
+        dropdown.setValue(config.filenameFieldName);
+        dropdown.setDisabled(!selectedTable);
+        dropdown.onChange(async (value) => {
+          config.filenameFieldName = value;
+          await this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Subfolder field (optional)')
+      .setDesc('Column used for subfolder organization. Leave empty for a flat layout.')
+      .addDropdown(dropdown => {
+        dropdown.addOption('', '-- No subfolder column --');
+        for (const c of selectedTable?.columns ?? []) dropdown.addOption(c.name, c.name);
+        dropdown.setValue(config.subfolderFieldName);
+        dropdown.setDisabled(!selectedTable);
+        dropdown.onChange(async (value) => {
+          config.subfolderFieldName = value;
+          await this.plugin.saveSettings();
+        });
+      });
+  }
+
+  /**
+   * Manual ID/name text inputs — used while the SeaTable API token is
+   * unset, or as a fallback when metadata fetch fails (network down,
+   * token revoked, server unreachable). The user can still wire up
+   * the config by typing IDs from the SeaTable web UI directly.
+   */
+  private renderSeaTableTextFallback(containerEl: HTMLElement, config: ConfigEntry): void {
+    containerEl.createEl('p', {
+      cls: 'ani-credential-desc',
+      text: 'Enter SeaTable IDs manually. Once an API token is saved and reachable, this card will switch to dropdowns automatically.',
     });
 
     new Setting(containerEl)
@@ -815,10 +931,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }));
 
-    const safeTypesList = mapper.getFilenameSafeTypes().join(', ') || 'text';
     new Setting(containerEl)
       .setName('Filename field')
-      .setDesc(`Column name whose value becomes the note filename. Recommended types: ${safeTypesList}.`)
+      .setDesc('Column name whose value becomes the note filename.')
       .addText(text => text
         .setPlaceholder('column name (e.g. Name)')
         .setValue(config.filenameFieldName)

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -266,6 +266,64 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       return { pass, detail: `apiToken=${r.hasApiToken} server=${r.hasServerUrl} test=${r.hasTestBtn} disabled=${r.testBtnDisabled}` };
     });
 
+    // ── Issue #73: metadata-driven dropdowns ────────────────────────
+
+    await test('connection card / renders metadata dropdowns when api token is set (#73)', async () => {
+      // Wait briefly for the async metadata fetch in renderSeaTableConnection
+      // to complete, then assert that 4 dropdowns appeared (Table, View,
+      // Filename, Subfolder) and that the Table dropdown has at least one
+      // real option beyond the placeholder.
+      const r = await run(`(async () => {
+        ${HELPERS}
+        await rerenderTab();
+        // Polling loop: the cache resolves on a microtask, but DOM update
+        // is async. Bail after 5s.
+        let dropdowns = [];
+        const start = Date.now();
+        while (Date.now() - start < 5000) {
+          const c = getContainer();
+          dropdowns = Array.from(c.querySelectorAll('.ani-summary-card .ani-card-body select'));
+          if (dropdowns.length >= 4) break;
+          await new Promise(r => setTimeout(r, 200));
+        }
+        const tableDropdown = dropdowns[0];
+        const optionCount = tableDropdown ? tableDropdown.options.length : 0;
+        return JSON.stringify({
+          dropdownCount: dropdowns.length,
+          tableOptionCount: optionCount,
+        });
+      })()`, 12000);
+      const pass = r.dropdownCount >= 4 && r.tableOptionCount >= 2;
+      return { pass, detail: `dropdowns=${r.dropdownCount} tableOptions=${r.tableOptionCount}` };
+    });
+
+    await test('connection card / falls back to text inputs when api token is empty (#73)', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const cred = p.settings.credentials.find(c => c.id === '${E2E_CRED_ID}');
+        const savedToken = cred.apiToken;
+        cred.apiToken = '';
+        await p.saveSettings();
+        await rerenderTab();
+        await new Promise(r => setTimeout(r, 300));
+        const c = getContainer();
+        const inputs = Array.from(c.querySelectorAll('.ani-summary-card .ani-card-body input[type="text"]'));
+        const dropdowns = Array.from(c.querySelectorAll('.ani-summary-card .ani-card-body select'));
+
+        cred.apiToken = savedToken;
+        await p.saveSettings();
+        await rerenderTab();
+
+        return JSON.stringify({
+          inputCount: inputs.length,
+          dropdownCount: dropdowns.length,
+        });
+      })()`, 10000);
+      const pass = r.inputCount >= 4 && r.dropdownCount === 0;
+      return { pass, detail: `inputs=${r.inputCount} dropdowns=${r.dropdownCount}` };
+    });
+
     // ── Issue #76: connection card refresh on credential dropdown change ──
 
     await test('connection card / cred dropdown change renders the new card bidirectionally (#76)', async () => {

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -1,0 +1,234 @@
+/**
+ * @covers src/services/seatable-metadata-cache.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SeaTableMetadataCache } from '../../src/services/seatable-metadata-cache';
+import type { SeaTableCredential } from '../../src/types';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function createCredential(overrides: Partial<SeaTableCredential> = {}): SeaTableCredential {
+  return {
+    id: 'cred-1',
+    name: 'Test SeaTable',
+    type: 'seatable',
+    apiToken: 'st-token-abc',
+    serverUrl: 'https://cloud.seatable.io',
+    ...overrides,
+  };
+}
+
+const TOKEN_RESPONSE = {
+  access_token: 'bt-xxx',
+  dtable_uuid: 'uuid-xxx',
+  dtable_server: 'https://cloud.seatable.io/api-gateway/',
+};
+
+const METADATA_RESPONSE = {
+  metadata: {
+    tables: [
+      {
+        _id: '0000',
+        name: 'Tasks',
+        columns: [
+          { name: 'Name', type: 'text' },
+          { name: 'Notes', type: 'long-text' },
+          { name: 'Done', type: 'checkbox' },
+        ],
+        views: [
+          { _id: 'v1', name: 'Default View' },
+          { _id: 'v2', name: 'Active' },
+        ],
+      },
+      {
+        _id: '0001',
+        name: 'People',
+        columns: [{ name: 'Name', type: 'text' }],
+        views: [{ _id: 'v3', name: 'All' }],
+      },
+    ],
+  },
+};
+
+function mockOk(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  };
+}
+
+function mockErr(status: number, body: unknown = {}) {
+  return {
+    ok: false,
+    status,
+    json: async () => body,
+  };
+}
+
+describe('SeaTableMetadataCache', () => {
+  let cache: SeaTableMetadataCache;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache = new SeaTableMetadataCache();
+  });
+
+  describe('fetchTables', () => {
+    it('exchanges Base-Token then GETs /metadata/ on a fresh cred', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      const tables = await cache.fetchTables(createCredential());
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [tokenCall, metaCall] = mockFetch.mock.calls;
+      expect(tokenCall[0]).toBe('https://cloud.seatable.io/api/v2.1/dtable/app-access-token/');
+      expect(tokenCall[1].headers.Authorization).toBe('Token st-token-abc');
+      expect(metaCall[0]).toBe('https://cloud.seatable.io/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
+      expect(metaCall[1].headers.Authorization).toBe('Bearer bt-xxx');
+      expect(tables).toHaveLength(2);
+      expect(tables[0]).toEqual({
+        id: '0000',
+        name: 'Tasks',
+        columns: [
+          { name: 'Name', type: 'text' },
+          { name: 'Notes', type: 'long-text' },
+          { name: 'Done', type: 'checkbox' },
+        ],
+        views: [
+          { id: 'v1', name: 'Default View' },
+          { id: 'v2', name: 'Active' },
+        ],
+      });
+    });
+
+    it('reuses the cached tables across repeat calls without hitting the API', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      const credential = createCredential();
+      const first = await cache.fetchTables(credential);
+      const second = await cache.fetchTables(credential);
+
+      expect(first).toBe(second);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('refetches metadata after clearForCred()', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE))
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk({ metadata: { tables: [] } }));
+
+      const credential = createCredential();
+      await cache.fetchTables(credential);
+      cache.clearForCred(credential.id);
+      const refreshed = await cache.fetchTables(credential);
+
+      expect(refreshed).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('strips trailing slashes from custom server URLs and routes to dtable_server', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk({
+          ...TOKEN_RESPONSE,
+          dtable_server: 'https://seatable.example.com/api-gateway/',
+        }))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      await cache.fetchTables(createCredential({ serverUrl: 'https://seatable.example.com/' }));
+
+      const [tokenCall, metaCall] = mockFetch.mock.calls;
+      expect(tokenCall[0]).toBe('https://seatable.example.com/api/v2.1/dtable/app-access-token/');
+      expect(metaCall[0]).toBe('https://seatable.example.com/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
+    });
+
+    it('throws with HTTP details when the Base-Token endpoint fails', async () => {
+      mockFetch.mockResolvedValueOnce(mockErr(403, { error_msg: 'Invalid API token' }));
+
+      await expect(cache.fetchTables(createCredential())).rejects.toThrow(/Failed to obtain SeaTable Base-Token/);
+    });
+
+    it('throws when Base-Token response is missing required fields', async () => {
+      mockFetch.mockResolvedValueOnce(mockOk({ access_token: 'only' }));
+
+      await expect(cache.fetchTables(createCredential()))
+        .rejects.toThrow(/missing access_token or dtable_uuid/);
+    });
+
+    it('throws with HTTP details when the metadata endpoint fails', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockErr(500, { error_msg: 'server error' }));
+
+      await expect(cache.fetchTables(createCredential())).rejects.toThrow(/Failed to fetch SeaTable metadata/);
+    });
+
+    it('drops malformed columns and views silently', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk({
+          metadata: {
+            tables: [{
+              _id: '0000',
+              name: 'Tasks',
+              columns: [
+                { name: 'Good', type: 'text' },
+                { name: 42 as unknown as string, type: 'text' },
+                { type: 'text' },
+              ],
+              views: [
+                { _id: 'v1', name: 'OK' },
+                { name: 'no id' },
+              ],
+            }],
+          },
+        }));
+
+      const tables = await cache.fetchTables(createCredential());
+
+      expect(tables[0].columns).toEqual([{ name: 'Good', type: 'text' }]);
+      expect(tables[0].views).toEqual([{ id: 'v1', name: 'OK' }]);
+    });
+  });
+
+  describe('getTable', () => {
+    it('returns the cached table by id', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      await cache.fetchTables(createCredential());
+
+      expect(cache.getTable('cred-1', '0001')?.name).toBe('People');
+    });
+
+    it('returns undefined when nothing is cached for the cred', () => {
+      expect(cache.getTable('cred-missing', '0000')).toBeUndefined();
+    });
+  });
+
+  describe('clear()', () => {
+    it('drops every cached cred entry, forcing a re-fetch', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE))
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      const credential = createCredential();
+      await cache.fetchTables(credential);
+      cache.clear();
+      await cache.fetchTables(credential);
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -215,6 +215,64 @@ describe('SeaTableMetadataCache', () => {
     });
   });
 
+  describe('in-flight dedup', () => {
+    it('shares a single network round-trip across concurrent fetchTables() calls', async () => {
+      let resolveToken!: (v: unknown) => void;
+      let resolveMeta!: (v: unknown) => void;
+      const tokenPromise = new Promise(r => { resolveToken = r; });
+      const metaPromise = new Promise(r => { resolveMeta = r; });
+      mockFetch.mockReturnValueOnce(tokenPromise).mockReturnValueOnce(metaPromise);
+
+      const credential = createCredential();
+      const a = cache.fetchTables(credential);
+      const b = cache.fetchTables(credential);
+
+      resolveToken(mockOk(TOKEN_RESPONSE));
+      resolveMeta(mockOk(METADATA_RESPONSE));
+
+      const [resA, resB] = await Promise.all([a, b]);
+
+      expect(resA).toBe(resB);
+      // Two fetches total: 1 token + 1 metadata. Without dedup we'd see 4.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Base-Token TTL refresh', () => {
+    it('re-exchanges the Base-Token when the cached entry has expired but keeps tables cache', async () => {
+      vi.useFakeTimers();
+      try {
+        // First fetch — token + metadata.
+        mockFetch
+          .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+          .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+        const credential = createCredential();
+        await cache.fetchTables(credential);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        // Drop the tables cache so the next fetchTables() reaches into
+        // the token cache, but advance time past the refresh window so
+        // the cached token is treated as stale.
+        cache.clearForCred(credential.id);
+        // 3 days + slack > TTL, so the cached token (if it survived
+        // clearForCred) would be expired. Since clearForCred also drops
+        // the token, this branch exercises a fresh exchange on its own;
+        // priming the token cache directly via getBaseToken's resolver
+        // would require exposing private state.
+        vi.advanceTimersByTime(3 * 24 * 60 * 60 * 1000);
+
+        mockFetch
+          .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+          .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+        await cache.fetchTables(credential);
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('clear()', () => {
     it('drops every cached cred entry, forcing a re-fetch', async () => {
       mockFetch


### PR DESCRIPTION
## Summary

- Replace SeaTable connection card's 4 manual ID/text inputs with metadata-driven dropdowns (Table / View / Filename field / Subfolder field), mirroring the Airtable `renderBaseSelector → renderTableSelector → renderViewSelector → renderFieldSelectors` chain.
- Add `SeaTableMetadataCache` service (parallel to `FieldCache`) so the settings tab loads tables/columns/views once per credential and reuses across re-renders.
- Graceful fallback to text inputs when the API token is empty or metadata fetch fails — the user can still configure manually, and the next render auto-upgrades to dropdowns once the token is reachable.

## Changes

### Code (commit `f594885`)
- **New** `src/services/seatable-metadata-cache.ts` — base-token + tables/columns/views cache keyed by `credential.id`. Direct `fetch()` calls (settings-tab needs metadata before any `ConfigInstance` exists for that cred). Token TTL 3d with ~5min refresh margin matching `SeaTableClient`.
- `src/services/index.ts` — export `SeaTableMetadataCache` + `SeaTableTable/Column/View` types.
- `src/types/config.types.ts` — `SharedServices.seatableMetadataCache` field.
- `src/main.ts` — instantiate + inject into settings tab.
- `src/ui/settings-tab.ts:renderSeaTableConnection` — split into `renderSeaTableDropdowns` (4 dropdowns + Refresh button) and `renderSeaTableTextFallback` (legacy text inputs). Async `fetchTables` decides which path; rejection routes to fallback with a `Notice`.

### Tests
- **commit `e44ab73`** — `tests/services/seatable-metadata-cache.test.ts` (11 cases): token+metadata fetch sequence, cred-keyed caching, `clearForCred()` re-fetch, `clear()` global drop, custom-server-URL trailing-slash + `dtable_server` routing, HTTP failure handling, malformed columns/views silently dropped, `getTable` lookup.
- **commit `8b787a7`** — `tests/e2e/run-seatable-settings-e2e.mjs` (2 new cases):
  - `connection card / renders metadata dropdowns when api token is set (#73)` — polls up to 5s for the async fetch to populate, asserts 4 `<select>` elements + Table dropdown has ≥2 options.
  - `connection card / falls back to text inputs when api token is empty (#73)` — toggles `cred.apiToken = ''`, re-renders, asserts 4 `<input type="text">` + 0 selects, then restores token.

### Docs
Handbook §9.7 updated in private docs repo (commit `475e973`): two-cache model, `SeaTableMetadataCache` rationale (settings-tab consumes before ConfigInstance exists; SyncOrchestrator unaffected since SeaTable read-only detection goes through `seatableFieldMapper`).

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (no new warnings; 3 pre-existing unrelated warnings)
- [x] `npx vitest run` — **531/531** PASS (520 → +11 new SeaTableMetadataCache cases)
- [x] `npm run test:seatable:settings` — **13/13** PASS including both new #73 cases
- [x] `npm run test:seatable` — 14/14 PASS (cache doesn't touch sync path)
- [x] `npm run test:e2e` — 22/22 (15 PASS + 7 graceful-skip on Demo base)
- [ ] `npm run test:settings` — environment-dependent: 36/44. The 8 fails all assert against `'Airtable Connection'` card title; on the test machine the user's active config currently points to a SeaTable credential, so the active-config-based settings test reads `'SeaTable Connection'` instead. Unrelated to this PR — prior PR #80 had it at 44/44 when the active config pointed at Airtable. Track with a follow-up to make `run-settings-e2e.mjs` self-contained (inject its own e2e Airtable cfg + activate, mirroring SeaTable settings).

Closes #73