### PR TITLE
feat: FieldTypeMapper.isSubfolderSafe + UI parity across providers (#98)

### DIFF
--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -348,8 +348,22 @@ export class SyncOrchestrator {
       return this.settings.folderPath;
     }
 
+    // Defense-in-depth: if the column's API value is a plain object or array
+    // of objects (e.g. Airtable collaborator, SeaTable geolocation, Supabase
+    // jsonb), String(...) yields '[object Object]' garbage. The settings UI
+    // filters these types out, but a legacy config from before #98 may still
+    // reference one — fall back to flat layout instead of bucketing every
+    // record under a literal '[object Object]' folder.
+    const rawString = String(subfolderValue).trim();
+    if (rawString.startsWith('[object ')) {
+      if (this.settings.debugMode) {
+        new Notice(`Auto Note Importer: Subfolder field '${this.settings.subfolderFieldName}' returned a non-string value; using flat layout.`);
+      }
+      return this.settings.folderPath;
+    }
+
     const sanitized = sanitizeSubfolderValue(
-      String(subfolderValue).trim(),
+      rawString,
       this.settings.subfolderTreatSlashAsLiteral,
     );
     if (!sanitized) {

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -106,8 +106,22 @@ class AirtableFieldMapperImpl implements FieldTypeMapper {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }
 
+  /**
+   * Subfolder is intentionally permissive — every known Airtable type is
+   * accepted because `sanitizeSubfolderValue` normalizes path-unsafe
+   * characters. Fail-closed on unknown types preserves the same forward-
+   * compatibility guarantee as `isReadOnly`. See issue #98.
+   */
+  isSubfolderSafe(providerType: string): boolean {
+    return providerType in TYPE_TO_STANDARD;
+  }
+
   getFilenameSafeTypes(): readonly string[] {
     return FILENAME_SAFE_TYPES;
+  }
+
+  getSubfolderSafeTypes(): readonly string[] {
+    return Object.keys(TYPE_TO_STANDARD);
   }
 
   getReadOnlyTypes(): readonly string[] {

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -82,14 +82,35 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   autoNumber: 'system',
 };
 
+// Types whose API value is an object / array of objects, NOT a scalar
+// string. Even though their StandardFieldType is 'single-select' / 'multi-
+// select' / 'computed' / 'text' / 'system', String(value) produces
+// '[object Object],…' garbage for these. Manual exclusion list — must be
+// kept in sync with TYPE_TO_STANDARD when new object-shaped types arrive.
+const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
+  'singleCollaborator',
+  'multipleCollaborators',
+  'barcode',          // { type, text }
+  'button',           // { label, url }
+  'aiText',           // { state, value, … }
+  'externalSyncSource', // { id, name }
+  'lookup',           // array of any shape (depends on rolled-up field)
+]);
+
 // Subfolder accepts any known Airtable type that stringifies to a reasonable
-// folder atom. Attachment / link types are excluded because their JSON shape
-// stringifies to "[object Object],..." — picking such a column would bucket
-// every record under one literal "[object Object]" folder. Built from
-// TYPE_TO_STANDARD so adding a new known type automatically surfaces it
-// (after a manual review against this exclusion list).
+// folder atom. Excludes (1) attachment / link standard types — their JSON
+// shape stringifies to "[object Object]…" garbage — and (2) explicit
+// object-shaped types (see OBJECT_SHAPED_TYPES above) whose standard-type
+// classification doesn't capture the serialization-shape problem. Picking
+// any of these as subfolder would bucket every record under one literal
+// "[object Object]" folder.
 const SUBFOLDER_SAFE_TYPES = Object.entries(TYPE_TO_STANDARD)
-  .filter(([, std]) => std !== 'attachment' && std !== 'link' && std !== 'unknown')
+  .filter(([t, std]) =>
+    std !== 'attachment' &&
+    std !== 'link' &&
+    std !== 'unknown' &&
+    !OBJECT_SHAPED_TYPES.has(t)
+  )
   .map(([t]) => t)
   .sort() as readonly string[];
 
@@ -109,7 +130,11 @@ class AirtableFieldMapperImpl implements FieldTypeMapper {
    * we'd rather skip the push than 422 the whole batch.
    */
   isReadOnly(providerType: string): boolean {
-    if (!(providerType in TYPE_TO_STANDARD)) return true;
+    // `Object.prototype.hasOwnProperty.call` avoids the prototype-chain leak
+    // of `providerType in TYPE_TO_STANDARD` — 'toString'/'constructor'/etc.
+    // would otherwise be treated as "known" and fall through to the
+    // .includes() check, returning false. See issue #98 fix.
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, providerType)) return true;
     return (READ_ONLY_TYPES as readonly string[]).includes(providerType);
   }
 

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -82,6 +82,17 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   autoNumber: 'system',
 };
 
+// Subfolder accepts any known Airtable type that stringifies to a reasonable
+// folder atom. Attachment / link types are excluded because their JSON shape
+// stringifies to "[object Object],..." — picking such a column would bucket
+// every record under one literal "[object Object]" folder. Built from
+// TYPE_TO_STANDARD so adding a new known type automatically surfaces it
+// (after a manual review against this exclusion list).
+const SUBFOLDER_SAFE_TYPES = Object.entries(TYPE_TO_STANDARD)
+  .filter(([, std]) => std !== 'attachment' && std !== 'link' && std !== 'unknown')
+  .map(([t]) => t)
+  .sort() as readonly string[];
+
 /**
  * Stateless singleton. Instances are cheap but shared to make identity
  * checks (`===`) meaningful in tests and future caching layers.
@@ -107,13 +118,14 @@ class AirtableFieldMapperImpl implements FieldTypeMapper {
   }
 
   /**
-   * Subfolder is intentionally permissive — every known Airtable type is
-   * accepted because `sanitizeSubfolderValue` normalizes path-unsafe
-   * characters. Fail-closed on unknown types preserves the same forward-
-   * compatibility guarantee as `isReadOnly`. See issue #98.
+   * Subfolder is permissive but not unlimited — accepts any known type that
+   * stringifies to a usable folder name. Attachment / link / unknown standard
+   * types are excluded (see SUBFOLDER_SAFE_TYPES). Uses Array.includes (not
+   * `in TYPE_TO_STANDARD`) to avoid prototype-chain leak on names like
+   * 'toString' / 'constructor'. See issue #98.
    */
   isSubfolderSafe(providerType: string): boolean {
-    return providerType in TYPE_TO_STANDARD;
+    return (SUBFOLDER_SAFE_TYPES as readonly string[]).includes(providerType);
   }
 
   getFilenameSafeTypes(): readonly string[] {
@@ -121,7 +133,7 @@ class AirtableFieldMapperImpl implements FieldTypeMapper {
   }
 
   getSubfolderSafeTypes(): readonly string[] {
-    return Object.keys(TYPE_TO_STANDARD);
+    return SUBFOLDER_SAFE_TYPES;
   }
 
   getReadOnlyTypes(): readonly string[] {

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -74,6 +74,14 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   'auto-number': 'system',
 };
 
+// Excludes attachment (image / file / digital-sign) and link types — they
+// stringify to JSON / record-id garbage when used as folder names. Sorted
+// for deterministic enumeration across providers.
+const SUBFOLDER_SAFE_TYPES = Object.entries(TYPE_TO_STANDARD)
+  .filter(([, std]) => std !== 'attachment' && std !== 'link' && std !== 'unknown')
+  .map(([t]) => t)
+  .sort() as readonly string[];
+
 class SeaTableFieldMapperImpl implements FieldTypeMapper {
   mapToStandardType(providerType: string): StandardFieldType {
     return TYPE_TO_STANDARD[providerType] ?? 'unknown';
@@ -89,12 +97,11 @@ class SeaTableFieldMapperImpl implements FieldTypeMapper {
   }
 
   /**
-   * Every known SeaTable type is acceptable as a subfolder value —
-   * sanitizeSubfolderValue normalizes path-unsafe characters before use.
-   * Issue #98.
+   * Permissive but excludes attachment / link types. Uses Array.includes to
+   * avoid `in TYPE_TO_STANDARD` prototype-chain leak. Issue #98.
    */
   isSubfolderSafe(providerType: string): boolean {
-    return providerType in TYPE_TO_STANDARD;
+    return (SUBFOLDER_SAFE_TYPES as readonly string[]).includes(providerType);
   }
 
   getFilenameSafeTypes(): readonly string[] {
@@ -102,7 +109,7 @@ class SeaTableFieldMapperImpl implements FieldTypeMapper {
   }
 
   getSubfolderSafeTypes(): readonly string[] {
-    return Object.keys(TYPE_TO_STANDARD);
+    return SUBFOLDER_SAFE_TYPES;
   }
 
   getReadOnlyTypes(): readonly string[] {

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -88,8 +88,21 @@ class SeaTableFieldMapperImpl implements FieldTypeMapper {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }
 
+  /**
+   * Every known SeaTable type is acceptable as a subfolder value —
+   * sanitizeSubfolderValue normalizes path-unsafe characters before use.
+   * Issue #98.
+   */
+  isSubfolderSafe(providerType: string): boolean {
+    return providerType in TYPE_TO_STANDARD;
+  }
+
   getFilenameSafeTypes(): readonly string[] {
     return FILENAME_SAFE_TYPES;
+  }
+
+  getSubfolderSafeTypes(): readonly string[] {
+    return Object.keys(TYPE_TO_STANDARD);
   }
 
   getReadOnlyTypes(): readonly string[] {

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -74,11 +74,27 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   'auto-number': 'system',
 };
 
+// Types whose SeaTable API value is an object, NOT a scalar string.
+// collaborator → array of { name, email, … }; geolocation → { lng, lat,
+// country_region }; button → link-formula-like object. Their standard-type
+// classification doesn't capture this — explicit exclusion.
+const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
+  'collaborator',
+  'geolocation',
+  'button',
+]);
+
 // Excludes attachment (image / file / digital-sign) and link types — they
-// stringify to JSON / record-id garbage when used as folder names. Sorted
-// for deterministic enumeration across providers.
+// stringify to JSON / record-id garbage when used as folder names — and
+// explicit object-shaped types (see OBJECT_SHAPED_TYPES). Sorted for
+// deterministic enumeration across providers.
 const SUBFOLDER_SAFE_TYPES = Object.entries(TYPE_TO_STANDARD)
-  .filter(([, std]) => std !== 'attachment' && std !== 'link' && std !== 'unknown')
+  .filter(([t, std]) =>
+    std !== 'attachment' &&
+    std !== 'link' &&
+    std !== 'unknown' &&
+    !OBJECT_SHAPED_TYPES.has(t)
+  )
   .map(([t]) => t)
   .sort() as readonly string[];
 
@@ -88,7 +104,9 @@ class SeaTableFieldMapperImpl implements FieldTypeMapper {
   }
 
   isReadOnly(providerType: string): boolean {
-    if (!(providerType in TYPE_TO_STANDARD)) return true;
+    // Use Object.prototype.hasOwnProperty.call to avoid `in`-operator
+    // prototype-chain leak (toString/constructor/etc.). See issue #98 fix.
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, providerType)) return true;
     return (READ_ONLY_TYPES as readonly string[]).includes(providerType);
   }
 

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -60,13 +60,18 @@ const READ_ONLY_TYPES = Object.keys(TYPE_TO_STANDARD)
   .map(t => `${t}${READONLY_SUFFIX}`)
   .sort() as readonly string[];
 
-// Subfolder accepts every known base type AND its :readonly variant.
-// Broader than FILENAME_SAFE_TYPES because date / boolean / array etc.
-// stringify to reasonable folder names once sanitizeSubfolderValue runs.
-const SUBFOLDER_SAFE_TYPES = [
-  ...Object.keys(TYPE_TO_STANDARD),
-  ...Object.keys(TYPE_TO_STANDARD).map(t => `${t}${READONLY_SUFFIX}`),
-].sort() as readonly string[];
+// Excludes types that map to 'unknown' (e.g. 'string:byte' — bytea blobs
+// stringify to truncated near-collision garbage). Includes both base and
+// :readonly variant for each surviving type.
+const SUBFOLDER_SAFE_TYPES = (() => {
+  const safeBases = Object.entries(TYPE_TO_STANDARD)
+    .filter(([, std]) => std !== 'unknown')
+    .map(([t]) => t);
+  return [
+    ...safeBases,
+    ...safeBases.map(t => `${t}${READONLY_SUFFIX}`),
+  ].sort() as readonly string[];
+})();
 
 class SupabaseFieldMapperImpl implements FieldTypeMapper {
   mapToStandardType(providerType: string): StandardFieldType {

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -21,11 +21,13 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   'string:date': 'date',
   'string:date-time': 'date',
   'string:byte': 'unknown',
-  // PostgreSQL json/jsonb are serialized by PostgREST as a JSON string in
-  // the OpenAPI shape (type: 'string', format: 'jsonb'/'json'). Map them
-  // as 'text' so they aren't rejected by the fail-closed default — the
-  // type-aware coercion in SupabaseClient.batchUpdate handles the "" → null
-  // conversion for actual upserts.
+  // PostgreSQL json/jsonb: PostgREST's OpenAPI spec describes these as
+  // {type: 'string', format: 'jsonb'/'json'}, but the runtime VALUE is a
+  // parsed JS object/array (NOT a string) — see OBJECT_SHAPED_TYPES below.
+  // Map as 'text' here so the fail-closed default doesn't reject them at
+  // the standard-type lookup; the type-aware coercion in SupabaseClient.
+  // batchUpdate handles "" → null for upserts; subfolder dropdown filters
+  // them out via OBJECT_SHAPED_TYPES because String(value) → '[object …]'.
   'string:jsonb': 'text',
   'string:json': 'text',
   'integer': 'number',

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -60,12 +60,23 @@ const READ_ONLY_TYPES = Object.keys(TYPE_TO_STANDARD)
   .map(t => `${t}${READONLY_SUFFIX}`)
   .sort() as readonly string[];
 
+// PostgREST types whose runtime value is a JSON object / array, not a
+// scalar string. Object / jsonb / json columns stringify to '[object
+// Object]' or unbounded JSON, neither suitable as a folder name.
+const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
+  'object',          // PostgREST 'object' type (jsonb composite, etc.)
+  'array:object',    // jsonb[] / array of records
+  'string:json',     // explicit json format
+  'string:jsonb',    // explicit jsonb format
+]);
+
 // Excludes types that map to 'unknown' (e.g. 'string:byte' — bytea blobs
-// stringify to truncated near-collision garbage). Includes both base and
+// stringify to truncated near-collision garbage) AND object-shaped types
+// whose runtime value isn't a usable folder atom. Includes both base and
 // :readonly variant for each surviving type.
 const SUBFOLDER_SAFE_TYPES = (() => {
   const safeBases = Object.entries(TYPE_TO_STANDARD)
-    .filter(([, std]) => std !== 'unknown')
+    .filter(([t, std]) => std !== 'unknown' && !OBJECT_SHAPED_TYPES.has(t))
     .map(([t]) => t);
   return [
     ...safeBases,

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -60,6 +60,14 @@ const READ_ONLY_TYPES = Object.keys(TYPE_TO_STANDARD)
   .map(t => `${t}${READONLY_SUFFIX}`)
   .sort() as readonly string[];
 
+// Subfolder accepts every known base type AND its :readonly variant.
+// Broader than FILENAME_SAFE_TYPES because date / boolean / array etc.
+// stringify to reasonable folder names once sanitizeSubfolderValue runs.
+const SUBFOLDER_SAFE_TYPES = [
+  ...Object.keys(TYPE_TO_STANDARD),
+  ...Object.keys(TYPE_TO_STANDARD).map(t => `${t}${READONLY_SUFFIX}`),
+].sort() as readonly string[];
+
 class SupabaseFieldMapperImpl implements FieldTypeMapper {
   mapToStandardType(providerType: string): StandardFieldType {
     const base = providerType.endsWith(READONLY_SUFFIX)
@@ -77,8 +85,20 @@ class SupabaseFieldMapperImpl implements FieldTypeMapper {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }
 
+  /**
+   * Subfolder is permissive: every type in TYPE_TO_STANDARD (and its
+   * :readonly variant) passes. Issue #98.
+   */
+  isSubfolderSafe(providerType: string): boolean {
+    return (SUBFOLDER_SAFE_TYPES as readonly string[]).includes(providerType);
+  }
+
   getFilenameSafeTypes(): readonly string[] {
     return FILENAME_SAFE_TYPES;
+  }
+
+  getSubfolderSafeTypes(): readonly string[] {
+    return SUBFOLDER_SAFE_TYPES;
   }
 
   getReadOnlyTypes(): readonly string[] {

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -93,7 +93,14 @@ class SupabaseFieldMapperImpl implements FieldTypeMapper {
   }
 
   isReadOnly(providerType: string): boolean {
-    if (!(providerType.replace(/:readonly$/, '') in TYPE_TO_STANDARD)) return true;
+    // Strip optional :readonly suffix then check base via hasOwnProperty.call
+    // (not `in`) to avoid prototype-chain leak — 'toString'/'constructor' etc.
+    // would otherwise pass the `in` check and return false (writable),
+    // breaking the fail-closed contract. Matches Airtable + SeaTable. #98.
+    const base = providerType.endsWith(READONLY_SUFFIX)
+      ? providerType.slice(0, -READONLY_SUFFIX.length)
+      : providerType;
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, base)) return true;
     return providerType.endsWith(READONLY_SUFFIX);
   }
 

--- a/src/types/field-types.types.ts
+++ b/src/types/field-types.types.ts
@@ -57,16 +57,33 @@ export interface FieldTypeMapper {
   isReadOnly(providerType: string): boolean;
 
   /**
-   * Returns true if the field type is usable as a filename or subfolder value.
-   * Used by settings-tab to filter the filename/subfolder field dropdown.
+   * Returns true if the field type is usable as a filename value.
+   * Stricter than `isSubfolderSafe` — only types that stringify to OS-safe
+   * filename atoms (no separators, stable text-like output). Used by
+   * settings-tab to filter the filename field dropdown.
    */
   isFilenameSafe(providerType: string): boolean;
+
+  /**
+   * Returns true if the field type is usable as a subfolder grouping key.
+   * Broader than `isFilenameSafe` — every type whose stringified value is a
+   * reasonable folder name passes. Subfolder values flow through
+   * `sanitizeSubfolderValue` which normalizes path-unsafe characters, so
+   * date / formula / multi-select / etc. are all acceptable. Issue #98.
+   */
+  isSubfolderSafe(providerType: string): boolean;
 
   /**
    * Returns all known provider-specific types that pass `isFilenameSafe`.
    * Enables UIs to enumerate the whitelist without guessing.
    */
   getFilenameSafeTypes(): readonly string[];
+
+  /**
+   * Returns all known provider-specific types that pass `isSubfolderSafe`.
+   * Used by settings-tab to filter the subfolder field dropdown.
+   */
+  getSubfolderSafeTypes(): readonly string[];
 
   /**
    * Returns all known provider-specific types that pass `isReadOnly`.

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1044,15 +1044,26 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
     // Subfolder accepts the broader `isSubfolderSafe` set (date / formula /
     // multi-select / etc.) since sanitizeSubfolderValue normalizes path-unsafe
-    // characters. Filename remains stricter (OS filename rules). Issue #98.
+    // characters. Excludes attachment/link/unknown types whose stringified
+    // shape is garbage. Filename remains stricter (OS filename rules). #98.
     const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
     const subfolderCandidates = (selectedTable?.columns ?? []).filter(c => subfolderSafeTypes.has(c.type));
+    const staleSubfolderValue =
+      config.subfolderFieldName &&
+      !subfolderCandidates.some(c => c.name === config.subfolderFieldName)
+        ? config.subfolderFieldName
+        : null;
     new Setting(containerEl)
       .setName('Subfolder field (optional)')
       .setDesc('Column used for subfolder organization. Leave empty for a flat layout.')
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- No subfolder column --');
         for (const c of subfolderCandidates) dropdown.addOption(c.name, c.name);
+        // Stale value surface: stored selection no longer matches any column —
+        // expose explicitly so the user sees what they have.
+        if (staleSubfolderValue) {
+          dropdown.addOption(staleSubfolderValue, `${staleSubfolderValue} (unsupported / hidden)`);
+        }
         dropdown.setValue(config.subfolderFieldName);
         dropdown.setDisabled(!selectedTable);
         dropdown.onChange(async (value) => {
@@ -1607,15 +1618,24 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       });
 
     // Subfolder filter: broader than filename (issue #98). Excludes
-    // unknown-to-mapper types fail-closed.
+    // unknown-to-mapper types fail-closed (e.g. bytea / unrecognized
+    // PostgREST formats).
     const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
     const subfolderCandidates = columns.filter(c => subfolderSafeTypes.has(c.providerType));
+    const staleSubfolderValue =
+      config.subfolderFieldName &&
+      !subfolderCandidates.some(c => c.name === config.subfolderFieldName)
+        ? config.subfolderFieldName
+        : null;
     new Setting(containerEl)
       .setName('Subfolder field (optional)')
       .setDesc('Column used for subfolder organization. Leave empty for flat layout.')
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- No subfolder column --');
         for (const c of subfolderCandidates) dropdown.addOption(c.name, c.name);
+        if (staleSubfolderValue) {
+          dropdown.addOption(staleSubfolderValue, `${staleSubfolderValue} (unsupported / hidden)`);
+        }
         dropdown.setValue(config.subfolderFieldName);
         dropdown.setDisabled(columns.length === 0);
         dropdown.onChange(async value => {
@@ -1860,16 +1880,41 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             config.tableId
           );
 
-          const supportedFields = filterMode === 'filename'
-            ? fields.filter(field => mapper.isFilenameSafe(field.type))
-            : fields.filter(field => mapper.isSubfolderSafe(field.type));
+          let supportedFields;
+          switch (filterMode) {
+            case 'filename':
+              supportedFields = fields.filter(field => mapper.isFilenameSafe(field.type));
+              break;
+            case 'subfolder':
+              supportedFields = fields.filter(field => mapper.isSubfolderSafe(field.type));
+              break;
+            default: {
+              // Exhaustiveness guard — future-proofs against silent fallthrough
+              // if `filterMode`'s union grows.
+              const _exhaustive: never = filterMode;
+              void _exhaustive;
+              supportedFields = fields;
+            }
+          }
           const unsupportedCount = fields.length - supportedFields.length;
 
           for (const field of supportedFields) {
             dropdown.addOption(field.name, `${field.name} (${field.type})`);
           }
 
+          // Stale value surface: if the stored field isn't in the visible
+          // options (e.g. column was renamed, type became unrecognized after
+          // a plugin downgrade), expose it as a synthetic '(unsupported /
+          // hidden)' entry. Otherwise dropdown.setValue silently no-ops on
+          // missing options and the stored config drifts from UI state.
+          if (currentValue && !supportedFields.some(f => f.name === currentValue)) {
+            dropdown.addOption(currentValue, `${currentValue} (unsupported / hidden)`);
+          }
+
           if (unsupportedCount > 0) {
+            // 'unsupported' = wrong type for the chosen role (filename rules
+            // strict, subfolder skips attachment/link/unknown). Same label for
+            // both modes is acceptable since both modes filter for a reason.
             dropdown.addOption("", `--- ${unsupportedCount} unsupported field${unsupportedCount > 1 ? 's' : ''} hidden ---`);
           }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1042,16 +1042,17 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         });
       });
 
-    // Subfolder allows every column type intentionally — date / formula /
-    // single-select are all reasonable subfolder grouping keys, and we
-    // sanitize the value before using it as a path. Filename is filtered
-    // to filename-safe types because OS filename rules are stricter.
+    // Subfolder accepts the broader `isSubfolderSafe` set (date / formula /
+    // multi-select / etc.) since sanitizeSubfolderValue normalizes path-unsafe
+    // characters. Filename remains stricter (OS filename rules). Issue #98.
+    const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
+    const subfolderCandidates = (selectedTable?.columns ?? []).filter(c => subfolderSafeTypes.has(c.type));
     new Setting(containerEl)
       .setName('Subfolder field (optional)')
       .setDesc('Column used for subfolder organization. Leave empty for a flat layout.')
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- No subfolder column --');
-        for (const c of selectedTable?.columns ?? []) dropdown.addOption(c.name, c.name);
+        for (const c of subfolderCandidates) dropdown.addOption(c.name, c.name);
         dropdown.setValue(config.subfolderFieldName);
         dropdown.setDisabled(!selectedTable);
         dropdown.onChange(async (value) => {
@@ -1605,12 +1606,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         });
       });
 
+    // Subfolder filter: broader than filename (issue #98). Excludes
+    // unknown-to-mapper types fail-closed.
+    const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
+    const subfolderCandidates = columns.filter(c => subfolderSafeTypes.has(c.providerType));
     new Setting(containerEl)
       .setName('Subfolder field (optional)')
       .setDesc('Column used for subfolder organization. Leave empty for flat layout.')
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- No subfolder column --');
-        for (const c of columns) dropdown.addOption(c.name, c.name);
+        for (const c of subfolderCandidates) dropdown.addOption(c.name, c.name);
         dropdown.setValue(config.subfolderFieldName);
         dropdown.setDisabled(columns.length === 0);
         dropdown.onChange(async value => {
@@ -1813,10 +1818,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
 
   private renderFieldSelectors(containerEl: HTMLElement, config: ConfigEntry, credential: AirtableCredential): void {
     this.renderFieldDropdown(containerEl, "Filename field", "Select the field to use for the note's filename.", "-- Select field --",
-      config.filenameFieldName, (value) => { config.filenameFieldName = value; }, config, credential);
+      config.filenameFieldName, (value) => { config.filenameFieldName = value; }, config, credential, 'filename');
 
     this.renderFieldDropdown(containerEl, "Subfolder field", "Select the field to use for subfolder organization.", "-- No subfolder --",
-      config.subfolderFieldName, (value) => { config.subfolderFieldName = value; }, config, credential);
+      config.subfolderFieldName, (value) => { config.subfolderFieldName = value; }, config, credential, 'subfolder');
 
     this.renderSubfolderSlashToggle(containerEl, config);
   }
@@ -1829,7 +1834,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     currentValue: string,
     onSelect: (value: string) => void,
     config: ConfigEntry,
-    credential: AirtableCredential
+    credential: AirtableCredential,
+    // Filter policy: 'filename' uses isFilenameSafe (strict — OS filename
+    // rules); 'subfolder' uses isSubfolderSafe (broader — sanitize handles
+    // path-unsafe chars). Both fail-closed on unknown types. Issue #98.
+    filterMode: 'filename' | 'subfolder'
   ): void {
     if (!hasFieldTypeMapper(credential.type)) {
       new Setting(containerEl)
@@ -1851,7 +1860,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             config.tableId
           );
 
-          const supportedFields = fields.filter(field => mapper.isFilenameSafe(field.type));
+          const supportedFields = filterMode === 'filename'
+            ? fields.filter(field => mapper.isFilenameSafe(field.type))
+            : fields.filter(field => mapper.isSubfolderSafe(field.type));
           const unsupportedCount = fields.length - supportedFields.length;
 
           for (const field of supportedFields) {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1028,12 +1028,24 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const safeTypes = new Set(mapper.getFilenameSafeTypes());
     const filenameCandidates = (selectedTable?.columns ?? []).filter(c => safeTypes.has(c.type));
     const safeTypesList = mapper.getFilenameSafeTypes().join(', ') || 'text';
+    // Stale-value surface: symmetric with the subfolder dropdown — exposes a
+    // stored filenameFieldName that no longer matches any candidate so the
+    // user sees what they have rather than a silent empty selection. Skip
+    // when columns haven't loaded yet (cold-load flicker guard).
+    const staleFilenameValue =
+      selectedTable && config.filenameFieldName &&
+      !filenameCandidates.some(c => c.name === config.filenameFieldName)
+        ? config.filenameFieldName
+        : null;
     new Setting(containerEl)
       .setName('Filename field')
       .setDesc(`Column whose value becomes the note filename. Filtered to: ${safeTypesList}.`)
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- Select filename column --');
         for (const c of filenameCandidates) dropdown.addOption(c.name, c.name);
+        if (staleFilenameValue) {
+          dropdown.addOption(staleFilenameValue, `${staleFilenameValue} (unsupported / hidden)`);
+        }
         dropdown.setValue(config.filenameFieldName);
         dropdown.setDisabled(!selectedTable);
         dropdown.onChange(async (value) => {
@@ -1048,8 +1060,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // shape is garbage. Filename remains stricter (OS filename rules). #98.
     const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
     const subfolderCandidates = (selectedTable?.columns ?? []).filter(c => subfolderSafeTypes.has(c.type));
+    // Skip stale-value surface when columns haven't loaded (cold-load flicker
+    // guard) — wait until selectedTable resolves before judging "stale".
     const staleSubfolderValue =
-      config.subfolderFieldName &&
+      selectedTable && config.subfolderFieldName &&
       !subfolderCandidates.some(c => c.name === config.subfolderFieldName)
         ? config.subfolderFieldName
         : null;
@@ -1612,6 +1626,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const safeTypes = new Set(mapper.getFilenameSafeTypes());
     const filenameCandidates = columns.filter(c => safeTypes.has(c.providerType));
     const safeTypesList = mapper.getFilenameSafeTypes().join(', ');
+    // Stale-value surface — only when columns have actually loaded.
+    const staleFilenameValue =
+      columns.length > 0 && config.filenameFieldName &&
+      !filenameCandidates.some(c => c.name === config.filenameFieldName)
+        ? config.filenameFieldName
+        : null;
 
     new Setting(containerEl)
       .setName('Filename field')
@@ -1619,6 +1639,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       .addDropdown(dropdown => {
         dropdown.addOption('', '-- Select filename column --');
         for (const c of filenameCandidates) dropdown.addOption(c.name, c.name);
+        if (staleFilenameValue) {
+          dropdown.addOption(staleFilenameValue, `${staleFilenameValue} (unsupported / hidden)`);
+        }
         dropdown.setValue(config.filenameFieldName);
         dropdown.setDisabled(columns.length === 0);
         dropdown.onChange(async value => {
@@ -1633,7 +1656,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     const subfolderSafeTypes = new Set(mapper.getSubfolderSafeTypes());
     const subfolderCandidates = columns.filter(c => subfolderSafeTypes.has(c.providerType));
     const staleSubfolderValue =
-      config.subfolderFieldName &&
+      columns.length > 0 && config.subfolderFieldName &&
       !subfolderCandidates.some(c => c.name === config.subfolderFieldName)
         ? config.subfolderFieldName
         : null;
@@ -1878,6 +1901,10 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     }
     const mapper = getFieldTypeMapper(credential.type);
 
+    // Capture renderGeneration so a subsequent display() invocation can
+    // invalidate this still-resolving async callback. Same guard SeaTable
+    // and Supabase use for their async metadata fetches.
+    const gen = this.renderGeneration;
     new Setting(containerEl)
       .setName(name)
       .setDesc(desc)
@@ -1889,8 +1916,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             config.baseId,
             config.tableId
           );
+          if (this.renderGeneration !== gen) return;
 
-          let supportedFields;
+          let supportedFields: typeof fields;
           switch (filterMode) {
             case 'filename':
               supportedFields = fields.filter(field => mapper.isFilenameSafe(field.type));
@@ -1899,35 +1927,40 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               supportedFields = fields.filter(field => mapper.isSubfolderSafe(field.type));
               break;
             default: {
-              // Exhaustiveness guard — future-proofs against silent fallthrough
-              // if `filterMode`'s union grows.
+              // Fail-closed exhaustiveness guard. The `never` assertion is a
+              // compile-time signal; the runtime fallback empties the option
+              // set so a future filterMode union extension can't silently
+              // surface attachment/link types.
               const _exhaustive: never = filterMode;
               void _exhaustive;
-              supportedFields = fields;
+              supportedFields = [];
             }
           }
-          const unsupportedCount = fields.length - supportedFields.length;
+          // Stale-value detection: the stored field isn't visible in the
+          // filtered set (renamed, type became unrecognized, etc.). We
+          // surface it as a synthetic '(unsupported / hidden)' entry AND
+          // exclude it from the "N hidden" count below — otherwise the
+          // single stale field would be both visible inline AND counted
+          // in the trailing banner ("1 hidden") which is contradictory.
+          const isStale = currentValue && !supportedFields.some(f => f.name === currentValue);
+          const fieldInCurrentBatch = currentValue && fields.some(f => f.name === currentValue);
+          const unsupportedCount =
+            fields.length - supportedFields.length - (isStale && fieldInCurrentBatch ? 1 : 0);
 
           for (const field of supportedFields) {
             dropdown.addOption(field.name, `${field.name} (${field.type})`);
           }
 
-          // Stale value surface: if the stored field isn't in the visible
-          // options (e.g. column was renamed, type became unrecognized after
-          // a plugin downgrade), expose it as a synthetic '(unsupported /
-          // hidden)' entry. Otherwise dropdown.setValue silently no-ops on
-          // missing options and the stored config drifts from UI state.
-          if (currentValue && !supportedFields.some(f => f.name === currentValue)) {
+          if (isStale) {
             dropdown.addOption(currentValue, `${currentValue} (unsupported / hidden)`);
           }
 
           if (unsupportedCount > 0) {
-            // Mode-specific wording: filename filter rejects on type-fit
-            // ('unsupported'); subfolder filter only rejects unknown /
-            // non-stringifiable types ('unrecognized') which usually means
-            // the plugin's mapper doesn't know the type yet.
-            const label = filterMode === 'filename' ? 'unsupported' : 'unrecognized';
-            dropdown.addOption("", `--- ${unsupportedCount} ${label} field${unsupportedCount > 1 ? 's' : ''} hidden ---`);
+            // 'excluded' covers both reasons: filename rules are stricter
+            // than what stringifies, subfolder rules drop attachment/link
+            // and object-shaped types. 'unrecognized' was misleading
+            // because attachment columns ARE recognized — just excluded.
+            dropdown.addOption("", `--- ${unsupportedCount} excluded field${unsupportedCount > 1 ? 's' : ''} hidden ---`);
           }
 
           dropdown.setValue(currentValue);

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1931,6 +1931,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               // compile-time signal; the runtime fallback empties the option
               // set so a future filterMode union extension can't silently
               // surface attachment/link types.
+              // (Idiomatic `satisfies never` requires TS 4.9+; this repo
+              // pins TS 4.7.4, so the `const _exhaustive: never = ...; void
+              // _exhaustive` pair is used instead.)
               const _exhaustive: never = filterMode;
               void _exhaustive;
               supportedFields = [];

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1141,6 +1141,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     config: ConfigEntry,
     credential: SupabaseCredential,
   ): Promise<void> {
+    // Symmetric with SeaTable's renderSeaTableConnection — bail early if the
+    // mapper isn't registered so the dropdown render path can use
+    // getFieldTypeMapper safely below.
+    if (!hasFieldTypeMapper(credential.type)) {
+      new Setting(containerEl)
+        .setName('Field type mapper missing')
+        .setDesc(`No field type mapper registered for ${credential.type}.`);
+      return;
+    }
+
     // Read defaults at render time; do NOT persist 'public' as a side effect of
     // rendering. The schema input's onChange handler is the only place that
     // writes baseId — opening the settings tab is read-only.
@@ -1912,10 +1922,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           }
 
           if (unsupportedCount > 0) {
-            // 'unsupported' = wrong type for the chosen role (filename rules
-            // strict, subfolder skips attachment/link/unknown). Same label for
-            // both modes is acceptable since both modes filter for a reason.
-            dropdown.addOption("", `--- ${unsupportedCount} unsupported field${unsupportedCount > 1 ? 's' : ''} hidden ---`);
+            // Mode-specific wording: filename filter rejects on type-fit
+            // ('unsupported'); subfolder filter only rejects unknown /
+            // non-stringifiable types ('unrecognized') which usually means
+            // the plugin's mapper doesn't know the type yet.
+            const label = filterMode === 'filename' ? 'unsupported' : 'unrecognized';
+            dropdown.addOption("", `--- ${unsupportedCount} ${label} field${unsupportedCount > 1 ? 's' : ''} hidden ---`);
           }
 
           dropdown.setValue(currentValue);

--- a/tests/__mocks__/database-client.mock.ts
+++ b/tests/__mocks__/database-client.mock.ts
@@ -16,11 +16,15 @@ export type MockDatabaseProvider = {
   reconfigure: ReturnType<typeof vi.fn>;
 };
 
+// Mirror the real mapper contract: fail-closed by default. Tests that need
+// permissive behavior should construct a custom mapper instead of relying
+// on a too-permissive NOOP. This prevents 'subfolder picks attachment' style
+// bugs from sneaking past tests that use this mock.
 const NOOP_MAPPER: FieldTypeMapper = {
   mapToStandardType: () => 'unknown',
-  isReadOnly: () => false,
-  isFilenameSafe: () => true,
-  isSubfolderSafe: () => true,
+  isReadOnly: () => true,      // unknown → read-only (matches production fail-closed)
+  isFilenameSafe: () => false, // unknown → not filename-safe
+  isSubfolderSafe: () => false,// unknown → not subfolder-safe
   getFilenameSafeTypes: () => [],
   getSubfolderSafeTypes: () => [],
   getReadOnlyTypes: () => [],

--- a/tests/__mocks__/database-client.mock.ts
+++ b/tests/__mocks__/database-client.mock.ts
@@ -20,7 +20,9 @@ const NOOP_MAPPER: FieldTypeMapper = {
   mapToStandardType: () => 'unknown',
   isReadOnly: () => false,
   isFilenameSafe: () => true,
+  isSubfolderSafe: () => true,
   getFilenameSafeTypes: () => [],
+  getSubfolderSafeTypes: () => [],
   getReadOnlyTypes: () => [],
 };
 

--- a/tests/core/sync-orchestrator.test.ts
+++ b/tests/core/sync-orchestrator.test.ts
@@ -170,6 +170,39 @@ describe('SyncOrchestrator', () => {
       expect(mockApp.vault.create).toHaveBeenCalledWith('Sync/AC-DC/Note.md', expect.any(String));
     });
 
+    // Issue #98 deep-fix: object-shaped subfolder values must not produce
+    // garbage folder names at runtime. If the resolved value stringifies to
+    // '[object …]' (i.e. it's a non-array object that the column type didn't
+    // pre-stringify), fall back to settings.folderPath. UI-only filter is
+    // not sufficient — legacy configs may still hold the field name.
+    it('falls back to folderPath when subfolder value is a plain object (defense-in-depth)', async () => {
+      settings = createSettings({ subfolderFieldName: 'Category' });
+      orchestrator.updateSettings(settings);
+      mockProvider.fetchNotes.mockResolvedValue([
+        { id: 'rec1', primaryField: 'rec1', fields: { title: 'Note', Category: { id: 'usr1', email: 'a@b.c' } } },
+      ]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+      await orchestrator.processSyncRequest('pull', 'all');
+
+      expect(mockApp.vault.create).toHaveBeenCalledWith('Sync/Note.md', expect.any(String));
+    });
+
+    it('falls back to folderPath when subfolder value is an array of objects', async () => {
+      settings = createSettings({ subfolderFieldName: 'Owners' });
+      orchestrator.updateSettings(settings);
+      mockProvider.fetchNotes.mockResolvedValue([
+        { id: 'rec1', primaryField: 'rec1', fields: { title: 'Note', Owners: [{ id: 'u1' }, { id: 'u2' }] } },
+      ]);
+      mockApp.vault.adapter.exists.mockResolvedValue(true);
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+      await orchestrator.processSyncRequest('pull', 'all');
+
+      expect(mockApp.vault.create).toHaveBeenCalledWith('Sync/Note.md', expect.any(String));
+    });
+
     // Regression: bare '..' / '.' in literal mode must NOT escape settings.folderPath
     it('does not escape folderPath when subfolder value is bare ".." in literal mode', async () => {
       settings = createSettings({

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -114,6 +114,59 @@ describe('airtableFieldMapper', () => {
     });
   });
 
+  describe('isSubfolderSafe', () => {
+    // Issue #98: subfolder allows every known type intentionally — the result
+    // passes through sanitizeSubfolderValue which handles any stringifiable
+    // input. Filename rules are stricter (OS filename constraints).
+    it('should return true for ALL known types (text / number / date / select / formula / attachment / link)', () => {
+      const allKnown = [
+        'singleLineText', 'multilineText', 'richText', 'email', 'phoneNumber', 'url', 'barcode',
+        'number', 'currency', 'percent', 'rating', 'duration',
+        'date', 'dateTime',
+        'checkbox',
+        'singleSelect', 'multipleSelects', 'multipleCollaborators', 'singleCollaborator',
+        'multipleAttachments',
+        'multipleRecordLinks',
+        'formula', 'rollup', 'count', 'lookup', 'externalSyncSource', 'aiText', 'button',
+        'createdTime', 'lastModifiedTime', 'createdBy', 'lastModifiedBy', 'autoNumber',
+      ];
+      for (const t of allKnown) {
+        expect(airtableFieldMapper.isSubfolderSafe(t)).toBe(true);
+      }
+    });
+
+    it('should return false for unknown types (fail-closed)', () => {
+      expect(airtableFieldMapper.isSubfolderSafe('bogusType')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('someNewAirtableType')).toBe(false);
+    });
+
+    it('should return a superset of isFilenameSafe (every filename-safe type is also subfolder-safe)', () => {
+      for (const t of airtableFieldMapper.getFilenameSafeTypes()) {
+        expect(airtableFieldMapper.isSubfolderSafe(t)).toBe(true);
+      }
+    });
+  });
+
+  describe('getSubfolderSafeTypes', () => {
+    it('should include every known type', () => {
+      const types = airtableFieldMapper.getSubfolderSafeTypes();
+      // sanity: includes broader set than filename-safe
+      expect(types).toContain('date');
+      expect(types).toContain('multipleSelects');
+      expect(types).toContain('checkbox');
+      // includes filename-safe types too
+      expect(types).toContain('singleLineText');
+      expect(types).toContain('formula');
+    });
+
+    it('should be a superset of getFilenameSafeTypes', () => {
+      const subset = new Set(airtableFieldMapper.getFilenameSafeTypes());
+      const superset = new Set(airtableFieldMapper.getSubfolderSafeTypes());
+      for (const t of subset) expect(superset.has(t)).toBe(true);
+    });
+  });
+
   describe('isFilenameSafe', () => {
     it('should return true for types producing safe filename output', () => {
       expect(airtableFieldMapper.isFilenameSafe('singleLineText')).toBe(true);

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -112,6 +112,14 @@ describe('airtableFieldMapper', () => {
       expect(airtableFieldMapper.isReadOnly('')).toBe(true);
       expect(airtableFieldMapper.isReadOnly('someNewAirtableType')).toBe(true);
     });
+
+    // Regression guard: same prototype-chain leak class as isSubfolderSafe.
+    // Must use Object.prototype.hasOwnProperty.call (not `in`).
+    it('should fail closed on prototype-chain names (no in-operator leak)', () => {
+      for (const t of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__', 'isPrototypeOf']) {
+        expect(airtableFieldMapper.isReadOnly(t)).toBe(true);
+      }
+    });
   });
 
   describe('isSubfolderSafe', () => {
@@ -120,13 +128,15 @@ describe('airtableFieldMapper', () => {
     // Attachment / link types are excluded because their stringified shape is
     // [object Object] / record-id JSON — produces garbage folder names.
     it('should return true for stringifiable known types (text / number / date / select / formula / system)', () => {
+      // Excludes OBJECT_SHAPED_TYPES (collaborator / barcode / button / aiText /
+      // externalSyncSource / lookup) — covered by a separate test below.
       const stringifiable = [
-        'singleLineText', 'multilineText', 'richText', 'email', 'phoneNumber', 'url', 'barcode',
+        'singleLineText', 'multilineText', 'richText', 'email', 'phoneNumber', 'url',
         'number', 'currency', 'percent', 'rating', 'duration',
         'date', 'dateTime',
         'checkbox',
-        'singleSelect', 'multipleSelects', 'multipleCollaborators', 'singleCollaborator',
-        'formula', 'rollup', 'count', 'lookup', 'externalSyncSource', 'aiText', 'button',
+        'singleSelect', 'multipleSelects',
+        'formula', 'rollup', 'count',
         'createdTime', 'lastModifiedTime', 'createdBy', 'lastModifiedBy', 'autoNumber',
       ];
       for (const t of stringifiable) {
@@ -137,6 +147,20 @@ describe('airtableFieldMapper', () => {
     it('should return false for attachment and link types (no sensible string)', () => {
       expect(airtableFieldMapper.isSubfolderSafe('multipleAttachments')).toBe(false);
       expect(airtableFieldMapper.isSubfolderSafe('multipleRecordLinks')).toBe(false);
+    });
+
+    // Issue #98 deep-fix: types whose API value shape is an object/array of
+    // objects, NOT a stringifiable scalar. The standard-type filter
+    // (attachment/link/unknown) misses these — explicit OBJECT_SHAPED_TYPES
+    // exclusion needed.
+    it('should return false for object-shaped types (collaborator / barcode / button / aiText / externalSyncSource / lookup)', () => {
+      expect(airtableFieldMapper.isSubfolderSafe('singleCollaborator')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('multipleCollaborators')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('barcode')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('button')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('aiText')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('externalSyncSource')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('lookup')).toBe(false);
     });
 
     it('should return false for unknown types (fail-closed)', () => {
@@ -186,6 +210,13 @@ describe('airtableFieldMapper', () => {
       const subset = new Set(airtableFieldMapper.getFilenameSafeTypes());
       const superset = new Set(airtableFieldMapper.getSubfolderSafeTypes());
       for (const t of subset) expect(superset.has(t)).toBe(true);
+    });
+
+    // Drift guard: if TYPE_TO_STANDARD grows with an attachment-shaped or
+    // object-shaped type that isn't added to OBJECT_SHAPED_TYPES, the count
+    // here flips and the assertion fails. Forces a manual review.
+    it('should have exact expected cardinality (drift guard)', () => {
+      expect(airtableFieldMapper.getSubfolderSafeTypes()).toHaveLength(24);
     });
   });
 

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -115,30 +115,47 @@ describe('airtableFieldMapper', () => {
   });
 
   describe('isSubfolderSafe', () => {
-    // Issue #98: subfolder allows every known type intentionally — the result
-    // passes through sanitizeSubfolderValue which handles any stringifiable
-    // input. Filename rules are stricter (OS filename constraints).
-    it('should return true for ALL known types (text / number / date / select / formula / attachment / link)', () => {
-      const allKnown = [
+    // Issue #98: subfolder allows a broad set of types — sanitizeSubfolderValue
+    // handles any stringifiable input. Filename rules are stricter (OS rules).
+    // Attachment / link types are excluded because their stringified shape is
+    // [object Object] / record-id JSON — produces garbage folder names.
+    it('should return true for stringifiable known types (text / number / date / select / formula / system)', () => {
+      const stringifiable = [
         'singleLineText', 'multilineText', 'richText', 'email', 'phoneNumber', 'url', 'barcode',
         'number', 'currency', 'percent', 'rating', 'duration',
         'date', 'dateTime',
         'checkbox',
         'singleSelect', 'multipleSelects', 'multipleCollaborators', 'singleCollaborator',
-        'multipleAttachments',
-        'multipleRecordLinks',
         'formula', 'rollup', 'count', 'lookup', 'externalSyncSource', 'aiText', 'button',
         'createdTime', 'lastModifiedTime', 'createdBy', 'lastModifiedBy', 'autoNumber',
       ];
-      for (const t of allKnown) {
+      for (const t of stringifiable) {
         expect(airtableFieldMapper.isSubfolderSafe(t)).toBe(true);
       }
+    });
+
+    it('should return false for attachment and link types (no sensible string)', () => {
+      expect(airtableFieldMapper.isSubfolderSafe('multipleAttachments')).toBe(false);
+      expect(airtableFieldMapper.isSubfolderSafe('multipleRecordLinks')).toBe(false);
     });
 
     it('should return false for unknown types (fail-closed)', () => {
       expect(airtableFieldMapper.isSubfolderSafe('bogusType')).toBe(false);
       expect(airtableFieldMapper.isSubfolderSafe('')).toBe(false);
       expect(airtableFieldMapper.isSubfolderSafe('someNewAirtableType')).toBe(false);
+    });
+
+    // Regression guard: the `in` operator walks Object.prototype so a naive
+    // implementation would accept inherited method names. Must use a safe
+    // membership check (.includes on a literal array, or hasOwnProperty).
+    it('should return false for JS prototype-chain names (no in-operator leak)', () => {
+      const inheritedNames = [
+        'toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__',
+        'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString',
+      ];
+      for (const t of inheritedNames) {
+        expect(airtableFieldMapper.isSubfolderSafe(t)).toBe(false);
+      }
     });
 
     it('should return a superset of isFilenameSafe (every filename-safe type is also subfolder-safe)', () => {
@@ -149,15 +166,20 @@ describe('airtableFieldMapper', () => {
   });
 
   describe('getSubfolderSafeTypes', () => {
-    it('should include every known type', () => {
+    it('should include stringifiable known types but exclude attachment/link', () => {
       const types = airtableFieldMapper.getSubfolderSafeTypes();
-      // sanity: includes broader set than filename-safe
       expect(types).toContain('date');
       expect(types).toContain('multipleSelects');
       expect(types).toContain('checkbox');
-      // includes filename-safe types too
       expect(types).toContain('singleLineText');
       expect(types).toContain('formula');
+      expect(types).not.toContain('multipleAttachments');
+      expect(types).not.toContain('multipleRecordLinks');
+    });
+
+    it('should be sorted for stable enumeration', () => {
+      const types = airtableFieldMapper.getSubfolderSafeTypes();
+      expect([...types]).toEqual([...types].sort());
     });
 
     it('should be a superset of getFilenameSafeTypes', () => {

--- a/tests/services/provider-registry.test.ts
+++ b/tests/services/provider-registry.test.ts
@@ -156,7 +156,9 @@ describe('provider-registry', () => {
         mapToStandardType: () => 'text' as const,
         isReadOnly: () => false,
         isFilenameSafe: () => true,
+        isSubfolderSafe: () => true,
         getFilenameSafeTypes: () => [],
+        getSubfolderSafeTypes: () => [],
         getReadOnlyTypes: () => [],
       };
       registerFieldTypeMapper('notion', fake);

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -102,6 +102,46 @@ describe('seatableFieldMapper', () => {
     });
   });
 
+  describe('isSubfolderSafe', () => {
+    it('should return true for ALL known SeaTable types', () => {
+      const allKnown = [
+        'text', 'long-text', 'email', 'url', 'geolocation',
+        'number', 'duration', 'rate',
+        'date',
+        'checkbox',
+        'single-select', 'multiple-select', 'department-single-select', 'collaborator',
+        'image', 'file', 'digital-sign',
+        'link',
+        'formula', 'link-formula', 'button',
+        'ctime', 'mtime', 'creator', 'last-modifier', 'auto-number',
+      ];
+      for (const t of allKnown) {
+        expect(seatableFieldMapper.isSubfolderSafe(t)).toBe(true);
+      }
+    });
+
+    it('should return false for unknown types', () => {
+      expect(seatableFieldMapper.isSubfolderSafe('bogusType')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('')).toBe(false);
+    });
+
+    it('should be a superset of isFilenameSafe', () => {
+      for (const t of seatableFieldMapper.getFilenameSafeTypes()) {
+        expect(seatableFieldMapper.isSubfolderSafe(t)).toBe(true);
+      }
+    });
+  });
+
+  describe('getSubfolderSafeTypes', () => {
+    it('should include filename-safe types and broader (date, multi-select)', () => {
+      const types = seatableFieldMapper.getSubfolderSafeTypes();
+      expect(types).toContain('date');
+      expect(types).toContain('multiple-select');
+      expect(types).toContain('checkbox');
+      expect(types).toContain('text');
+    });
+  });
+
   describe('isFilenameSafe', () => {
     it('should return true for types producing safe filename output', () => {
       expect(seatableFieldMapper.isFilenameSafe('text')).toBe(true);

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -100,17 +100,25 @@ describe('seatableFieldMapper', () => {
       expect(seatableFieldMapper.isReadOnly('')).toBe(true);
       expect(seatableFieldMapper.isReadOnly('someNewSeaTableType')).toBe(true);
     });
+
+    it('should fail closed on prototype-chain names (no in-operator leak)', () => {
+      for (const t of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+        expect(seatableFieldMapper.isReadOnly(t)).toBe(true);
+      }
+    });
   });
 
   describe('isSubfolderSafe', () => {
     it('should return true for stringifiable known SeaTable types', () => {
+      // Excludes OBJECT_SHAPED_TYPES (collaborator / geolocation / button) —
+      // covered by a separate test below.
       const stringifiable = [
-        'text', 'long-text', 'email', 'url', 'geolocation',
+        'text', 'long-text', 'email', 'url',
         'number', 'duration', 'rate',
         'date',
         'checkbox',
-        'single-select', 'multiple-select', 'department-single-select', 'collaborator',
-        'formula', 'link-formula', 'button',
+        'single-select', 'multiple-select', 'department-single-select',
+        'formula', 'link-formula',
         'ctime', 'mtime', 'creator', 'last-modifier', 'auto-number',
       ];
       for (const t of stringifiable) {
@@ -123,6 +131,14 @@ describe('seatableFieldMapper', () => {
       expect(seatableFieldMapper.isSubfolderSafe('file')).toBe(false);
       expect(seatableFieldMapper.isSubfolderSafe('digital-sign')).toBe(false);
       expect(seatableFieldMapper.isSubfolderSafe('link')).toBe(false);
+    });
+
+    // Issue #98 deep-fix: object-shaped types whose API value is {…} or
+    // array of {…}, not a scalar. Standard-type filter misses these.
+    it('should return false for object-shaped types (collaborator / geolocation / button)', () => {
+      expect(seatableFieldMapper.isSubfolderSafe('collaborator')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('geolocation')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('button')).toBe(false);
     });
 
     it('should return false for unknown types', () => {
@@ -158,6 +174,10 @@ describe('seatableFieldMapper', () => {
     it('should be sorted for stable enumeration', () => {
       const types = seatableFieldMapper.getSubfolderSafeTypes();
       expect([...types]).toEqual([...types].sort());
+    });
+
+    it('should have exact expected cardinality (drift guard)', () => {
+      expect(seatableFieldMapper.getSubfolderSafeTypes()).toHaveLength(19);
     });
   });
 

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -103,26 +103,37 @@ describe('seatableFieldMapper', () => {
   });
 
   describe('isSubfolderSafe', () => {
-    it('should return true for ALL known SeaTable types', () => {
-      const allKnown = [
+    it('should return true for stringifiable known SeaTable types', () => {
+      const stringifiable = [
         'text', 'long-text', 'email', 'url', 'geolocation',
         'number', 'duration', 'rate',
         'date',
         'checkbox',
         'single-select', 'multiple-select', 'department-single-select', 'collaborator',
-        'image', 'file', 'digital-sign',
-        'link',
         'formula', 'link-formula', 'button',
         'ctime', 'mtime', 'creator', 'last-modifier', 'auto-number',
       ];
-      for (const t of allKnown) {
+      for (const t of stringifiable) {
         expect(seatableFieldMapper.isSubfolderSafe(t)).toBe(true);
       }
+    });
+
+    it('should return false for attachment + link types (no sensible string)', () => {
+      expect(seatableFieldMapper.isSubfolderSafe('image')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('file')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('digital-sign')).toBe(false);
+      expect(seatableFieldMapper.isSubfolderSafe('link')).toBe(false);
     });
 
     it('should return false for unknown types', () => {
       expect(seatableFieldMapper.isSubfolderSafe('bogusType')).toBe(false);
       expect(seatableFieldMapper.isSubfolderSafe('')).toBe(false);
+    });
+
+    it('should return false for JS prototype-chain names (no in-operator leak)', () => {
+      for (const t of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+        expect(seatableFieldMapper.isSubfolderSafe(t)).toBe(false);
+      }
     });
 
     it('should be a superset of isFilenameSafe', () => {
@@ -133,12 +144,20 @@ describe('seatableFieldMapper', () => {
   });
 
   describe('getSubfolderSafeTypes', () => {
-    it('should include filename-safe types and broader (date, multi-select)', () => {
+    it('should include stringifiable types but exclude attachment/link', () => {
       const types = seatableFieldMapper.getSubfolderSafeTypes();
       expect(types).toContain('date');
       expect(types).toContain('multiple-select');
       expect(types).toContain('checkbox');
       expect(types).toContain('text');
+      expect(types).not.toContain('image');
+      expect(types).not.toContain('file');
+      expect(types).not.toContain('link');
+    });
+
+    it('should be sorted for stable enumeration', () => {
+      const types = seatableFieldMapper.getSubfolderSafeTypes();
+      expect([...types]).toEqual([...types].sort());
     });
   });
 

--- a/tests/services/supabase-field-mapper.test.ts
+++ b/tests/services/supabase-field-mapper.test.ts
@@ -69,11 +69,46 @@ describe('supabaseFieldMapper.isFilenameSafe', () => {
   });
 });
 
+describe('supabaseFieldMapper.isSubfolderSafe', () => {
+  // Issue #98: subfolder accepts all known types — broader than filename.
+  it('returns true for every known base type and its :readonly variant', () => {
+    const known = [
+      'string', 'string:uuid', 'string:date', 'string:date-time',
+      'integer', 'integer:int64', 'number',
+      'boolean',
+      'object',
+      'array:string', 'array:integer', 'array:number', 'array:boolean', 'array:object',
+    ];
+    for (const t of known) {
+      expect(supabaseFieldMapper.isSubfolderSafe(t)).toBe(true);
+      expect(supabaseFieldMapper.isSubfolderSafe(`${t}:readonly`)).toBe(true);
+    }
+  });
+
+  it('returns false for unknown types', () => {
+    expect(supabaseFieldMapper.isSubfolderSafe('something-weird')).toBe(false);
+    expect(supabaseFieldMapper.isSubfolderSafe('')).toBe(false);
+  });
+
+  it('is a superset of isFilenameSafe', () => {
+    for (const t of supabaseFieldMapper.getFilenameSafeTypes()) {
+      expect(supabaseFieldMapper.isSubfolderSafe(t)).toBe(true);
+    }
+  });
+});
+
 describe('supabaseFieldMapper enumerations', () => {
   it('getFilenameSafeTypes returns sorted with no duplicates', () => {
     const list = supabaseFieldMapper.getFilenameSafeTypes();
     expect(new Set(list).size).toBe(list.length);
     expect([...list]).toEqual([...list].sort());
+  });
+
+  it('getSubfolderSafeTypes is a superset of getFilenameSafeTypes', () => {
+    const filename = new Set(supabaseFieldMapper.getFilenameSafeTypes());
+    const subfolder = new Set(supabaseFieldMapper.getSubfolderSafeTypes());
+    for (const t of filename) expect(subfolder.has(t)).toBe(true);
+    expect(subfolder.size).toBeGreaterThan(filename.size);
   });
 
   it('getReadOnlyTypes contains expected entries', () => {

--- a/tests/services/supabase-field-mapper.test.ts
+++ b/tests/services/supabase-field-mapper.test.ts
@@ -36,6 +36,18 @@ describe('supabaseFieldMapper.mapToStandardType', () => {
   });
 });
 
+describe('supabaseFieldMapper.isReadOnly prototype-chain leak guard', () => {
+  // Symmetric with Airtable/SeaTable isReadOnly hardening. The `in
+  // TYPE_TO_STANDARD` check would match 'toString'/'constructor' via
+  // Object.prototype — must use hasOwnProperty.call.
+  it('fails closed on prototype-chain names', () => {
+    for (const t of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+      expect(supabaseFieldMapper.isReadOnly(t)).toBe(true);
+      expect(supabaseFieldMapper.isReadOnly(`${t}:readonly`)).toBe(true);
+    }
+  });
+});
+
 describe('supabaseFieldMapper.isReadOnly', () => {
   it('returns true for types ending with readonly suffix', () => {
     expect(supabaseFieldMapper.isReadOnly('string:readonly')).toBe(true);

--- a/tests/services/supabase-field-mapper.test.ts
+++ b/tests/services/supabase-field-mapper.test.ts
@@ -71,13 +71,13 @@ describe('supabaseFieldMapper.isFilenameSafe', () => {
 
 describe('supabaseFieldMapper.isSubfolderSafe', () => {
   it('returns true for stringifiable known types and their :readonly variants', () => {
+    // Excludes OBJECT_SHAPED_TYPES (object / array:object / string:json /
+    // string:jsonb) — covered by a separate test below.
     const known = [
       'string', 'string:uuid', 'string:date', 'string:date-time',
-      'string:jsonb', 'string:json',
       'integer', 'integer:int64', 'number',
       'boolean',
-      'object',
-      'array:string', 'array:integer', 'array:number', 'array:boolean', 'array:object',
+      'array:string', 'array:integer', 'array:number', 'array:boolean',
     ];
     for (const t of known) {
       expect(supabaseFieldMapper.isSubfolderSafe(t)).toBe(true);
@@ -88,6 +88,16 @@ describe('supabaseFieldMapper.isSubfolderSafe', () => {
   it('returns false for string:byte (maps to unknown — would produce garbage folders)', () => {
     expect(supabaseFieldMapper.isSubfolderSafe('string:byte')).toBe(false);
     expect(supabaseFieldMapper.isSubfolderSafe('string:byte:readonly')).toBe(false);
+  });
+
+  // Issue #98 deep-fix: jsonb / object-shaped PostgREST types — their
+  // stringified form is '[object Object]' or unbounded JSON garbage. Same
+  // root cause as Airtable's collaborator types.
+  it('returns false for object-shaped types (object / array:object / string:json / string:jsonb)', () => {
+    for (const t of ['object', 'array:object', 'string:json', 'string:jsonb']) {
+      expect(supabaseFieldMapper.isSubfolderSafe(t)).toBe(false);
+      expect(supabaseFieldMapper.isSubfolderSafe(`${t}:readonly`)).toBe(false);
+    }
   });
 
   it('returns false for unknown types', () => {
@@ -114,6 +124,11 @@ describe('supabaseFieldMapper enumerations', () => {
     const subfolder = new Set(supabaseFieldMapper.getSubfolderSafeTypes());
     for (const t of filename) expect(subfolder.has(t)).toBe(true);
     expect(subfolder.size).toBeGreaterThan(filename.size);
+  });
+
+  it('getSubfolderSafeTypes has exact expected cardinality (drift guard)', () => {
+    // 15 stringifiable base types × 2 (base + :readonly variant) = 30.
+    expect(supabaseFieldMapper.getSubfolderSafeTypes()).toHaveLength(30);
   });
 
   it('getReadOnlyTypes contains expected entries', () => {

--- a/tests/services/supabase-field-mapper.test.ts
+++ b/tests/services/supabase-field-mapper.test.ts
@@ -70,10 +70,10 @@ describe('supabaseFieldMapper.isFilenameSafe', () => {
 });
 
 describe('supabaseFieldMapper.isSubfolderSafe', () => {
-  // Issue #98: subfolder accepts all known types — broader than filename.
-  it('returns true for every known base type and its :readonly variant', () => {
+  it('returns true for stringifiable known types and their :readonly variants', () => {
     const known = [
       'string', 'string:uuid', 'string:date', 'string:date-time',
+      'string:jsonb', 'string:json',
       'integer', 'integer:int64', 'number',
       'boolean',
       'object',
@@ -83,6 +83,11 @@ describe('supabaseFieldMapper.isSubfolderSafe', () => {
       expect(supabaseFieldMapper.isSubfolderSafe(t)).toBe(true);
       expect(supabaseFieldMapper.isSubfolderSafe(`${t}:readonly`)).toBe(true);
     }
+  });
+
+  it('returns false for string:byte (maps to unknown — would produce garbage folders)', () => {
+    expect(supabaseFieldMapper.isSubfolderSafe('string:byte')).toBe(false);
+    expect(supabaseFieldMapper.isSubfolderSafe('string:byte:readonly')).toBe(false);
   });
 
   it('returns false for unknown types', () => {


### PR DESCRIPTION
## Summary
- Adds `isSubfolderSafe` + `getSubfolderSafeTypes` to `FieldTypeMapper` interface — broader than `isFilenameSafe`, excludes attachment / link / unknown standard types AND explicit per-mapper `OBJECT_SHAPED_TYPES` allowlists (collaborator / geolocation / barcode / button / jsonb / etc.)
- Airtable's `renderFieldDropdown` gains a `filterMode: 'filename' | 'subfolder'` parameter so the same helper applies the right policy
- SeaTable / Supabase subfolder + filename dropdowns surface stale stored values that no longer match the filter as a synthetic `(unsupported / hidden)` option
- Runtime defense-in-depth: `determineFolderPath` falls back to flat layout if `String(value)` starts with `'[object '` (catches legacy configs pointing at object-shaped columns)
- Prototype-chain-safe membership across `isSubfolderSafe` AND `isReadOnly` (`.includes` / `hasOwnProperty.call`), exhaustive fail-closed `switch` on `filterMode`, `hasFieldTypeMapper` guard at every entry, mode-specific placeholder wording, NOOP_MAPPER fail-closed mirror, cardinality drift assertions

Closes #98.

## Background

PR #97 review surfaced that the original implementation:
1. Filtered Airtable's subfolder dropdown by the strict `isFilenameSafe` set (over-restrictive)
2. Showed every column in SeaTable / Supabase subfolder dropdowns including attachment / link types (under-restrictive)

This PR added `isSubfolderSafe` to fix both. Subsequent Codex + Claude review revealed object-shaped types whose StandardFieldType classification didn't capture their object value shape — handled in the deeper fix commits.

## Changes by layer

### Interface (`src/types/field-types.types.ts`)
- `+ isSubfolderSafe(providerType: string): boolean`
- `+ getSubfolderSafeTypes(): readonly string[]`

### Mapper implementations
Each mapper now combines two exclusion layers — StandardFieldType filter plus an explicit per-mapper `OBJECT_SHAPED_TYPES` allowlist:

| Mapper | TYPE_TO_STANDARD | Excluded (std + object-shaped) | Subfolder-safe count |
|:---|:---:|:---|:---:|
| Airtable | 33 | 2 attachment/link + 7 object-shaped (collaborator x2, barcode, button, aiText, externalSyncSource, lookup) | **24** |
| SeaTable | 26 | 4 attachment/link + 3 object-shaped (collaborator, geolocation, button) | **19** |
| Supabase | 20 base | 1 unknown (`string:byte`) + 4 object-shaped (object, array:object, string:json, string:jsonb) | **15 base × 2 :readonly = 30** |

Membership via `.includes()` (subfolder/filename) and `Object.prototype.hasOwnProperty.call` (read-only) — no `in`-operator prototype-chain leaks.

### Runtime guard (`src/core/sync-orchestrator.ts`)
`determineFolderPath()` now rejects values whose `String(...).trim()` starts with `'[object '`, falling back to `settings.folderPath`. Defense-in-depth for legacy configs that predate this PR.

### UI (`src/ui/settings-tab.ts`)
- `renderFieldDropdown` (Airtable) — `filterMode` param + exhaustive switch with fail-closed `[]` default + `renderGeneration` race guard
- SeaTable + Supabase subfolder AND filename dropdowns surface stale stored values via synthetic option (with cold-load flicker guard — wait until columns load before judging "stale")
- `unsupportedCount` no longer double-counts the inline stale value
- Hint wording: `--- N excluded fields hidden ---` (was `unsupported` / `unrecognized` per mode; "excluded" covers both reasons accurately)
- `renderSupabaseConnection` gains `hasFieldTypeMapper` guard for parity with SeaTable

### Tests (+42 new cases since PR #97)
- isSubfolderSafe object-shaped exclusion (3 providers)
- isReadOnly prototype-chain regression guard (Airtable + SeaTable)
- Cardinality drift assertions
- Runtime guard tests in sync-orchestrator (plain object + array of objects)
- NOOP_MAPPER fail-closed (mock parity with production)
- `provider-registry.test.ts` fake mapper updated

### Docs (private repo)
- Handbook §4.4 — two-layer exclusion (StandardFieldType + OBJECT_SHAPED_TYPES) + membership-check correctness
- Handbook §7.1 — Subfolder runtime guard + dot-segment guard

## Compatibility

- Existing users: previously-stored `subfolderFieldName` continues to work at sync time. If it pointed at an object-shaped column, runtime falls back to flat instead of producing garbage folders.
- Settings UI surfaces stale stored values explicitly so users can re-select.
- No interface break beyond the 3 production mappers + NOOP_MAPPER + provider-registry test fake (all updated).

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` 0 errors (3 pre-existing warnings unchanged)
- [x] `npm run test:run` 751/751 (+42 new since PR #97)
- [x] Mapper unit tests 98/98 across 3 providers (33 + 31 + 31)
- [x] Orchestrator runtime guard tests 6/6
- [x] Airtable settings e2e — subfolder-toggle 3/3 PASS (re-verified)
- [ ] SeaTable / Supabase settings e2e — pre-existing env failure (Connection card metadata not loading; not introduced by this PR)
- [ ] Manual smoke: Airtable settings → Subfolder field dropdown shows `Status` (single-select) / `DueDate` (date) / `Calculation` (formula) but NOT `Attachments` / `Owners (collaborator)` / `Photos (multipleAttachments)`
- [ ] Manual smoke: SeaTable settings → `image` / `file` / `geolocation` excluded
- [ ] Manual smoke: legacy config with subfolderFieldName='Attachments' → next sync uses flat folder instead of '[object Object]'