### PR TITLE
fix: Supabase publishable key inline RPC setup banner (#91)

### DIFF
--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -18,6 +18,7 @@ import type {
   CredentialBuildResult,
   CredentialFormRenderer,
   CredentialFormState,
+  SupabaseCredential,
 } from '../types';
 import { extractApiErrorMessage, normalizeServerUrl } from '../utils';
 import { SUPABASE_RPC_SCHEMA_FN } from '../constants';
@@ -170,10 +171,21 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
     };
   }
 
-  async testConnection(credential: Credential): Promise<ConnectionTestResult> {
-    if (credential.type !== 'supabase') {
-      return { success: false, error: `Expected supabase credential, got ${credential.type}` };
-    }
+  /**
+   * Probes the Supabase project for reachability + key authority +
+   * schema-introspection access. Single source of truth for the
+   * 2-step probe shared by testConnection and verifySetup — see the
+   * "verifySetup duplicates the RPC call" PR review (PR #92) for why
+   * this is shared instead of duplicated.
+   *
+   * Returns ConnectionTestResult with the same semantics as
+   * testConnection / verifySetup: success without needsSetup means the
+   * key can read schema natively (legacy anon JWT / secret) OR the RPC
+   * is installed; success with needsSetup means the key is publishable
+   * AND the RPC is missing; failure means the key itself is invalid or
+   * the network is unreachable.
+   */
+  private async probeRpc(credential: SupabaseCredential): Promise<ConnectionTestResult> {
     const projectUrl = normalizeServerUrl(credential.projectUrl, '');
     if (!projectUrl) return { success: false, error: 'Project URL is empty.' };
     const baseHeaders = {
@@ -182,6 +194,10 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
     };
 
     // Step 1: prefer the native OpenAPI endpoint (legacy anon JWT / secret).
+    // 200 here means the key reads schema directly — no RPC fallback needed,
+    // and crucially no needsSetup signal (Codex P1 regression: previously,
+    // verifySetup skipped this step and blocked save for secret/anon keys
+    // whenever the RPC was missing).
     try {
       const response = await requestUrl({
         url: `${projectUrl}/rest/v1/`,
@@ -213,6 +229,10 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
     // Step 2: publishable-key path — call the RPC fallback. 200 = installed,
     // 4xx with PGRST202 / "function does not exist" = key works but RPC not
     // installed yet (still a successful auth test).
+    //
+    // p_schema: 'public' — the RPC itself is always installed in the
+    // public schema regardless of which schema the user's data lives in;
+    // we only need to confirm the function exists.
     try {
       const rpc = await requestUrl({
         url: `${projectUrl}/rest/v1/rpc/${SUPABASE_RPC_SCHEMA_FN}`,
@@ -239,39 +259,18 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
     }
   }
 
+  async testConnection(credential: Credential): Promise<ConnectionTestResult> {
+    if (credential.type !== 'supabase') {
+      return { success: false, error: `Expected supabase credential, got ${credential.type}` };
+    }
+    return this.probeRpc(credential);
+  }
+
   async verifySetup(credential: Credential): Promise<ConnectionTestResult> {
     if (credential.type !== 'supabase') {
       return { success: false, error: `Expected supabase credential, got ${credential.type}` };
     }
-    const projectUrl = normalizeServerUrl(credential.projectUrl, '');
-    if (!projectUrl) return { success: false, error: 'Project URL is empty.' };
-
-    try {
-      const rpc = await requestUrl({
-        url: `${projectUrl}/rest/v1/rpc/${SUPABASE_RPC_SCHEMA_FN}`,
-        method: 'POST',
-        headers: {
-          'apikey': credential.apiKey,
-          'Authorization': `Bearer ${credential.apiKey}`,
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ p_schema: 'public' }),
-        throw: false,
-      });
-
-      if (rpc.status === 200) {
-        return { success: true, detail: 'RPC reachable.' };
-      }
-
-      if (isRpcMissingResponse(rpc)) {
-        return { success: true, needsSetup: { kind: 'supabase-rpc' } };
-      }
-
-      return { success: false, error: `HTTP ${rpc.status}: ${extractApiErrorMessage(rpc)}` };
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Network error' };
-    }
+    return this.probeRpc(credential);
   }
 }
 

--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -85,15 +85,21 @@ const API_KEY_KEY = 'apiKey';
  * Detects whether a non-200 PostgREST RPC response indicates the
  * `ani_supabase_schema` function is not installed.
  *
- * Guards against non-JSON response bodies (HTML proxy errors, empty
- * 502 pages) by checking that `rpc.json` is a plain object before
- * reading `.code` / `.message`. Without this guard, a `rpc.json` of
- * `null` / `string` / `array` (Obsidian's requestUrl returns parsed
- * JSON or undefined; some self-hosted PostgREST setups behind a
- * misconfigured proxy return HTML 502) would slip through the
- * `code === 'PGRST202'` check as false and miscategorize the error.
+ * Status anchor (PR #92 sweep follow-up): PostgREST issues PGRST202
+ * "function not found" with a 4xx status (typically 404 / 400 / 406),
+ * never 401/403 — those are auth families with PGRST301-style codes.
+ * A proxy / Cloudflare / WAF in front of the user's project could
+ * inject a stale or wrong body into an auth response; without a status
+ * check, a 401 with body `code: 'PGRST202'` would be silently routed
+ * to the setup banner instead of the auth error, masking the actual
+ * problem.
+ *
+ * Body shape guard: also rejects non-JSON bodies (HTML proxy errors,
+ * empty 502 pages, null, arrays) before reading `.code` / `.message`.
  */
 function isRpcMissingResponse(rpc: RequestUrlResponse): boolean {
+  if (rpc.status < 400 || rpc.status >= 500) return false;
+  if (rpc.status === 401 || rpc.status === 403) return false;
   const json: unknown = rpc.json;
   if (!json || typeof json !== 'object' || Array.isArray(json)) return false;
   const body = json as { code?: string; message?: string };

--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -211,7 +211,8 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
       if (rpcMissing) {
         return {
           success: true,
-          detail: 'Publishable key authenticates — run the setup SQL (settings card) to enable schema introspection.',
+          detail: 'Publishable key authenticates.',
+          needsSetup: { kind: 'supabase-rpc' },
         };
       }
       return { success: false, error: `HTTP ${rpc.status}: ${extractApiErrorMessage(rpc)}` };

--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -220,6 +220,44 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
       return { success: false, error: error instanceof Error ? error.message : 'Network error' };
     }
   }
+
+  async verifySetup(credential: Credential): Promise<ConnectionTestResult> {
+    if (credential.type !== 'supabase') {
+      return { success: false, error: `Expected supabase credential, got ${credential.type}` };
+    }
+    const projectUrl = normalizeServerUrl(credential.projectUrl, '');
+    if (!projectUrl) return { success: false, error: 'Project URL is empty.' };
+
+    try {
+      const rpc = await requestUrl({
+        url: `${projectUrl}/rest/v1/rpc/${SUPABASE_RPC_SCHEMA_FN}`,
+        method: 'POST',
+        headers: {
+          'apikey': credential.apiKey,
+          'Authorization': `Bearer ${credential.apiKey}`,
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ p_schema: 'public' }),
+        throw: false,
+      });
+
+      if (rpc.status === 200) {
+        return { success: true };
+      }
+
+      const body = rpc.json as { code?: string; message?: string } | undefined;
+      const rpcMissing = body?.code === 'PGRST202' ||
+        (typeof body?.message === 'string' && /function .* does not exist/i.test(body.message));
+      if (rpcMissing) {
+        return { success: true, needsSetup: { kind: 'supabase-rpc' } };
+      }
+
+      return { success: false, error: `HTTP ${rpc.status}: ${extractApiErrorMessage(rpc)}` };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Network error' };
+    }
+  }
 }
 
 export const supabaseCredentialFormRenderer: CredentialFormRenderer =

--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -10,7 +10,7 @@
  * @tested tests/services/supabase-credential-form.test.ts
  */
 
-import { Setting, requestUrl } from 'obsidian';
+import { Setting, requestUrl, type RequestUrlResponse } from 'obsidian';
 import type {
   ConnectionTestResult,
   Credential,
@@ -78,6 +78,26 @@ export function detectKeyType(key: string): KeyTypeInfo {
 
 const PROJECT_URL_KEY = 'projectUrl';
 const API_KEY_KEY = 'apiKey';
+
+/**
+ * Detects whether a non-200 PostgREST RPC response indicates the
+ * `ani_supabase_schema` function is not installed.
+ *
+ * Guards against non-JSON response bodies (HTML proxy errors, empty
+ * 502 pages) by checking that `rpc.json` is a plain object before
+ * reading `.code` / `.message`. Without this guard, a `rpc.json` of
+ * `null` / `string` / `array` (Obsidian's requestUrl returns parsed
+ * JSON or undefined; some self-hosted PostgREST setups behind a
+ * misconfigured proxy return HTML 502) would slip through the
+ * `code === 'PGRST202'` check as false and miscategorize the error.
+ */
+function isRpcMissingResponse(rpc: RequestUrlResponse): boolean {
+  const json: unknown = rpc.json;
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return false;
+  const body = json as { code?: string; message?: string };
+  return body.code === 'PGRST202' ||
+    (typeof body.message === 'string' && /function .* does not exist/i.test(body.message));
+}
 
 class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
   readonly type = 'supabase' as const;
@@ -205,10 +225,7 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
         const tableCount = defs && typeof defs === 'object' && !Array.isArray(defs) ? Object.keys(defs).length : 0;
         return { success: true, detail: `Connected via RPC - ${tableCount} endpoints visible` };
       }
-      const body = rpc.json as { code?: string; message?: string } | undefined;
-      const rpcMissing = body?.code === 'PGRST202' ||
-        (typeof body?.message === 'string' && /function .* does not exist/i.test(body.message));
-      if (rpcMissing) {
+      if (isRpcMissingResponse(rpc)) {
         return {
           success: true,
           detail: 'Publishable key authenticates.',
@@ -243,13 +260,10 @@ class SupabaseCredentialFormRendererImpl implements CredentialFormRenderer {
       });
 
       if (rpc.status === 200) {
-        return { success: true };
+        return { success: true, detail: 'RPC reachable.' };
       }
 
-      const body = rpc.json as { code?: string; message?: string } | undefined;
-      const rpcMissing = body?.code === 'PGRST202' ||
-        (typeof body?.message === 'string' && /function .* does not exist/i.test(body.message));
-      if (rpcMissing) {
+      if (isRpcMissingResponse(rpc)) {
         return { success: true, needsSetup: { kind: 'supabase-rpc' } };
       }
 

--- a/src/services/supabase-credential-form.ts
+++ b/src/services/supabase-credential-form.ts
@@ -8,6 +8,7 @@
  * @handbook 4.4-provider-abstraction
  * @handbook 5.1-ui-components
  * @tested tests/services/supabase-credential-form.test.ts
+ * @tested e2e:tests/e2e/run-supabase-settings-e2e.mjs
  */
 
 import { Setting, requestUrl, type RequestUrlResponse } from 'obsidian';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export type {
   CredentialBuildResult,
   ConnectionTestResult,
   CredentialFormRenderer,
+  SetupRequirement,
 } from './provider-settings.types';
 
 export type {

--- a/src/types/provider-settings.types.ts
+++ b/src/types/provider-settings.types.ts
@@ -28,10 +28,24 @@ export type CredentialBuildResult =
   | { ok: false; error: string };
 
 /**
- * Result of testing a credential against the remote service.
+ * Describes a one-time setup action the user must perform before the
+ * credential can be used. Surfaced from testConnection / verifySetup so
+ * the settings UI can render contextual setup instructions instead of a
+ * blind error toast.
+ */
+export interface SetupRequirement {
+  /** Discriminator for the setup kind. Widened as more providers need it. */
+  kind: 'supabase-rpc';
+}
+
+/**
+ * Result of testing a credential against the remote service. A
+ * `success: true` result MAY also carry `needsSetup` to signal that the
+ * credential authenticates but cannot complete its job until the user
+ * performs a one-time setup action.
  */
 export type ConnectionTestResult =
-  | { success: true; detail?: string }
+  | { success: true; detail?: string; needsSetup?: SetupRequirement }
   | { success: false; error: string };
 
 /**
@@ -80,4 +94,15 @@ export interface CredentialFormRenderer {
    * without a cheap auth probe can omit this.
    */
   testConnection?(credential: Credential): Promise<ConnectionTestResult>;
+
+  /**
+   * Verifies a credential is ready to be saved. Distinct from
+   * testConnection in intent: testConnection answers "does this key
+   * work?", verifySetup answers "can the user save right now, or do they
+   * need a setup step first?". Providers that gate save behind a
+   * one-time setup (e.g. Supabase publishable key + ani_supabase_schema
+   * RPC) implement this; others omit it and the settings tab skips the
+   * pre-save check.
+   */
+  verifySetup?(credential: Credential): Promise<ConnectionTestResult>;
 }

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -57,6 +57,7 @@ interface CredentialFormUiState {
   setupRequirement: SetupRequirement | null;
   bannerHost: HTMLElement | null;
   saveButton: HTMLButtonElement | null;
+  testButton: HTMLButtonElement | null;
   isTesting: boolean;
   isSaving: boolean;
   cleanups: Array<() => void>;
@@ -422,17 +423,18 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         });
       })
       .addButton(button => {
-        button
-          .setButtonText('Test')
-          .setDisabled(!renderer.testConnection)
-          .onClick(() => {
-            const result = renderer.build(nameValue, state, cred.id);
-            if (!result.ok) {
-              new Notice(`Auto Note Importer: ${result.error}`);
-              return;
-            }
-            void this.runConnectionTest(renderer, result.credential, containerEl);
-          });
+        button.setButtonText('Test').setDisabled(!renderer.testConnection);
+        if (this.credentialFormUi) {
+          this.credentialFormUi.testButton = button.buttonEl;
+        }
+        button.onClick(() => {
+          const result = renderer.build(nameValue, state, cred.id);
+          if (!result.ok) {
+            new Notice(`Auto Note Importer: ${result.error}`);
+            return;
+          }
+          void this.runConnectionTest(renderer, result.credential, containerEl);
+        });
       })
       .addButton(button => button
         .setButtonText('Cancel')
@@ -552,17 +554,18 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         });
       })
       .addButton(button => {
-        button
-          .setButtonText('Test')
-          .setDisabled(!renderer.testConnection)
-          .onClick(() => {
-            const result = renderer.build(context.name, context.state, 'test-only');
-            if (!result.ok) {
-              new Notice(`Auto Note Importer: ${result.error}`);
-              return;
-            }
-            void this.runConnectionTest(renderer, result.credential, containerEl);
-          });
+        button.setButtonText('Test').setDisabled(!renderer.testConnection);
+        if (this.credentialFormUi) {
+          this.credentialFormUi.testButton = button.buttonEl;
+        }
+        button.onClick(() => {
+          const result = renderer.build(context.name, context.state, 'test-only');
+          if (!result.ok) {
+            new Notice(`Auto Note Importer: ${result.error}`);
+            return;
+          }
+          void this.runConnectionTest(renderer, result.credential, containerEl);
+        });
       })
       .addButton(button => button
         .setButtonText('Cancel')
@@ -581,6 +584,17 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     if (!renderer.testConnection) return;
     if (this.credentialFormUi?.isTesting) return;   // re-entry guard
     if (this.credentialFormUi) this.credentialFormUi.isTesting = true;
+
+    // Visual loading state on the Test button itself \u2014 re-entry guard
+    // silently drops rapid double-clicks, but without UI feedback the
+    // user has no idea the second click was ignored.
+    const testBtn = this.credentialFormUi?.testButton ?? null;
+    const originalTestText = testBtn?.textContent ?? null;
+    if (testBtn) {
+      testBtn.disabled = true;
+      testBtn.textContent = 'Testing\u2026';
+    }
+
     new Notice('Auto Note Importer: Testing connection\u2026');
     try {
       const result = await renderer.testConnection(credential);
@@ -595,6 +609,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         this.renderSetupBannerForRequirement(result.needsSetup, credential, formHostEl);
         return;
       }
+      // Success without needsSetup \u2014 if a prior probe set the banner
+      // (e.g. user installed the RPC externally between Test clicks),
+      // clear it now so Save isn't stuck disabled (Codex P2, PR #92).
+      if (this.credentialFormUi?.setupRequirement) {
+        this.clearFormSetupRequirement();
+      }
       const detail = result.detail ? ` ${result.detail}` : '';
       new Notice(`Auto Note Importer: Connection OK.${detail}`);
     } catch (error) {
@@ -602,6 +622,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       new Notice(`Auto Note Importer: Connection test errored \u2014 ${message}`);
     } finally {
       if (this.credentialFormUi) this.credentialFormUi.isTesting = false;
+      if (testBtn) {
+        testBtn.disabled = false;
+        testBtn.textContent = originalTestText ?? 'Test';
+      }
     }
   }
 
@@ -1196,7 +1220,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         }
       } finally {
         verifyBtn.disabled = false;
-        verifyBtn.textContent = originalText;
+        // `textContent` is `string | null`; restore the literal default
+        // if the original was somehow null (e.g. detached node) so the
+        // button never goes blank (claude #1, PR #92).
+        verifyBtn.textContent = originalText ?? 'I’ve run it — Verify';
       }
     });
   }
@@ -1283,6 +1310,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       setupRequirement: null,
       bannerHost: null,
       saveButton: null,
+      testButton: null,
       isTesting: false,
       isSaving: false,
       cleanups: [],
@@ -1361,6 +1389,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       if (result.needsSetup) {
         this.renderSetupBannerForRequirement(result.needsSetup, credential, formHostEl);
         return 'blocked';
+      }
+      // Save-time verify can also clear a stale banner — e.g. user
+      // installed the RPC externally then clicked Save without Verify
+      // first (Codex P2, PR #92).
+      if (this.credentialFormUi?.setupRequirement) {
+        this.clearFormSetupRequirement();
       }
       return 'proceed';
     } catch (error) {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1323,14 +1323,15 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
    * SetupRequirement.kind so future widening of the union fails at
    * compile time until a handler is added.
    *
-   * Returns true if a banner was rendered (caller should skip the
-   * usual success Notice), false otherwise.
+   * Callers must already have decided to suppress the usual success
+   * Notice / return blocked from the gate — see runConnectionTest and
+   * verifyCredentialBeforeSave for the surrounding flow.
    */
   private renderSetupBannerForRequirement(
     needsSetup: SetupRequirement,
     credential: Credential,
     formHostEl: HTMLElement,
-  ): boolean {
+  ): void {
     switch (needsSetup.kind) {
       case 'supabase-rpc': {
         if (credential.type !== 'supabase') {
@@ -1338,7 +1339,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           // Supabase. Surface as an internal error rather than silently
           // skipping the banner.
           new Notice(`Auto Note Importer: Internal error — supabase-rpc setup requested for ${credential.type} credential.`);
-          return false;
+          return;
         }
         const host = this.ensureFormBannerHost(formHostEl);
         this.renderRpcSetupBannerInForm(
@@ -1353,7 +1354,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             this.credentialFormUi.saveButton.disabled = true;
           }
         }
-        return true;
+        return;
       }
       default: {
         const _exhaustive: never = needsSetup.kind;

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -383,6 +383,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             new Notice(`Auto Note Importer: ${result.error}`);
             return;
           }
+          const gate = await this.verifyCredentialBeforeSave(renderer, result.credential, containerEl);
+          if (gate !== 'proceed') return;
           // Replace the existing credential in-place
           const idx = this.plugin.settings.credentials.findIndex(c => c.id === cred.id);
           if (idx >= 0) {
@@ -494,6 +496,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
+            const gate = await this.verifyCredentialBeforeSave(renderer, result.credential, containerEl);
+            if (gate !== 'proceed') return;
             this.plugin.settings.credentials.push(result.credential);
             await this.plugin.saveSettings();
             this.addingCredential = false;
@@ -1214,6 +1218,51 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       host = formHostEl.createDiv({ cls: 'ani-rpc-setup-host' });
     }
     return host;
+  }
+
+  /**
+   * Pre-save gate. Calls verifySetup on the credential and returns
+   * - 'proceed' if the credential is ready to persist
+   * - 'blocked' if needsSetup or verify failure — the banner / Notice
+   *   has been surfaced and the caller MUST NOT persist.
+   *
+   * Fails closed: any network failure during verify blocks the save
+   * with a Notice. Silently saving a credential that cannot sync is
+   * worse than a one-extra-click retry.
+   */
+  private async verifyCredentialBeforeSave(
+    renderer: CredentialFormRenderer,
+    credential: Credential,
+    formHostEl: HTMLElement,
+  ): Promise<'proceed' | 'blocked'> {
+    if (!renderer.verifySetup) return 'proceed';
+    try {
+      const result = await renderer.verifySetup(credential);
+      if (!result.success) {
+        new Notice(`Auto Note Importer: Could not verify setup before save — ${result.error}`);
+        return 'blocked';
+      }
+      if (result.needsSetup && credential.type === 'supabase') {
+        const banner = this.renderRpcSetupBannerInForm(
+          this.ensureFormBannerHost(formHostEl),
+          credential,
+          () => this.clearFormSetupRequirement(),
+        );
+        if (this.credentialFormUi) {
+          this.credentialFormUi.setupRequirement = result.needsSetup;
+          this.credentialFormUi.bannerHost = banner;
+          if (this.credentialFormUi.saveButton) {
+            this.credentialFormUi.saveButton.disabled = true;
+          }
+        }
+        return 'blocked';
+      }
+      return 'proceed';
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      new Notice(`Auto Note Importer: Could not verify setup before save — ${message}`);
+      return 'blocked';
+    }
   }
 
   /**

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -359,6 +359,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       return;
     }
     const renderer = getCredentialFormRenderer(cred.type);
+    this.credentialFormUi = { setupRequirement: null, bannerHost: null, saveButton: null };
     const state: CredentialFormState = {};
     let nameValue = cred.name;
 
@@ -401,7 +402,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
-            void this.runConnectionTest(renderer, result.credential);
+            void this.runConnectionTest(renderer, result.credential, containerEl);
           });
       })
       .addButton(button => button
@@ -476,6 +477,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     }
 
     const renderer = getCredentialFormRenderer(type);
+    this.credentialFormUi = { setupRequirement: null, bannerHost: null, saveButton: null };
     if (renderer.description) {
       containerEl.createEl('p', { cls: 'ani-credential-desc', text: renderer.description });
     }
@@ -509,7 +511,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               new Notice(`Auto Note Importer: ${result.error}`);
               return;
             }
-            void this.runConnectionTest(renderer, result.credential);
+            void this.runConnectionTest(renderer, result.credential, containerEl);
           });
       })
       .addButton(button => button
@@ -524,17 +526,36 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private async runConnectionTest(
     renderer: CredentialFormRenderer,
     credential: Credential,
+    formHostEl: HTMLElement,
   ): Promise<void> {
     if (!renderer.testConnection) return;
     new Notice('Auto Note Importer: Testing connection\u2026');
     try {
       const result = await renderer.testConnection(credential);
-      if (result.success) {
-        const detail = result.detail ? ` ${result.detail}` : '';
-        new Notice(`Auto Note Importer: Connection OK.${detail}`);
-      } else {
+      if (!result.success) {
         new Notice(`Auto Note Importer: Connection failed \u2014 ${result.error}`);
+        return;
       }
+      if (result.needsSetup && credential.type === 'supabase') {
+        // Suppress the "Connection OK" Notice \u2014 the inline banner is the
+        // contextual surface. Render banner inside form host, disable
+        // Save until verify succeeds.
+        const banner = this.renderRpcSetupBannerInForm(
+          this.ensureFormBannerHost(formHostEl),
+          credential,
+          () => this.clearFormSetupRequirement(),
+        );
+        if (this.credentialFormUi) {
+          this.credentialFormUi.setupRequirement = result.needsSetup;
+          this.credentialFormUi.bannerHost = banner;
+          if (this.credentialFormUi.saveButton) {
+            this.credentialFormUi.saveButton.disabled = true;
+          }
+        }
+        return;
+      }
+      const detail = result.detail ? ` ${result.detail}` : '';
+      new Notice(`Auto Note Importer: Connection OK.${detail}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       new Notice(`Auto Note Importer: Connection test errored \u2014 ${message}`);
@@ -1135,6 +1156,79 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         verifyBtn.textContent = originalText;
       }
     });
+  }
+
+  /**
+   * Credential-form variant of the RPC setup banner. Unlike the
+   * connection-card variant, this one does NOT include the manual-entry
+   * text fallback (the credential is still being authored — no config
+   * exists yet). On verify success the banner removes itself, calls the
+   * caller's onSuccess (to re-enable Save), and emits a one-line
+   * confirmation Notice. On verify failure it surfaces the error inline
+   * inside the banner.
+   *
+   * Returns the banner element so callers can stash it for later
+   * removal on field-change auto-reset.
+   */
+  private renderRpcSetupBannerInForm(
+    host: HTMLElement,
+    credential: SupabaseCredential,
+    onSuccess: () => void,
+  ): HTMLElement {
+    host.empty();
+    const banner = host.createDiv({ cls: 'ani-rpc-setup-banner' });
+    banner.createEl('h4', { text: 'One-time setup required for publishable keys' });
+    banner.createEl('p').setText(
+      'Supabase’s new key system blocks publishable keys from reading the ' +
+      'OpenAPI schema. Run this SQL once in your Supabase SQL Editor — it ' +
+      'creates a SECURITY DEFINER function the plugin uses for schema introspection.',
+    );
+
+    const errorHost = banner.createDiv({ cls: 'ani-rpc-setup-error' });
+
+    this.renderRpcSetupBannerCore(
+      banner,
+      credential,
+      () => {
+        new Notice('Auto Note Importer: Setup confirmed — you can save now.');
+        banner.remove();
+        onSuccess();
+      },
+      (error) => {
+        errorHost.empty();
+        errorHost.createEl('p', { cls: 'ani-rpc-setup-error-msg', text: `⚠ ${error}` });
+      },
+    );
+
+    return banner;
+  }
+
+  /**
+   * Returns (creating if needed) the dedicated banner host inside the
+   * credential form. Reusing one host means consecutive Test/Save
+   * cycles replace the previous banner instead of stacking.
+   */
+  private ensureFormBannerHost(formHostEl: HTMLElement): HTMLElement {
+    let host = formHostEl.querySelector<HTMLElement>(':scope > .ani-rpc-setup-host');
+    if (!host) {
+      host = formHostEl.createDiv({ cls: 'ani-rpc-setup-host' });
+    }
+    return host;
+  }
+
+  /**
+   * Clears the form-scoped setup requirement: removes the banner from
+   * the DOM and re-enables Save. Called when the user verifies setup
+   * successfully or edits a credential field (Task 9 auto-reset).
+   */
+  private clearFormSetupRequirement(): void {
+    if (!this.credentialFormUi) return;
+    this.credentialFormUi.setupRequirement = null;
+    this.credentialFormUi.bannerHost?.remove();
+    this.credentialFormUi.bannerHost = null;
+    if (this.credentialFormUi.saveButton) {
+      this.credentialFormUi.saveButton.disabled = false;
+    }
   }
 
   /**

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1236,15 +1236,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
    * (which calls clearFormSetupRequirement → removes the host); on
    * verify failure the error is surfaced inline inside the banner.
    *
-   * Returns the host element (outer `.ani-rpc-setup-host`) so callers
-   * can stash it as the cleanup target — removing the host wipes the
-   * inner banner + buttons + error in one DOM op.
+   * Returns void — the caller already holds the host from
+   * `ensureFormBannerHost`. Removing that host wipes the inner banner +
+   * buttons + error in one DOM op (claude bot round 2 PR #92 review:
+   * the prior `return host` was redundant API surface noise).
    */
   private renderRpcSetupBannerInForm(
     host: HTMLElement,
     credential: SupabaseCredential,
     onSuccess: () => void,
-  ): HTMLElement {
+  ): void {
     host.empty();
     const banner = host.createDiv({ cls: 'ani-rpc-setup-banner' });
     banner.createEl('h4', { text: 'One-time setup required for publishable keys' });
@@ -1268,8 +1269,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         errorHost.createEl('p', { cls: 'ani-rpc-setup-error-msg', text: `⚠ ${error}` });
       },
     );
-
-    return host;
   }
 
   /**
@@ -1341,8 +1340,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           new Notice(`Auto Note Importer: Internal error — supabase-rpc setup requested for ${credential.type} credential.`);
           return false;
         }
-        const host = this.renderRpcSetupBannerInForm(
-          this.ensureFormBannerHost(formHostEl),
+        const host = this.ensureFormBannerHost(formHostEl);
+        this.renderRpcSetupBannerInForm(
+          host,
           credential,
           () => this.clearFormSetupRequirement(),
         );
@@ -1380,6 +1380,19 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     if (!renderer.verifySetup) return 'proceed';
     if (this.credentialFormUi?.isSaving) return 'blocked';   // re-entry guard
     if (this.credentialFormUi) this.credentialFormUi.isSaving = true;
+
+    // Visual loading state on the Save button — symmetric with the
+    // Test button pattern in runConnectionTest (claude bot round 2
+    // PR #92 review). verifySetup is a 2-step network probe and can
+    // take 1-3s; silent re-entry drops with no UI feedback would
+    // confuse users.
+    const saveBtn = this.credentialFormUi?.saveButton ?? null;
+    const originalSaveText = saveBtn?.textContent ?? null;
+    if (saveBtn) {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
+    }
+
     try {
       const result = await renderer.verifySetup(credential);
       if (!result.success) {
@@ -1403,6 +1416,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       return 'blocked';
     } finally {
       if (this.credentialFormUi) this.credentialFormUi.isSaving = false;
+      if (saveBtn) {
+        // Only restore disabled=false if the banner didn't take over the
+        // disable state. renderSetupBannerForRequirement sets
+        // saveButton.disabled=true when needsSetup is rendered — we must
+        // not clobber that here.
+        if (!this.credentialFormUi?.setupRequirement) {
+          saveBtn.disabled = false;
+        }
+        saveBtn.textContent = originalSaveText ?? 'Save';
+      }
     }
   }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -45,15 +45,21 @@ export interface SettingsPlugin extends Plugin {
 /**
  * Transient UI state for the credential add/edit form. Tracks whether
  * the active form has a pending setup requirement (e.g. Supabase RPC
- * not installed), plus references to the banner host and Save button so
- * handlers can clear them when the user edits a field (auto-reset) or
- * verifies the setup. Owned by the settings tab; reset on display()
- * and re-initialized when a credential form opens.
+ * not installed), references to the banner host element and Save button,
+ * in-flight guards to prevent concurrent click races, and a cleanups
+ * array for any event listeners that must be detached when the form is
+ * disposed or re-rendered (prevents listener accumulation across
+ * type-switches and re-displays). Owned by the settings tab; reset via
+ * resetCredentialFormUi() when a credential form opens, and torn down
+ * (cleanups invoked) by display().
  */
 interface CredentialFormUiState {
   setupRequirement: SetupRequirement | null;
   bannerHost: HTMLElement | null;
   saveButton: HTMLButtonElement | null;
+  isTesting: boolean;
+  isSaving: boolean;
+  cleanups: Array<() => void>;
 }
 
 /**
@@ -153,7 +159,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
   display(): void {
     this.renderGeneration++;
-    this.credentialFormUi = null;
+    this.tearDownCredentialFormUi();
     const { containerEl } = this;
     containerEl.empty();
 
@@ -359,7 +365,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       return;
     }
     const renderer = getCredentialFormRenderer(cred.type);
-    this.credentialFormUi = { setupRequirement: null, bannerHost: null, saveButton: null };
+    this.resetCredentialFormUi();
     const state: CredentialFormState = {};
     let nameValue = cred.name;
 
@@ -376,11 +382,20 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Any field edit invalidates a prior setup verification. Auto-clear
     // the banner + re-enable Save so a stale RPC-missing diagnosis can't
     // outlive the inputs it was diagnosed against.
-    containerEl.addEventListener('input', () => {
+    //
+    // Register the handler reference in credentialFormUi.cleanups so the
+    // next form render / display() detaches it — otherwise add-mode
+    // type-switches (which re-call renderCredentialAddDetails on the
+    // same containerEl) would accumulate listeners.
+    const inputResetHandler = (): void => {
       if (this.credentialFormUi?.setupRequirement) {
         this.clearFormSetupRequirement();
       }
-    });
+    };
+    containerEl.addEventListener('input', inputResetHandler);
+    this.credentialFormUi?.cleanups.push(() =>
+      containerEl.removeEventListener('input', inputResetHandler),
+    );
 
     new Setting(containerEl)
       .addButton(button => {
@@ -491,7 +506,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     }
 
     const renderer = getCredentialFormRenderer(type);
-    this.credentialFormUi = { setupRequirement: null, bannerHost: null, saveButton: null };
+    this.resetCredentialFormUi();
     if (renderer.description) {
       containerEl.createEl('p', { cls: 'ani-credential-desc', text: renderer.description });
     }
@@ -500,11 +515,20 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Any field edit invalidates a prior setup verification. Auto-clear
     // the banner + re-enable Save so a stale RPC-missing diagnosis can't
     // outlive the inputs it was diagnosed against.
-    containerEl.addEventListener('input', () => {
+    //
+    // Register the handler reference in credentialFormUi.cleanups so the
+    // next form render / display() detaches it — otherwise add-mode
+    // type-switches (which re-call renderCredentialAddDetails on the
+    // same containerEl) would accumulate listeners.
+    const inputResetHandler = (): void => {
       if (this.credentialFormUi?.setupRequirement) {
         this.clearFormSetupRequirement();
       }
-    });
+    };
+    containerEl.addEventListener('input', inputResetHandler);
+    this.credentialFormUi?.cleanups.push(() =>
+      containerEl.removeEventListener('input', inputResetHandler),
+    );
 
     new Setting(containerEl)
       .addButton(button => {
@@ -555,6 +579,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     formHostEl: HTMLElement,
   ): Promise<void> {
     if (!renderer.testConnection) return;
+    if (this.credentialFormUi?.isTesting) return;   // re-entry guard
+    if (this.credentialFormUi) this.credentialFormUi.isTesting = true;
     new Notice('Auto Note Importer: Testing connection\u2026');
     try {
       const result = await renderer.testConnection(credential);
@@ -562,22 +588,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         new Notice(`Auto Note Importer: Connection failed \u2014 ${result.error}`);
         return;
       }
-      if (result.needsSetup && credential.type === 'supabase') {
+      if (result.needsSetup) {
         // Suppress the "Connection OK" Notice \u2014 the inline banner is the
         // contextual surface. Render banner inside form host, disable
         // Save until verify succeeds.
-        const banner = this.renderRpcSetupBannerInForm(
-          this.ensureFormBannerHost(formHostEl),
-          credential,
-          () => this.clearFormSetupRequirement(),
-        );
-        if (this.credentialFormUi) {
-          this.credentialFormUi.setupRequirement = result.needsSetup;
-          this.credentialFormUi.bannerHost = banner;
-          if (this.credentialFormUi.saveButton) {
-            this.credentialFormUi.saveButton.disabled = true;
-          }
-        }
+        this.renderSetupBannerForRequirement(result.needsSetup, credential, formHostEl);
         return;
       }
       const detail = result.detail ? ` ${result.detail}` : '';
@@ -585,6 +600,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       new Notice(`Auto Note Importer: Connection test errored \u2014 ${message}`);
+    } finally {
+      if (this.credentialFormUi) this.credentialFormUi.isTesting = false;
     }
   }
 
@@ -1188,13 +1205,13 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
    * Credential-form variant of the RPC setup banner. Unlike the
    * connection-card variant, this one does NOT include the manual-entry
    * text fallback (the credential is still being authored — no config
-   * exists yet). On verify success the banner removes itself, calls the
-   * caller's onSuccess (to re-enable Save), and emits a one-line
-   * confirmation Notice. On verify failure it surfaces the error inline
-   * inside the banner.
+   * exists yet). On verify success the caller's onSuccess fires
+   * (which calls clearFormSetupRequirement → removes the host); on
+   * verify failure the error is surfaced inline inside the banner.
    *
-   * Returns the banner element so callers can stash it for later
-   * removal on field-change auto-reset.
+   * Returns the host element (outer `.ani-rpc-setup-host`) so callers
+   * can stash it as the cleanup target — removing the host wipes the
+   * inner banner + buttons + error in one DOM op.
    */
   private renderRpcSetupBannerInForm(
     host: HTMLElement,
@@ -1217,8 +1234,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       credential,
       () => {
         new Notice('Auto Note Importer: Setup confirmed — you can save now.');
-        banner.remove();
-        onSuccess();
+        onSuccess();   // clearFormSetupRequirement removes the host (covers banner)
       },
       (error) => {
         errorHost.empty();
@@ -1226,7 +1242,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       },
     );
 
-    return banner;
+    return host;
   }
 
   /**
@@ -1240,6 +1256,82 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       host = formHostEl.createDiv({ cls: 'ani-rpc-setup-host' });
     }
     return host;
+  }
+
+  /**
+   * Runs all pending cleanups (e.g. removeEventListener handles) and
+   * drops the credential form UI state. Called from display() and
+   * before initializing a fresh form via resetCredentialFormUi() so
+   * type-switches in the add-mode form do not leak listeners.
+   */
+  private tearDownCredentialFormUi(): void {
+    if (!this.credentialFormUi) return;
+    for (const cleanup of this.credentialFormUi.cleanups) {
+      try { cleanup(); } catch { /* listener removal must not throw */ }
+    }
+    this.credentialFormUi = null;
+  }
+
+  /**
+   * Tears down any prior form state then initializes a fresh
+   * CredentialFormUiState. Both renderCredentialEditRow and
+   * renderCredentialAddDetails call this at their entry point.
+   */
+  private resetCredentialFormUi(): void {
+    this.tearDownCredentialFormUi();
+    this.credentialFormUi = {
+      setupRequirement: null,
+      bannerHost: null,
+      saveButton: null,
+      isTesting: false,
+      isSaving: false,
+      cleanups: [],
+    };
+  }
+
+  /**
+   * Renders the inline RPC setup banner for the given requirement and
+   * wires it to the form-scoped UI state (setupRequirement + bannerHost
+   * + saveButton.disabled). Uses an exhaustive switch on
+   * SetupRequirement.kind so future widening of the union fails at
+   * compile time until a handler is added.
+   *
+   * Returns true if a banner was rendered (caller should skip the
+   * usual success Notice), false otherwise.
+   */
+  private renderSetupBannerForRequirement(
+    needsSetup: SetupRequirement,
+    credential: Credential,
+    formHostEl: HTMLElement,
+  ): boolean {
+    switch (needsSetup.kind) {
+      case 'supabase-rpc': {
+        if (credential.type !== 'supabase') {
+          // Shouldn't happen — registry only maps supabase-rpc to
+          // Supabase. Surface as an internal error rather than silently
+          // skipping the banner.
+          new Notice(`Auto Note Importer: Internal error — supabase-rpc setup requested for ${credential.type} credential.`);
+          return false;
+        }
+        const host = this.renderRpcSetupBannerInForm(
+          this.ensureFormBannerHost(formHostEl),
+          credential,
+          () => this.clearFormSetupRequirement(),
+        );
+        if (this.credentialFormUi) {
+          this.credentialFormUi.setupRequirement = needsSetup;
+          this.credentialFormUi.bannerHost = host;
+          if (this.credentialFormUi.saveButton) {
+            this.credentialFormUi.saveButton.disabled = true;
+          }
+        }
+        return true;
+      }
+      default: {
+        const _exhaustive: never = needsSetup.kind;
+        throw new Error(`Unhandled setup requirement kind: ${String(_exhaustive)}`);
+      }
+    }
   }
 
   /**
@@ -1258,25 +1350,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     formHostEl: HTMLElement,
   ): Promise<'proceed' | 'blocked'> {
     if (!renderer.verifySetup) return 'proceed';
+    if (this.credentialFormUi?.isSaving) return 'blocked';   // re-entry guard
+    if (this.credentialFormUi) this.credentialFormUi.isSaving = true;
     try {
       const result = await renderer.verifySetup(credential);
       if (!result.success) {
         new Notice(`Auto Note Importer: Could not verify setup before save — ${result.error}`);
         return 'blocked';
       }
-      if (result.needsSetup && credential.type === 'supabase') {
-        const banner = this.renderRpcSetupBannerInForm(
-          this.ensureFormBannerHost(formHostEl),
-          credential,
-          () => this.clearFormSetupRequirement(),
-        );
-        if (this.credentialFormUi) {
-          this.credentialFormUi.setupRequirement = result.needsSetup;
-          this.credentialFormUi.bannerHost = banner;
-          if (this.credentialFormUi.saveButton) {
-            this.credentialFormUi.saveButton.disabled = true;
-          }
-        }
+      if (result.needsSetup) {
+        this.renderSetupBannerForRequirement(result.needsSetup, credential, formHostEl);
         return 'blocked';
       }
       return 'proceed';
@@ -1284,6 +1367,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       const message = error instanceof Error ? error.message : 'Unknown error';
       new Notice(`Auto Note Importer: Could not verify setup before save — ${message}`);
       return 'blocked';
+    } finally {
+      if (this.credentialFormUi) this.credentialFormUi.isSaving = false;
     }
   }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -25,7 +25,7 @@ import {
   hasCredentialFormRenderer,
 } from '../services';
 import type { SeaTableTable } from '../services';
-import type { CredentialFormState, CredentialFormRenderer } from '../types';
+import type { CredentialFormState, CredentialFormRenderer, SetupRequirement } from '../types';
 import type { AutoNoteImporterSettings, ConfigEntry, Credential, AirtableCredential, SeaTableCredential, SupabaseCredential, SupabaseOpenApiSpec, CredentialType, ConflictResolutionMode, BasesFileLocation } from '../types';
 import { DEFAULT_CONFIG_ENTRY, CREDENTIAL_TYPES, CREDENTIAL_TYPE_LABELS } from '../types';
 import { SUPABASE_DEFAULT_SCHEMA, SUPABASE_RPC_SCHEMA_SQL } from '../constants';
@@ -40,6 +40,20 @@ import { debounce } from '../utils/debounce';
 export interface SettingsPlugin extends Plugin {
   settings: AutoNoteImporterSettings;
   saveSettings(): Promise<void>;
+}
+
+/**
+ * Transient UI state for the credential add/edit form. Tracks whether
+ * the active form has a pending setup requirement (e.g. Supabase RPC
+ * not installed), plus references to the banner host and Save button so
+ * handlers can clear them when the user edits a field (auto-reset) or
+ * verifies the setup. Owned by the settings tab; reset on display()
+ * and re-initialized when a credential form opens.
+ */
+interface CredentialFormUiState {
+  setupRequirement: SetupRequirement | null;
+  bannerHost: HTMLElement | null;
+  saveButton: HTMLButtonElement | null;
 }
 
 /**
@@ -68,6 +82,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private expandedSections: Set<string> = new Set(['airtable-connection', 'seatable-connection', 'supabase-connection']);
   private pendingDeleteConfigId: string | null = null;
   private pendingDeleteCredentialId: string | null = null;
+  private credentialFormUi: CredentialFormUiState | null = null;
 
   constructor(
     app: App,
@@ -138,6 +153,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
   display(): void {
     this.renderGeneration++;
+    this.credentialFormUi = null;
     const { containerEl } = this;
     containerEl.empty();
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1061,33 +1061,28 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   }
 
   /**
-   * Rendered when the publishable key can read /rest/v1/<table> for data but
-   * cannot read /rest/v1/ for schema introspection (Supabase new key policy)
-   * AND the user has not yet installed the SECURITY DEFINER RPC fallback.
+   * Renders the shared parts of the RPC setup banner — SQL code block,
+   * Copy SQL button, and "I've run it — Verify" button — into the given
+   * host. Callers wrap this with banner-specific header/desc/manual-
+   * fallback content. The two callbacks decide what happens after the
+   * Verify RPC call returns; both connection-card and credential-form
+   * contexts share the SQL block + buttons but diverge in post-verify
+   * action.
    *
-   * Shows the one-time setup SQL with a Copy button + a Refresh action that
-   * clears the cache and re-runs the fetch chain. Settled, the card flips
-   * to renderSupabaseDropdowns automatically.
+   * The verify path always bypasses the cache (clearForCred) before
+   * calling verifySetup — the user just ran the SQL, so the previous
+   * 404 is stale by definition.
    */
-  private renderSupabaseRpcSetupBanner(
-    containerEl: HTMLElement,
-    config: ConfigEntry,
+  private renderRpcSetupBannerCore(
+    host: HTMLElement,
     credential: SupabaseCredential,
+    onVerifySuccess: () => void,
+    onVerifyFailure: (error: string) => void,
   ): void {
-    containerEl.empty();
-    const banner = containerEl.createDiv({ cls: 'ani-rpc-setup-banner' });
-    banner.createEl('h4', { text: 'One-time setup required for publishable keys' });
-    const desc = banner.createEl('p');
-    desc.setText(
-      'Supabase’s new key system blocks publishable keys from reading the ' +
-      'OpenAPI schema. Run this SQL once in your Supabase SQL Editor — it ' +
-      'creates a SECURITY DEFINER function the plugin uses for schema introspection.',
-    );
-
-    const codeBlock = banner.createEl('pre', { cls: 'ani-rpc-setup-sql' });
+    const codeBlock = host.createEl('pre', { cls: 'ani-rpc-setup-sql' });
     codeBlock.createEl('code', { text: SUPABASE_RPC_SCHEMA_SQL });
 
-    const buttonRow = banner.createDiv({ cls: 'ani-rpc-setup-actions' });
+    const buttonRow = host.createDiv({ cls: 'ani-rpc-setup-actions' });
 
     const copyBtn = buttonRow.createEl('button', { text: 'Copy SQL', cls: 'mod-cta' });
     copyBtn.addEventListener('click', async () => {
@@ -1099,11 +1094,71 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       }
     });
 
-    const refreshBtn = buttonRow.createEl('button', { text: 'I’ve run it — Refresh' });
-    refreshBtn.addEventListener('click', () => {
-      this.supabaseMetadataCache.clearForCred(credential.id);
-      this.debounceDisplay(0);
+    const verifyBtn = buttonRow.createEl('button', { text: 'I’ve run it — Verify' });
+    verifyBtn.addEventListener('click', async () => {
+      verifyBtn.disabled = true;
+      const originalText = verifyBtn.textContent;
+      verifyBtn.textContent = 'Verifying…';
+      try {
+        this.supabaseMetadataCache.clearForCred(credential.id);
+        const renderer = getCredentialFormRenderer('supabase');
+        if (!renderer.verifySetup) {
+          onVerifyFailure('Supabase provider does not implement verifySetup — please report this as a bug.');
+          return;
+        }
+        const result = await renderer.verifySetup(credential);
+        if (result.success && !result.needsSetup) {
+          onVerifySuccess();
+        } else if (result.success && result.needsSetup) {
+          onVerifyFailure('RPC still not installed. Common issues: SQL ran in the wrong schema (try \'public\'); missing GRANT EXECUTE — re-run the SQL fully; different project — verify the Project URL matches.');
+        } else if (!result.success) {
+          onVerifyFailure(result.error);
+        }
+      } finally {
+        verifyBtn.disabled = false;
+        verifyBtn.textContent = originalText;
+      }
     });
+  }
+
+  /**
+   * Rendered when the publishable key can read /rest/v1/<table> for data but
+   * cannot read /rest/v1/ for schema introspection (Supabase new key policy)
+   * AND the user has not yet installed the SECURITY DEFINER RPC fallback.
+   *
+   * Shows the one-time setup SQL with a Copy button + a Verify action via
+   * the shared renderRpcSetupBannerCore. On verify success the cache is
+   * cleared and the settings tab re-renders so the card flips to
+   * renderSupabaseDropdowns automatically. Includes a manual-entry text
+   * fallback for users who want to keep the publishable key without
+   * installing the RPC.
+   */
+  private renderSupabaseRpcSetupBanner(
+    containerEl: HTMLElement,
+    config: ConfigEntry,
+    credential: SupabaseCredential,
+  ): void {
+    containerEl.empty();
+    const banner = containerEl.createDiv({ cls: 'ani-rpc-setup-banner' });
+    banner.createEl('h4', { text: 'One-time setup required for publishable keys' });
+    banner.createEl('p').setText(
+      'Supabase’s new key system blocks publishable keys from reading the ' +
+      'OpenAPI schema. Run this SQL once in your Supabase SQL Editor — it ' +
+      'creates a SECURITY DEFINER function the plugin uses for schema introspection.',
+    );
+
+    this.renderRpcSetupBannerCore(
+      banner,
+      credential,
+      () => {
+        // Connection-card success: re-render so the card flips back to
+        // dropdowns (verifySetup already cleared the cache).
+        this.debounceDisplay(0);
+      },
+      (error) => {
+        new Notice(`Auto Note Importer: ${error}`);
+      },
+    );
 
     // Manual-entry escape hatch — render into a fresh sub-container so the
     // fallback's containerEl.empty() can't wipe the banner above it.

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -373,6 +373,15 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
     renderer.renderFields(containerEl, state, cred);
 
+    // Any field edit invalidates a prior setup verification. Auto-clear
+    // the banner + re-enable Save so a stale RPC-missing diagnosis can't
+    // outlive the inputs it was diagnosed against.
+    containerEl.addEventListener('input', () => {
+      if (this.credentialFormUi?.setupRequirement) {
+        this.clearFormSetupRequirement();
+      }
+    });
+
     new Setting(containerEl)
       .addButton(button => {
         button.setButtonText('Save').setCta();
@@ -487,6 +496,15 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       containerEl.createEl('p', { cls: 'ani-credential-desc', text: renderer.description });
     }
     renderer.renderFields(containerEl, context.state);
+
+    // Any field edit invalidates a prior setup verification. Auto-clear
+    // the banner + re-enable Save so a stale RPC-missing diagnosis can't
+    // outlive the inputs it was diagnosed against.
+    containerEl.addEventListener('input', () => {
+      if (this.credentialFormUi?.setupRequirement) {
+        this.clearFormSetupRequirement();
+      }
+    });
 
     new Setting(containerEl)
       .addButton(button => {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -374,10 +374,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     renderer.renderFields(containerEl, state, cred);
 
     new Setting(containerEl)
-      .addButton(button => button
-        .setButtonText('Save')
-        .setCta()
-        .onClick(async () => {
+      .addButton(button => {
+        button.setButtonText('Save').setCta();
+        if (this.credentialFormUi) {
+          this.credentialFormUi.saveButton = button.buttonEl;
+        }
+        button.onClick(async () => {
           const result = renderer.build(nameValue, state, cred.id);
           if (!result.ok) {
             new Notice(`Auto Note Importer: ${result.error}`);
@@ -393,7 +395,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
           this.editingCredentialId = null;
           this.display();
-        }))
+        });
+      })
       .addButton(button => {
         button
           .setButtonText('Test')
@@ -487,23 +490,24 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .addButton(button => {
-        button
-          .setButtonText('Save')
-          .setCta()
-          .onClick(async () => {
-            const result = renderer.build(context.name, context.state, generateId());
-            if (!result.ok) {
-              new Notice(`Auto Note Importer: ${result.error}`);
-              return;
-            }
-            const gate = await this.verifyCredentialBeforeSave(renderer, result.credential, containerEl);
-            if (gate !== 'proceed') return;
-            this.plugin.settings.credentials.push(result.credential);
-            await this.plugin.saveSettings();
-            this.addingCredential = false;
-            this.addingCredentialType = 'airtable';
-            this.display();
-          });
+        button.setButtonText('Save').setCta();
+        if (this.credentialFormUi) {
+          this.credentialFormUi.saveButton = button.buttonEl;
+        }
+        button.onClick(async () => {
+          const result = renderer.build(context.name, context.state, generateId());
+          if (!result.ok) {
+            new Notice(`Auto Note Importer: ${result.error}`);
+            return;
+          }
+          const gate = await this.verifyCredentialBeforeSave(renderer, result.credential, containerEl);
+          if (gate !== 'proceed') return;
+          this.plugin.settings.credentials.push(result.credential);
+          await this.plugin.saveSettings();
+          this.addingCredential = false;
+          this.addingCredentialType = 'airtable';
+          this.display();
+        });
       })
       .addButton(button => {
         button

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -15,6 +15,18 @@
  *
  * Usage:
  *   node tests/e2e/run-supabase-settings-e2e.mjs
+ *
+ * IMPORTANT — TypeScript `private` access at runtime:
+ *   Scenarios under "Issue #91" (RPC setup banner) intentionally call
+ *   TypeScript `private` members on the settings tab at runtime —
+ *   `tab.ensureFormBannerHost`, `tab.renderRpcSetupBannerInForm`,
+ *   `tab.credentialFormUi`. JS has no enforcement so this works, but the
+ *   bindings MUST be kept in sync with the settings-tab implementation.
+ *   A rename or signature change to any of those without updating these
+ *   scenarios will silently break the e2e without a compile error.
+ *   This is acknowledged in PR #92 review (claude #3) — the trade-off
+ *   is faster + less flaky than driving the full Test/Save button flow
+ *   via CDP clicks for state↔DOM integration verification.
  */
 
 import { findPageTarget } from './cdp-helpers.mjs';

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -318,8 +318,10 @@ const { results, log, run, test } = createTestHarness({ getTargetId: () => targe
         // Invoke the same helper testConnection / Save handlers use to
         // surface the banner; bypass the actual RPC by going through
         // the render path directly.
-        // NOTE: renderRpcSetupBannerInForm returns void — use `host`
-        // (from ensureFormBannerHost) as bannerHost, not the return value.
+        // NOTE: renderRpcSetupBannerInForm returns void - use the host
+        // variable (from ensureFormBannerHost) as bannerHost.
+        // (No backticks here: the surrounding run(...) is itself a
+        // template literal, and nested backticks break parsing.)
         const host = tab.ensureFormBannerHost(formHost);
         tab.renderRpcSetupBannerInForm(host, cred, () => {});
         tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };
@@ -389,8 +391,10 @@ const { results, log, run, test } = createTestHarness({ getTargetId: () => targe
         };
 
         // Set up the banner + setupRequirement + saveButton reference.
-        // NOTE: renderRpcSetupBannerInForm returns void — use `host`
-        // (from ensureFormBannerHost) as bannerHost, not the return value.
+        // NOTE: renderRpcSetupBannerInForm returns void - use the host
+        // variable (from ensureFormBannerHost) as bannerHost.
+        // (No backticks here: the surrounding run(...) is itself a
+        // template literal, and nested backticks break parsing.)
         const host = tab.ensureFormBannerHost(formHost);
         tab.renderRpcSetupBannerInForm(host, cred, () => {});
         tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -266,6 +266,163 @@ const { results, log, run, test } = createTestHarness({ getTargetId: () => targe
       };
     });
 
+    // ════════════════════════════════════════════════════════════════
+    // Issue #91 — Supabase RPC setup inline banner (state ↔ DOM)
+    // ════════════════════════════════════════════════════════════════
+
+    // RPC branch logic is covered by 28 unit tests in
+    // tests/services/supabase-credential-form.test.ts (testConnection +
+    // verifySetup). These e2e scenarios verify the integration: state
+    // injection → DOM mutation → banner removal on input event. Real
+    // publishable-key + missing-RPC flow validation lives in the PR
+    // manual checklist (must run against a live Supabase project).
+
+    await test('credential form / setupRequirement injection renders inline banner (#91)', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const tab = app.setting.activeTab;
+
+        // Open the Add Credential form with Supabase pre-selected so
+        // renderCredentialAddDetails initializes credentialFormUi.
+        tab.addingCredential = true;
+        tab.addingCredentialType = 'supabase';
+        tab.display();
+        await new Promise(r => setTimeout(r, 200));
+
+        const c = getContainer();
+        const formHost = c.querySelector('.ani-credential-add-details');
+        if (!formHost) return JSON.stringify({ noFormHost: true });
+        if (!tab.credentialFormUi) return JSON.stringify({ noUiState: true });
+
+        const cred = {
+          id: 'e2e-rpc-banner',
+          name: 'E2E RPC Banner',
+          type: 'supabase',
+          projectUrl: 'https://example.supabase.co',
+          apiKey: 'sb_publishable_e2e',
+        };
+
+        // Invoke the same helper testConnection / Save handlers use to
+        // surface the banner; bypass the actual RPC by going through
+        // the render path directly.
+        const host = tab.ensureFormBannerHost(formHost);
+        const banner = tab.renderRpcSetupBannerInForm(host, cred, () => {});
+        tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };
+        tab.credentialFormUi.bannerHost = banner;
+
+        await new Promise(r => setTimeout(r, 100));
+
+        const rendered = formHost.querySelector('.ani-rpc-setup-banner');
+        const sqlBlock = rendered ? rendered.querySelector('.ani-rpc-setup-sql code') : null;
+        const buttons = rendered ? Array.from(rendered.querySelectorAll('button')) : [];
+        const buttonTexts = buttons.map(b => b.textContent || '');
+        const result = {
+          bannerVisible: !!rendered,
+          sqlPresent: !!sqlBlock && (sqlBlock.textContent || '').includes('CREATE OR REPLACE FUNCTION'),
+          buttonTexts,
+          setupKind: tab.credentialFormUi.setupRequirement.kind,
+        };
+
+        // Cleanup form
+        tab.addingCredential = false;
+        tab.display();
+
+        return JSON.stringify(result);
+      })()`, 15000);
+
+      if (r.noFormHost) return { pass: false, detail: 'add-form host not found' };
+      if (r.noUiState) return { pass: false, detail: 'credentialFormUi not initialized on form render' };
+      const hasCopy = (r.buttonTexts || []).some(t => /Copy SQL/i.test(t));
+      const hasVerify = (r.buttonTexts || []).some(t => /Verify/i.test(t));
+      const pass = r.bannerVisible && r.sqlPresent && hasCopy && hasVerify && r.setupKind === 'supabase-rpc';
+      return {
+        pass,
+        detail: `banner=${r.bannerVisible} sql=${r.sqlPresent} buttons=[${(r.buttonTexts || []).join(' | ')}] kind=${r.setupKind}`,
+      };
+    });
+
+    await test('credential form / field input auto-resets banner + re-enables save (#91)', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const p = getPlugin();
+        const tab = app.setting.activeTab;
+
+        tab.addingCredential = true;
+        tab.addingCredentialType = 'supabase';
+        tab.display();
+        await new Promise(r => setTimeout(r, 200));
+
+        const c = getContainer();
+        const formHost = c.querySelector('.ani-credential-add-details');
+        if (!formHost) return JSON.stringify({ noFormHost: true });
+        if (!tab.credentialFormUi) return JSON.stringify({ noUiState: true });
+
+        // Locate the API Key input (password type per renderFields).
+        const apiKeyInput = formHost.querySelector('input[type="password"]');
+        if (!apiKeyInput) return JSON.stringify({ noApiKeyInput: true });
+
+        // Locate the Save button (the only .mod-cta in the form).
+        const saveBtn = formHost.querySelector('button.mod-cta');
+        if (!saveBtn) return JSON.stringify({ noSaveBtn: true });
+
+        const cred = {
+          id: 'e2e-rpc-reset',
+          name: 'E2E Reset',
+          type: 'supabase',
+          projectUrl: 'https://example.supabase.co',
+          apiKey: 'sb_publishable_e2e',
+        };
+
+        // Set up the banner + setupRequirement + saveButton reference.
+        const host = tab.ensureFormBannerHost(formHost);
+        const banner = tab.renderRpcSetupBannerInForm(host, cred, () => {});
+        tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };
+        tab.credentialFormUi.bannerHost = banner;
+        tab.credentialFormUi.saveButton = saveBtn;
+        saveBtn.disabled = true;
+
+        await new Promise(r => setTimeout(r, 50));
+        const beforeReset = {
+          bannerInDom: !!formHost.querySelector('.ani-rpc-setup-banner'),
+          saveDisabled: saveBtn.disabled,
+          kind: tab.credentialFormUi.setupRequirement?.kind || null,
+        };
+
+        // Simulate user typing in the API Key field — dispatch 'input'.
+        const proto = Object.getPrototypeOf(apiKeyInput);
+        const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+        setter.call(apiKeyInput, 'sb_publishable_e2e_changed');
+        apiKeyInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        await new Promise(r => setTimeout(r, 100));
+        const afterReset = {
+          bannerInDom: !!formHost.querySelector('.ani-rpc-setup-banner'),
+          saveDisabled: saveBtn.disabled,
+          kind: tab.credentialFormUi.setupRequirement || null,
+        };
+
+        // Cleanup form
+        tab.addingCredential = false;
+        tab.display();
+
+        return JSON.stringify({ beforeReset, afterReset });
+      })()`, 15000);
+
+      if (r.noFormHost) return { pass: false, detail: 'add-form host not found' };
+      if (r.noUiState) return { pass: false, detail: 'credentialFormUi not initialized' };
+      if (r.noApiKeyInput) return { pass: false, detail: 'API Key input not found' };
+      if (r.noSaveBtn) return { pass: false, detail: 'Save button not found' };
+
+      const beforeOk = r.beforeReset.bannerInDom && r.beforeReset.saveDisabled && r.beforeReset.kind === 'supabase-rpc';
+      const afterOk = !r.afterReset.bannerInDom && !r.afterReset.saveDisabled && r.afterReset.kind === null;
+      const pass = beforeOk && afterOk;
+      return {
+        pass,
+        detail: `before={banner=${r.beforeReset.bannerInDom} disabled=${r.beforeReset.saveDisabled} kind=${r.beforeReset.kind}} after={banner=${r.afterReset.bannerInDom} disabled=${r.afterReset.saveDisabled} kind=${JSON.stringify(r.afterReset.kind)}}`,
+      };
+    });
+
     // ── Cleanup ──────────────────────────────────────────────────
 
     log('\n=== Cleanup ===');

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -318,10 +318,12 @@ const { results, log, run, test } = createTestHarness({ getTargetId: () => targe
         // Invoke the same helper testConnection / Save handlers use to
         // surface the banner; bypass the actual RPC by going through
         // the render path directly.
+        // NOTE: renderRpcSetupBannerInForm returns void — use `host`
+        // (from ensureFormBannerHost) as bannerHost, not the return value.
         const host = tab.ensureFormBannerHost(formHost);
-        const banner = tab.renderRpcSetupBannerInForm(host, cred, () => {});
+        tab.renderRpcSetupBannerInForm(host, cred, () => {});
         tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };
-        tab.credentialFormUi.bannerHost = banner;
+        tab.credentialFormUi.bannerHost = host;
 
         await new Promise(r => setTimeout(r, 100));
 
@@ -387,10 +389,12 @@ const { results, log, run, test } = createTestHarness({ getTargetId: () => targe
         };
 
         // Set up the banner + setupRequirement + saveButton reference.
+        // NOTE: renderRpcSetupBannerInForm returns void — use `host`
+        // (from ensureFormBannerHost) as bannerHost, not the return value.
         const host = tab.ensureFormBannerHost(formHost);
-        const banner = tab.renderRpcSetupBannerInForm(host, cred, () => {});
+        tab.renderRpcSetupBannerInForm(host, cred, () => {});
         tab.credentialFormUi.setupRequirement = { kind: 'supabase-rpc' };
-        tab.credentialFormUi.bannerHost = banner;
+        tab.credentialFormUi.bannerHost = host;
         tab.credentialFormUi.saveButton = saveBtn;
         saveBtn.disabled = true;
 

--- a/tests/services/supabase-credential-form.test.ts
+++ b/tests/services/supabase-credential-form.test.ts
@@ -228,38 +228,54 @@ describe('supabaseCredentialFormRenderer.verifySetup', () => {
     projectUrl: 'https://abc.supabase.co', apiKey: 'sb_publishable_xxx',
   };
 
-  it('returns needsSetup when RPC returns 404/PGRST202', async () => {
-    mockRequestUrl.mockResolvedValueOnce({
-      status: 404,
-      json: { code: 'PGRST202', message: 'function ani_supabase_schema does not exist' },
-    });
+  it('returns needsSetup when publishable key + OpenAPI 401 + RPC PGRST202', async () => {
+    // verifySetup now mirrors testConnection's 2-step probe — OpenAPI
+    // first, RPC fallback on 401.
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 404, json: { code: 'PGRST202', message: 'function ani_supabase_schema does not exist' } });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(true);
     if (!r.success) return;
     expect(r.needsSetup).toEqual({ kind: 'supabase-rpc' });
   });
 
-  it('returns plain success with detail when RPC returns 200', async () => {
-    mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { notes: {} } });
+  // Codex P1 (PR #92) regression coverage: prior to the probeRpc
+  // refactor, verifySetup skipped the OpenAPI step and went straight to
+  // the RPC. A secret/anon-JWT user with a project missing the RPC
+  // would be wrongly blocked from saving even though OpenAPI 200 means
+  // the key reads schema natively — no RPC needed.
+  it('returns success WITHOUT needsSetup when OpenAPI 200 (secret / anon JWT)', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: { definitions: { notes: {}, tags: {} } },
+    });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(true);
     if (!r.success) return;
     expect(r.needsSetup).toBeUndefined();
-    expect(r.detail).toBe('RPC reachable.');
+    expect(r.detail).toContain('2');
   });
 
-  it('does NOT miscategorize non-JSON body (HTML 502) as rpc-missing', async () => {
-    // Self-hosted PostgREST behind a misconfigured proxy may return
-    // HTML 502 with no JSON body — without isRpcMissingResponse's type
-    // guard, the .code check would silently fall through to "not
-    // missing" and we'd return a generic HTTP error (still correct here)
-    // — but with `rpc.json === undefined` we MUST NOT throw or
-    // miscategorize as success.
-    mockRequestUrl.mockResolvedValueOnce({
-      status: 502,
-      json: undefined,
-      text: () => '<html>502 Bad Gateway</html>',
-    });
+  it('returns success WITHOUT needsSetup when OpenAPI 401 + RPC 200 (publishable + installed)', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 200, json: { notes: {}, tags: {} } });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.needsSetup).toBeUndefined();
+    expect(r.detail).toContain('RPC');
+  });
+
+  it('does NOT miscategorize non-JSON body (HTML 502) on RPC step as rpc-missing', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({
+        status: 502,
+        json: undefined,
+        text: () => '<html>502 Bad Gateway</html>',
+      });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
     if (r.success) return;
@@ -267,46 +283,55 @@ describe('supabaseCredentialFormRenderer.verifySetup', () => {
   });
 
   it('does NOT miscategorize null rpc.json as rpc-missing', async () => {
-    mockRequestUrl.mockResolvedValueOnce({ status: 500, json: null });
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 500, json: null });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
   });
 
   it('does NOT miscategorize array rpc.json as rpc-missing', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 404, json: ['unexpected', 'shape'] });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('404');
+  });
+
+  it('returns failure on OpenAPI non-401 / non-200 (e.g. 500)', async () => {
     mockRequestUrl.mockResolvedValueOnce({
-      status: 404,
-      json: ['unexpected', 'shape'],
+      status: 500,
+      json: { message: 'server error' },
     });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
     if (r.success) return;
-    // Critical: must surface as failure, NOT as `success: true, needsSetup`.
-    expect(r.error).toContain('404');
+    expect(r.error).toContain('500');
   });
 
-  it('returns failure on 401', async () => {
-    mockRequestUrl.mockResolvedValueOnce({
-      status: 401,
-      json: { message: 'Invalid API key' },
-    });
+  it('returns failure on RPC 401 (publishable key revoked between OpenAPI and RPC)', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 401, json: { message: 'Invalid API key' } });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
     if (r.success) return;
     expect(r.error).toContain('401');
   });
 
-  it('returns failure on 5xx', async () => {
-    mockRequestUrl.mockResolvedValueOnce({
-      status: 503,
-      json: { message: 'service unavailable' },
-    });
+  it('returns failure on RPC 5xx', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 503, json: { message: 'service unavailable' } });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
     if (r.success) return;
     expect(r.error).toContain('503');
   });
 
-  it('returns failure on network error', async () => {
+  it('returns failure on network error during OpenAPI step', async () => {
     mockRequestUrl.mockRejectedValueOnce(new Error('network unreachable'));
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);

--- a/tests/services/supabase-credential-form.test.ts
+++ b/tests/services/supabase-credential-form.test.ts
@@ -202,3 +202,67 @@ describe('supabaseCredentialFormRenderer.testConnection', () => {
     expect(r.success).toBe(false);
   });
 });
+
+describe('supabaseCredentialFormRenderer.verifySetup', () => {
+  beforeEach(() => mockRequestUrl.mockReset());
+
+  const cred: Credential = {
+    id: 'c1', name: 'X', type: 'supabase',
+    projectUrl: 'https://abc.supabase.co', apiKey: 'sb_publishable_xxx',
+  };
+
+  it('returns needsSetup when RPC returns 404/PGRST202', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 404,
+      json: { code: 'PGRST202', message: 'function ani_supabase_schema does not exist' },
+    });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.needsSetup).toEqual({ kind: 'supabase-rpc' });
+  });
+
+  it('returns plain success when RPC returns 200', async () => {
+    mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { notes: {} } });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.needsSetup).toBeUndefined();
+  });
+
+  it('returns failure on 401', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 401,
+      json: { message: 'Invalid API key' },
+    });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('401');
+  });
+
+  it('returns failure on 5xx', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 503,
+      json: { message: 'service unavailable' },
+    });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('503');
+  });
+
+  it('returns failure on network error', async () => {
+    mockRequestUrl.mockRejectedValueOnce(new Error('network unreachable'));
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('network');
+  });
+
+  it('refuses non-supabase credential', async () => {
+    const wrong: Credential = { id: 'c1', name: 'X', type: 'airtable', apiKey: 'k' };
+    const r = await supabaseCredentialFormRenderer.verifySetup!(wrong);
+    expect(r.success).toBe(false);
+  });
+});

--- a/tests/services/supabase-credential-form.test.ts
+++ b/tests/services/supabase-credential-form.test.ts
@@ -177,6 +177,23 @@ describe('supabaseCredentialFormRenderer.testConnection', () => {
     expect(r.needsSetup).toBeUndefined();
   });
 
+  it('does NOT miscategorize non-JSON body on RPC fallback as rpc-missing', async () => {
+    // OpenAPI 401 → falls through to RPC. RPC returns HTML 502 (proxy).
+    // Without isRpcMissingResponse's type guard, the .code check would
+    // silently fall through. Verify the helper catches it.
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({
+        status: 502,
+        json: undefined,
+        text: () => '<html>502</html>',
+      });
+    const r = await supabaseCredentialFormRenderer.testConnection!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('502');
+  });
+
   it('returns failure on non-401 OpenAPI status (e.g., 500)', async () => {
     mockRequestUrl.mockResolvedValueOnce({
       status: 500,
@@ -222,12 +239,49 @@ describe('supabaseCredentialFormRenderer.verifySetup', () => {
     expect(r.needsSetup).toEqual({ kind: 'supabase-rpc' });
   });
 
-  it('returns plain success when RPC returns 200', async () => {
+  it('returns plain success with detail when RPC returns 200', async () => {
     mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { notes: {} } });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(true);
     if (!r.success) return;
     expect(r.needsSetup).toBeUndefined();
+    expect(r.detail).toBe('RPC reachable.');
+  });
+
+  it('does NOT miscategorize non-JSON body (HTML 502) as rpc-missing', async () => {
+    // Self-hosted PostgREST behind a misconfigured proxy may return
+    // HTML 502 with no JSON body — without isRpcMissingResponse's type
+    // guard, the .code check would silently fall through to "not
+    // missing" and we'd return a generic HTTP error (still correct here)
+    // — but with `rpc.json === undefined` we MUST NOT throw or
+    // miscategorize as success.
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 502,
+      json: undefined,
+      text: () => '<html>502 Bad Gateway</html>',
+    });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('502');
+  });
+
+  it('does NOT miscategorize null rpc.json as rpc-missing', async () => {
+    mockRequestUrl.mockResolvedValueOnce({ status: 500, json: null });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+  });
+
+  it('does NOT miscategorize array rpc.json as rpc-missing', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 404,
+      json: ['unexpected', 'shape'],
+    });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    // Critical: must surface as failure, NOT as `success: true, needsSetup`.
+    expect(r.error).toContain('404');
   });
 
   it('returns failure on 401', async () => {

--- a/tests/services/supabase-credential-form.test.ts
+++ b/tests/services/supabase-credential-form.test.ts
@@ -143,14 +143,38 @@ describe('supabaseCredentialFormRenderer.testConnection', () => {
     expect(r.detail).toContain('RPC');
   });
 
-  it('treats OpenAPI 401 + RPC PGRST202 (missing) as authenticated-but-setup-required success', async () => {
+  it('returns needsSetup on OpenAPI 401 + RPC PGRST202 (publishable + missing RPC)', async () => {
     mockRequestUrl
       .mockResolvedValueOnce({ status: 401, json: {} })
       .mockResolvedValueOnce({ status: 404, json: { code: 'PGRST202', message: 'function ani_supabase_schema does not exist' } });
     const r = await supabaseCredentialFormRenderer.testConnection!(cred);
     expect(r.success).toBe(true);
     if (!r.success) return;
-    expect(r.detail).toContain('setup SQL');
+    expect(r.needsSetup).toEqual({ kind: 'supabase-rpc' });
+    // Detail no longer references "(settings card)" — the UI renders the
+    // inline banner in-place, so the location hint is redundant.
+    expect(r.detail).not.toMatch(/settings card/i);
+  });
+
+  it('omits needsSetup when OpenAPI returns 200 (legacy anon JWT / secret key)', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: { definitions: { notes: {} } },
+    });
+    const r = await supabaseCredentialFormRenderer.testConnection!(cred);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.needsSetup).toBeUndefined();
+  });
+
+  it('omits needsSetup when OpenAPI 401 + RPC 200 (publishable + installed RPC)', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({ status: 200, json: { notes: {} } });
+    const r = await supabaseCredentialFormRenderer.testConnection!(cred);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.needsSetup).toBeUndefined();
   });
 
   it('returns failure on non-401 OpenAPI status (e.g., 500)', async () => {

--- a/tests/services/supabase-credential-form.test.ts
+++ b/tests/services/supabase-credential-form.test.ts
@@ -245,12 +245,21 @@ describe('supabaseCredentialFormRenderer.verifySetup', () => {
   // the RPC. A secret/anon-JWT user with a project missing the RPC
   // would be wrongly blocked from saving even though OpenAPI 200 means
   // the key reads schema natively — no RPC needed.
+  //
+  // Uses a secret-prefixed cred to match the test intent (secret / anon
+  // JWT typically get OpenAPI 200; publishable typically gets 401).
+  // probeRpc doesn't actually branch on key prefix, but matching the
+  // realistic flow makes the regression's failure mode unambiguous.
   it('returns success WITHOUT needsSetup when OpenAPI 200 (secret / anon JWT)', async () => {
+    const credSecret: Credential = {
+      id: 'c1', name: 'X', type: 'supabase',
+      projectUrl: 'https://abc.supabase.co', apiKey: 'sb_secret_xxx',
+    };
     mockRequestUrl.mockResolvedValueOnce({
       status: 200,
       json: { definitions: { notes: {}, tags: {} } },
     });
-    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    const r = await supabaseCredentialFormRenderer.verifySetup!(credSecret);
     expect(r.success).toBe(true);
     if (!r.success) return;
     expect(r.needsSetup).toBeUndefined();
@@ -315,6 +324,23 @@ describe('supabaseCredentialFormRenderer.verifySetup', () => {
     mockRequestUrl
       .mockResolvedValueOnce({ status: 401, json: {} })
       .mockResolvedValueOnce({ status: 401, json: { message: 'Invalid API key' } });
+    const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    expect(r.error).toContain('401');
+  });
+
+  // PR #92 sweep follow-up: isRpcMissingResponse anchors on status to
+  // prevent a 401 auth response with body code='PGRST202' (from a
+  // misconfigured proxy / WAF) from being silently routed to the
+  // setup banner instead of surfacing the auth error.
+  it('does NOT misclassify 401 + PGRST202 body as rpc-missing', async () => {
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 401, json: {} })
+      .mockResolvedValueOnce({
+        status: 401,
+        json: { code: 'PGRST202', message: 'function ani_supabase_schema does not exist' },
+      });
     const r = await supabaseCredentialFormRenderer.verifySetup!(cred);
     expect(r.success).toBe(false);
     if (r.success) return;


### PR DESCRIPTION
## Summary

- Replace the toast Notice ("run the setup SQL (settings card)") with an **inline banner inside the credential form** when a publishable key is entered against a project missing the `ani_supabase_schema` RPC.
- Block credential save until the RPC is verified — fail-closed so a publishable + missing-RPC credential cannot be silently saved.
- Refactor `renderSupabaseRpcSetupBanner` to share its SQL / Copy / Verify core with the new credential-form variant.
- Hardening from `/simplify` max-effort review + 2 rounds of bot code review feedback (probeRpc, status-anchored isRpcMissingResponse, stale banner cleanup, Test/Save button loading, form-scoped UI state lifecycle).

## Changes

### Types (additive, backward-compatible)

- `ConnectionTestResult.needsSetup?: SetupRequirement` — new optional signal on success variant
- `CredentialFormRenderer.verifySetup?` — new optional save-time gate method
- `SetupRequirement` — `{ kind: 'supabase-rpc' }` union (widens via exhaustive switch)

### Supabase renderer

- New private `probeRpc(credential)` helper — single source of truth for the 2-step probe (OpenAPI → 401 fallback to RPC). Both `testConnection` and `verifySetup` delegate to it, so they only differ in intent.
- `testConnection` returns `needsSetup` on publishable + missing-RPC; `verifySetup` mirrors it for save-time use.
- `isRpcMissingResponse` helper — status-anchored (4xx, excluding 401/403) + body-shape guard against non-JSON / proxy / WAF stale bodies.

### Settings tab

- `renderRpcSetupBannerCore` — shared SQL/Copy/Verify (extracted from connection-card banner)
- `renderRpcSetupBannerInForm` — credential-form variant, void return (caller owns host)
- `runConnectionTest(renderer, credential, formHostEl)` — branches on `needsSetup`; auto-clears stale banner on success-without-needsSetup; **Test button visual loading**
- `verifyCredentialBeforeSave` — pre-save gate; fail-closed on network failure; same stale-banner cleanup; **Save button visual loading**
- `renderSetupBannerForRequirement` — exhaustive switch dispatch by `SetupRequirement.kind`
- Form-scoped `CredentialFormUiState` — `setupRequirement` / `bannerHost` / `saveButton` / `testButton` / `isTesting` / `isSaving` / `cleanups`
- `resetCredentialFormUi` / `tearDownCredentialFormUi` — lifecycle hooks at form entry and `display()`
- `input` event handler auto-resets setup state when any field changes

## Review feedback addressed

### Round 1 (Codex + claude bot first pass)

| # | Source | Item | Commit |
|:---:|:---|:---|:---|
| 1 | Codex P1 | `verifySetup` blocks secret/anon-JWT users with missing RPC | `1a76965` |
| 2 | Codex P2 | Stale banner not cleared on successful Test/Save | `e69bfbd` |
| 3 | Claude #1 | `verifyBtn.textContent` null restore | `e69bfbd` |
| 4 | Claude #2 | `verifySetup` / `testConnection` RPC duplication | `1a76965` |
| 5 | Claude #3 | E2E private-member access (docs) | `db234b5` |
| 6 | Claude #4 | `p_schema: 'public'` intent comment | `1a76965` |
| 7 | Claude #5 | Test button visual loading | `e69bfbd` |
| 8 | Simplify sweep | `isRpcMissingResponse` status anchor (401 + PGRST202 misclassify) | `2b84e90` |
| 9 | Simplify sweep | Test cred label cleanup | `2b84e90` |

### Round 2 (claude bot 2nd pass after round 1 fixes)

| # | Source | Item | Commit |
|:---:|:---|:---|:---|
| 10 | Claude r2-#1 | Save button visual loading (symmetric with Test) | `6f81fad` |
| 11 | Claude r2-#2 | `renderRpcSetupBannerInForm` redundant return value | `6f81fad` |
| 12 | Claude r2-#3 | Verify-then-Save double probe optimization | **Deferred to #93** (last-verified-at cache) |

## Test plan

### Automated

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings unrelated to this PR)
- [x] `npm run test:run` — **693 unit tests pass** (+36 new for #91 / #92)
- [x] Build artifact deployed to live vault; plugin reload; console error-free

### Manual (live publishable-key vault)

- [x] publishable key + missing RPC → **Test connection** → inline banner appears, no "Connection OK" Notice
- [x] publishable key + missing RPC → **Save direct** → same banner + credential NOT persisted; **Save button shows 'Saving…' during probe**
- [x] **Copy SQL** → run in Supabase SQL Editor → **Verify** → banner fades, "Setup confirmed" Notice, Save enabled
- [ ] **API Key change** → banner auto-clears, Save re-enabled
- [ ] **legacy anon JWT** path → existing "Connection OK" Notice, banner never appears (Codex P1 regression coverage)
- [ ] **secret key** + missing RPC → Test/Save succeeds, banner never appears (Codex P1 regression coverage)
- [ ] **External SQL install** → Test (or Save) auto-clears stale banner (Codex P2 regression coverage)
- [ ] **Test button shows 'Testing…'** during probe (round 2 #1 symmetric counterpart)

### E2E (existing harness)

`tests/e2e/run-supabase-settings-e2e.mjs` — +2 state↔DOM integration scenarios. RPC branch logic is covered by 36 unit tests (mock-RPC scenarios deliberately not duplicated in e2e).

## Spec / plan / handbook

- Design spec: `docs/superpowers/specs/2026-05-23-supabase-rpc-setup-inline-banner-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-23-supabase-rpc-banner-implementation.md`
- Handbook §4.4 (Save-time setup gate + probeRpc invariant), §5.1 (Credential form inline RPC banner + form-scoped UI state + testButton/saveButton loading), §9.7 (verifySetup + isRpcMissingResponse status/body anchors)

## Follow-up

- #93 — feat: cache last-verified-at to skip redundant verifySetup probe on save (claude bot r2-#3 deferred optimization)

Closes #91