### PR TITLE
fix: community scorecard cleanup + hardening from review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Required by actions/attest-build-provenance to mint a signing
+      # certificate from Sigstore and publish the attestation to GitHub's
+      # attestation store.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +32,13 @@ jobs:
         run: |
           npm install
           npm run build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            styles.css
 
       - name: Create or update release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,21 @@ on:
       # bogus published releases under the sync-tag name.
       - "[0-9]*"
 
+# Split into two jobs so that npm install (which can run third-party
+# postinstall scripts) never executes in the same job as the OIDC
+# `id-token: write` permission. Build deps cannot exfiltrate the
+# attestation signing identity.
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      # Required by actions/attest-build-provenance to mint a signing
-      # certificate from Sigstore and publish the attestation to GitHub's
-      # attestation store.
-      id-token: write
-      attestations: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Don't leave GITHUB_TOKEN in .git/config where postinstall
+          # scripts could pick it up.
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -29,16 +32,51 @@ jobs:
           node-version: "20.x"
 
       - name: Build plugin
+        # --ignore-scripts blocks postinstall lifecycle hooks across the
+        # whole dep tree. esbuild and our other deps do not require them.
+        # npm ci honors the lockfile exactly (no silent drift).
         run: |
-          npm install
+          npm ci --ignore-scripts
           npm run build
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-build
+          path: |
+            main.js
+            styles.css
+          retention-days: 1
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Sigstore OIDC + attestation publishing. Scoped to this job only,
+      # which runs no npm install and no third-party code beyond the
+      # pinned attest action.
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-build
+
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        # SHA-pinned (v2.4.0). When bumping, update both SHA and comment.
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
         with:
           subject-path: |
             main.js
             styles.css
+            manifest.json
 
       - name: Create or update release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,15 @@ jobs:
           npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        # SHA-pinned (v4.6.2) for supply-chain hardening consistency
+        # with the attest step. Bump SHA together with comment.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: plugin-build
           path: |
             main.js
             styles.css
+            manifest.json
           retention-days: 1
           if-no-files-found: error
 
@@ -65,7 +68,8 @@ jobs:
           persist-credentials: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        # SHA-pinned (v4.3.0).
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: plugin-build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned (v6.0.2) — all actions pinned for supply-chain consistency.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           # Don't leave GITHUB_TOKEN in .git/config where postinstall
           # scripts could pick it up.
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        # SHA-pinned (v6.4.0).
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "20.x"
 
@@ -63,7 +65,8 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned (v6.0.2).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -247,12 +247,15 @@ This plugin emits Bases-compatible YAML frontmatter with proper data types for s
 
 What the plugin accesses and why — full transparency. Nothing is sent anywhere except the database APIs you configure; there is no telemetry.
 
-- **Vault file enumeration** (`vault.getFiles`, `vault.getMarkdownFiles`, `vault.getAllLoadedFiles`)
+- **Vault file enumeration** (`vault.getAllLoadedFiles`, `vault.getAbstractFileByPath`)
   - **Why**: find notes to sync, scope sync to your destination folder, and power folder / file autocomplete in settings.
   - **Scope**: file *paths* only. Contents are read on demand by the sync flow (see below), not during enumeration.
-- **Vault read & write** (`vault.read`, `vault.cachedRead`, `vault.modify`, `vault.create`)
-  - **Why**: import remote records into `.md` files, parse frontmatter to push edits back, and write computed values returned by formulas / rollups.
+- **Vault read & write** (`vault.read`, `vault.create`, `vault.modify`, `vault.createFolder`, `vault.adapter.exists`)
+  - **Why**: import remote records into `.md` files, parse frontmatter to push edits back, create destination subfolders, and write computed values returned by formulas / rollups.
   - **Scope**: only files inside the destination folder you configure per sync config.
+- **Vault change events** (`vault.on`, `vault.offref`)
+  - **Why**: detect file edits when "Watch for file changes" is enabled, so edits can be queued for push.
+  - **Scope**: events on all files; the handler filters to your configured destination folder before queuing.
 - **Clipboard write** (`navigator.clipboard.writeText`)
   - **Why**: the Supabase credential form's "Copy SQL" button copies a one-time `SECURITY DEFINER` setup function for you to paste into the Supabase SQL Editor. A `Notice` fallback is shown when clipboard access is denied.
   - **Scope**: clipboard is only ever *written* (never read), and only when you click that specific button.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,23 @@ This plugin emits Bases-compatible YAML frontmatter with proper data types for s
 4. **Compute** formulas / rollups / link-formulas server-side
 5. **Pull** computed values back into Obsidian
 
+## 🔐 Permissions & Disclosures
+
+What the plugin accesses and why — full transparency. Nothing is sent anywhere except the database APIs you configure; there is no telemetry.
+
+- **Vault file enumeration** (`vault.getFiles`, `vault.getMarkdownFiles`, `vault.getAllLoadedFiles`)
+  - **Why**: find notes to sync, scope sync to your destination folder, and power folder / file autocomplete in settings.
+  - **Scope**: file *paths* only. Contents are read on demand by the sync flow (see below), not during enumeration.
+- **Vault read & write** (`vault.read`, `vault.cachedRead`, `vault.modify`, `vault.create`)
+  - **Why**: import remote records into `.md` files, parse frontmatter to push edits back, and write computed values returned by formulas / rollups.
+  - **Scope**: only files inside the destination folder you configure per sync config.
+- **Clipboard write** (`navigator.clipboard.writeText`)
+  - **Why**: the Supabase credential form's "Copy SQL" button copies a one-time `SECURITY DEFINER` setup function for you to paste into the Supabase SQL Editor. A `Notice` fallback is shown when clipboard access is denied.
+  - **Scope**: clipboard is only ever *written* (never read), and only when you click that specific button.
+- **Network requests** (Obsidian `requestUrl`)
+  - **Why**: REST calls to Airtable / SeaTable / Supabase only, scoped to credentials you register.
+  - **Scope**: no third-party services, no analytics endpoints, no auto-update checks.
+
 ## 🛠️ Troubleshooting
 
 **Common Issues:**

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "module";
 
 const banner =
 `/*
@@ -31,7 +31,7 @@ const context = await esbuild.context({
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/lr",
-		...builtins],
+		...builtinModules],
 	format: "cjs",
 	target: "es2018",
 	logLevel: "info",

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
 	"minAppVersion": "0.15.0",
 	"description": "Sync notes bidirectionally between your vault and Airtable, SeaTable, or Supabase databases.",
 	"author": "uppinote",
-	"authorUrl": "https://github.com/uppinote20/obsidian-auto-note-importer",
+	"authorUrl": "https://github.com/uppinote20",
 	"fundingUrl": {
 		"Buy Me a Coffee": "https://www.buymeacoffee.com/uppinote",
 		"ko-fi": "https://ko-fi.com/uppinote"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"@typescript-eslint/eslint-plugin": "^5.29.0",
 				"@typescript-eslint/parser": "^5.29.0",
 				"@vitest/coverage-v8": "^0.34.6",
-				"builtin-modules": "3.3.0",
 				"esbuild": "^0.25.9",
 				"eslint": "^8.57.1",
 				"obsidian": "latest",
@@ -1612,19 +1611,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cac": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"@typescript-eslint/eslint-plugin": "^5.29.0",
 		"@typescript-eslint/parser": "^5.29.0",
 		"@vitest/coverage-v8": "^0.34.6",
-		"builtin-modules": "3.3.0",
 		"esbuild": "^0.25.9",
 		"eslint": "^8.57.1",
 		"obsidian": "latest",

--- a/src/services/seatable-metadata-cache.ts
+++ b/src/services/seatable-metadata-cache.ts
@@ -9,16 +9,19 @@
  * round trips. Both caches are keyed by `credential.id` so swapping
  * credentials evicts cleanly.
  *
- * Direct `fetch()` calls (instead of plumbing through `SeaTableClient`)
- * are intentional: settings-tab needs metadata before any
- * `ConfigInstance` exists for that credential, and Obsidian's
- * `requestUrl` and the browser `fetch` produce equivalent results for
- * SeaTable's CORS-enabled endpoints. The token refresh margin matches
+ * Uses Obsidian's `requestUrl` (matching `SeaTableClient`) rather than
+ * native `fetch` — keeps a single network surface for plugin guideline
+ * compliance and avoids CORS issues on Obsidian Mobile where browser
+ * fetch is more restrictive. Settings-tab still calls this directly
+ * (without going through `ConfigInstance`) because metadata is needed
+ * before any sync config is wired up. The token refresh margin matches
  * `SeaTableClient` so the two never diverge by more than a few seconds.
  *
  * @handbook 9.7-field-cache
  * @tested tests/services/seatable-metadata-cache.test.ts
  */
+
+import { requestUrl } from 'obsidian';
 
 import {
   SEATABLE_BASE_TOKEN_REFRESH_MARGIN_MS,
@@ -117,18 +120,16 @@ export class SeaTableMetadataCache {
   private async fetchTablesUncached(credential: SeaTableCredential): Promise<SeaTableTable[]> {
     const token = await this.getBaseToken(credential);
     const url = this.buildDtableUrl(token, 'metadata/');
-    const r = await fetch(url, {
+    const r = await requestUrl({
+      url,
+      method: 'GET',
       headers: { Authorization: `Bearer ${token.access_token}` },
+      throw: false,
     });
-    if (!r.ok) {
-      throw new Error(
-        `Failed to fetch SeaTable metadata: ${extractApiErrorDetails({
-          status: r.status,
-          json: await r.json().catch(() => undefined),
-        })}`,
-      );
+    if (r.status !== 200) {
+      throw new Error(`Failed to fetch SeaTable metadata: ${extractApiErrorDetails(r)}`);
     }
-    const json = (await r.json()) as { metadata?: { tables?: RawMetadataTable[] } };
+    const json = r.json as { metadata?: { tables?: RawMetadataTable[] } };
     const rawTables = json.metadata?.tables ?? [];
     const tables: SeaTableTable[] = rawTables.map(t => ({
       id: t._id,
@@ -164,18 +165,16 @@ export class SeaTableMetadataCache {
 
     const serverUrl = normalizeServerUrl(credential.serverUrl, SEATABLE_DEFAULT_SERVER_URL);
     const url = `${serverUrl}/api/v2.1/dtable/app-access-token/`;
-    const r = await fetch(url, {
+    const r = await requestUrl({
+      url,
+      method: 'GET',
       headers: { Authorization: `Token ${credential.apiToken}` },
+      throw: false,
     });
-    if (!r.ok) {
-      throw new Error(
-        `Failed to obtain SeaTable Base-Token: ${extractApiErrorDetails({
-          status: r.status,
-          json: await r.json().catch(() => undefined),
-        })}`,
-      );
+    if (r.status !== 200) {
+      throw new Error(`Failed to obtain SeaTable Base-Token: ${extractApiErrorDetails(r)}`);
     }
-    const body = (await r.json()) as BaseTokenResponse;
+    const body = r.json as BaseTokenResponse;
     if (!body.access_token || !body.dtable_uuid) {
       throw new Error('SeaTable Base-Token response missing access_token or dtable_uuid');
     }

--- a/src/services/seatable-metadata-cache.ts
+++ b/src/services/seatable-metadata-cache.ts
@@ -144,6 +144,12 @@ export class SeaTableMetadataCache {
       throw new Error(`Failed to fetch SeaTable metadata: ${extractApiErrorDetails(r)}`);
     }
     const json = this.parseJson(r) as { metadata?: { tables?: RawMetadataTable[] } } | null;
+    if (json === null) {
+      // Diagnostic for the silent empty-list path — a 200 response with a
+      // non-JSON body usually means a proxy interstitial (captive portal,
+      // CDN maintenance page) sat in front of SeaTable.
+      console.warn('SeaTableMetadataCache: metadata response was not JSON (proxy interstitial?), returning empty table list');
+    }
     const rawTables = json?.metadata?.tables ?? [];
     const tables: SeaTableTable[] = rawTables.map(t => ({
       id: t._id,

--- a/src/services/seatable-metadata-cache.ts
+++ b/src/services/seatable-metadata-cache.ts
@@ -17,11 +17,18 @@
  * before any sync config is wired up. The token refresh margin matches
  * `SeaTableClient` so the two never diverge by more than a few seconds.
  *
+ * Defensive patterns mirror `SupabaseMetadataCache`:
+ *  - `request()` wraps requestUrl with a try/catch fallback for older
+ *    Obsidian builds that ignore `throw: false` and reject on 4xx/5xx.
+ *  - `parseJson()` swallows SyntaxError from the lazy `r.json` getter
+ *    so a non-JSON body (proxy maintenance page, HTML 502) surfaces
+ *    as a friendly `HTTP {status}` message, not a raw parse error.
+ *
  * @handbook 9.7-field-cache
  * @tested tests/services/seatable-metadata-cache.test.ts
  */
 
-import { requestUrl } from 'obsidian';
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from 'obsidian';
 
 import {
   SEATABLE_BASE_TOKEN_REFRESH_MARGIN_MS,
@@ -113,24 +120,31 @@ export class SeaTableMetadataCache {
     try {
       return await promise;
     } finally {
-      this.inFlightTables.delete(credential.id);
+      // Identity-checked delete: if `clearForCred` (or a later concurrent
+      // call) replaced our entry mid-flight, leave the new entry alone so
+      // it can dedupe its own callers.
+      if (this.inFlightTables.get(credential.id) === promise) {
+        this.inFlightTables.delete(credential.id);
+      }
     }
   }
 
   private async fetchTablesUncached(credential: SeaTableCredential): Promise<SeaTableTable[]> {
     const token = await this.getBaseToken(credential);
     const url = this.buildDtableUrl(token, 'metadata/');
-    const r = await requestUrl({
+    const r = await this.request({
       url,
       method: 'GET',
-      headers: { Authorization: `Bearer ${token.access_token}` },
-      throw: false,
+      headers: {
+        'Authorization': `Bearer ${token.access_token}`,
+        'Accept': 'application/json',
+      },
     });
-    if (r.status !== 200) {
+    if (r.status < 200 || r.status >= 300) {
       throw new Error(`Failed to fetch SeaTable metadata: ${extractApiErrorDetails(r)}`);
     }
-    const json = r.json as { metadata?: { tables?: RawMetadataTable[] } };
-    const rawTables = json.metadata?.tables ?? [];
+    const json = this.parseJson(r) as { metadata?: { tables?: RawMetadataTable[] } } | null;
+    const rawTables = json?.metadata?.tables ?? [];
     const tables: SeaTableTable[] = rawTables.map(t => ({
       id: t._id,
       name: t.name,
@@ -165,20 +179,25 @@ export class SeaTableMetadataCache {
 
     const serverUrl = normalizeServerUrl(credential.serverUrl, SEATABLE_DEFAULT_SERVER_URL);
     const url = `${serverUrl}/api/v2.1/dtable/app-access-token/`;
-    const r = await requestUrl({
+    const r = await this.request({
       url,
       method: 'GET',
-      headers: { Authorization: `Token ${credential.apiToken}` },
-      throw: false,
+      headers: {
+        'Authorization': `Token ${credential.apiToken}`,
+        'Accept': 'application/json',
+      },
     });
-    if (r.status !== 200) {
+    if (r.status < 200 || r.status >= 300) {
       throw new Error(`Failed to obtain SeaTable Base-Token: ${extractApiErrorDetails(r)}`);
     }
-    const body = r.json as BaseTokenResponse;
-    if (!body.access_token || !body.dtable_uuid) {
+    const body = this.parseJson(r) as BaseTokenResponse | null;
+    if (!body?.access_token || !body?.dtable_uuid) {
       throw new Error('SeaTable Base-Token response missing access_token or dtable_uuid');
     }
-    const gatewayBase = normalizeServerUrl(body.dtable_server, serverUrl);
+    // Fallback matches SeaTableClient.getBaseToken (line 164) so settings-tab
+    // and sync paths agree on the gateway base when SeaTable omits
+    // `dtable_server` (older self-hosted, custom proxies).
+    const gatewayBase = normalizeServerUrl(body.dtable_server, `${serverUrl}/api-gateway/`);
     const token: CachedToken = {
       ...body,
       gatewayBase,
@@ -190,5 +209,41 @@ export class SeaTableMetadataCache {
 
   private buildDtableUrl(token: CachedToken, path: string): string {
     return `${token.gatewayBase}/api/v2/dtables/${token.dtable_uuid}/${path}`;
+  }
+
+  /**
+   * Wraps `requestUrl({...opts, throw: false})` with a fallback for older
+   * Obsidian builds that ignore `throw: false` and reject on 4xx/5xx —
+   * recovers the response shape so `r.status` branches stay live.
+   * Mirrors `SupabaseMetadataCache` and `SupabaseClient`.
+   */
+  private async request(opts: RequestUrlParam): Promise<RequestUrlResponse> {
+    try {
+      return await requestUrl({ ...opts, throw: false });
+    } catch (e) {
+      const err = e as { status?: number; headers?: Record<string, string>; json?: unknown; text?: string };
+      if (typeof err.status !== 'number') throw e;
+      return {
+        status: err.status,
+        headers: err.headers ?? {},
+        json: err.json,
+        text: err.text ?? '',
+        arrayBuffer: new ArrayBuffer(0),
+      } as RequestUrlResponse;
+    }
+  }
+
+  /**
+   * Safe access to the lazy `r.json` getter. Obsidian's requestUrl parses
+   * JSON on demand and throws `SyntaxError` if the body is non-JSON
+   * (proxy HTML interstitials, captive portals). Returns `null` on parse
+   * failure so callers can fall back to `??` defaulting.
+   */
+  private parseJson(r: RequestUrlResponse): unknown {
+    try {
+      return r.json;
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/utils/api-errors.ts
+++ b/src/utils/api-errors.ts
@@ -36,7 +36,19 @@ interface ApiErrorResponse {
 }
 
 export function extractApiErrorMessage(response: ApiErrorResponse): string {
-  const body = response.json as ApiErrorBody | undefined;
+  // Obsidian `requestUrl` exposes `.json` as a LAZY getter that runs
+  // `JSON.parse(response.text)` on access — it throws SyntaxError when
+  // the body is non-JSON (HTML 502 from a proxy, captive portal page,
+  // empty body, etc.). Without this guard, every caller that passes a
+  // raw RequestUrlResponse here would see the SyntaxError bubble out of
+  // their `throw new Error('Failed: ${extractApiErrorDetails(r)}')`
+  // and replace the intended HTTP-status message.
+  let body: ApiErrorBody | undefined;
+  try {
+    body = response.json as ApiErrorBody | undefined;
+  } catch {
+    body = undefined;
+  }
   if (body) {
     // PostgREST proper: code + message (both strings) is the most structured form
     if (typeof body.code === 'string' && typeof body.message === 'string') {

--- a/styles.css
+++ b/styles.css
@@ -63,13 +63,12 @@
 .ani-credentials-table .ani-cred-key-set {
   color: var(--text-accent);
   cursor: pointer;
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  transition: text-decoration-color 150ms;
+  border-bottom: 1px solid transparent;
+  transition: border-bottom-color 150ms;
 }
 
 .ani-credentials-table .ani-cred-key-set:hover {
-  text-decoration-color: var(--text-accent);
+  border-bottom-color: var(--text-accent);
 }
 
 .ani-credentials-table .ani-cred-actions {
@@ -259,8 +258,12 @@
 
 /* ─── Inline Field Errors ─────────────────────────────────────────── */
 
-.ani-field-error {
-  color: var(--text-error) !important;
+/* Specificity bump (.setting-item-description.ani-field-error = 0,2,0) beats
+   Obsidian's default `.setting-item-description { color: var(--text-muted) }`
+   (0,1,0) without resorting to !important. The class is only ever applied
+   to a Setting's descEl, which always carries `.setting-item-description`. */
+.setting-item-description.ani-field-error {
+  color: var(--text-error);
 }
 
 /* ─── Delete Config ───────────────────────────────────────────────── */

--- a/styles.css
+++ b/styles.css
@@ -258,11 +258,13 @@
 
 /* ─── Inline Field Errors ─────────────────────────────────────────── */
 
-/* Specificity bump (.setting-item-description.ani-field-error = 0,2,0) beats
-   Obsidian's default `.setting-item-description { color: var(--text-muted) }`
-   (0,1,0) without resorting to !important. The class is only ever applied
-   to a Setting's descEl, which always carries `.setting-item-description`. */
-.setting-item-description.ani-field-error {
+/* (0,3,0) selector beats both Obsidian core's `.setting-item-description`
+   (0,1,0) and popular themes (Minimal, Things, AnuPpuccin) that ship
+   `.setting-item .setting-item-description` at (0,2,0). The plugin's
+   settings UI always renders inside `.vertical-tab-content`, so this
+   parent is guaranteed at runtime. Avoids !important without depending
+   on stylesheet load order. */
+.vertical-tab-content .setting-item-description.ani-field-error {
   color: var(--text-error);
 }
 

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -83,8 +83,10 @@ describe('SeaTableMetadataCache', () => {
       const [tokenCall, metaCall] = mockRequestUrl.mock.calls;
       expect(tokenCall[0].url).toBe('https://cloud.seatable.io/api/v2.1/dtable/app-access-token/');
       expect(tokenCall[0].headers?.Authorization).toBe('Token st-token-abc');
+      expect(tokenCall[0].headers?.Accept).toBe('application/json');
       expect(metaCall[0].url).toBe('https://cloud.seatable.io/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
       expect(metaCall[0].headers?.Authorization).toBe('Bearer bt-xxx');
+      expect(metaCall[0].headers?.Accept).toBe('application/json');
       expect(tables).toHaveLength(2);
       expect(tables[0]).toEqual({
         id: '0000',
@@ -256,6 +258,64 @@ describe('SeaTableMetadataCache', () => {
 
     it('returns undefined when nothing is cached for the cred', () => {
       expect(cache.getTable('cred-missing', '0000')).toBeUndefined();
+    });
+  });
+
+  describe('clearForCred during in-flight fetch', () => {
+    it('preserves a later in-flight entry when an earlier promise resolves (identity-checked finally)', async () => {
+      // Reproduces SWEEP#2 race: clearForCred mid-flight, then a new fetch
+      // starts. Without identity-checked delete in fetchTables' finally,
+      // the original promise's cleanup would wipe the NEW promise's
+      // in-flight entry → a follow-up call would NOT dedupe and start a
+      // redundant fetch.
+      //
+      // We need to observe a follow-up that arrives AFTER A's finally but
+      // BEFORE B finishes — and crucially, no cachedTables entry from A
+      // (which would short-circuit the dedup test). Solving that by making
+      // A fail (its metadata response is a 500), so the cache stays empty
+      // and the inFlightTables Map is the only thing keeping D from
+      // starting fresh.
+      let resolveMetaA!: (v: unknown) => void;
+      let resolveMetaB!: (v: unknown) => void;
+      const metaPromiseA = new Promise(r => { resolveMetaA = r; });
+      const metaPromiseB = new Promise(r => { resolveMetaB = r; });
+
+      mockRequestUrl
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))   // A token
+        .mockReturnValueOnce(metaPromiseA)               // A metadata (will fail)
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))   // B token
+        .mockReturnValueOnce(metaPromiseB);              // B metadata (will succeed)
+
+      const credential = createCredential();
+
+      const callA = cache.fetchTables(credential);
+      // Drain microtasks so A's token resolves and A reaches the metadata
+      // await — A is now the in-flight entry.
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+
+      cache.clearForCred(credential.id);
+
+      const callB = cache.fetchTables(credential);
+      const callC = cache.fetchTables(credential);
+
+      // A's metadata fails. A throws; A's finally runs identity-check:
+      // current inFlightTables entry is B's promise, NOT A's → must not delete.
+      // A also never reached `cachedTables.set`, so cache is empty.
+      resolveMetaA(mockErr(500, { error_msg: 'server error' }));
+      await expect(callA).rejects.toThrow();
+
+      // D arrives. With identity check: B's in-flight entry intact → dedupe.
+      // Without it (the bug): no in-flight, no cache → fresh round trip.
+      const callD = cache.fetchTables(credential);
+
+      resolveMetaB(mockOk(METADATA_RESPONSE));
+      const [resB, resC, resD] = await Promise.all([callB, callC, callD]);
+
+      expect(resB).toBe(resC);
+      expect(resB).toBe(resD);
+      // 4 total mock calls: A(token+meta) + B(token+meta). C and D dedupe.
+      // Without the race fix this would be 6 (extra token+meta for D).
+      expect(mockRequestUrl).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -64,7 +64,10 @@ describe('SeaTableMetadataCache', () => {
   let cache: SeaTableMetadataCache;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) drops mockImplementation set in
+    // other tests / suites — prevents the obsidian mock from leaking
+    // request behavior between files.
+    vi.resetAllMocks();
     cache = new SeaTableMetadataCache();
   });
 
@@ -161,6 +164,55 @@ describe('SeaTableMetadataCache', () => {
         .mockResolvedValueOnce(mockErr(500, { error_msg: 'server error' }));
 
       await expect(cache.fetchTables(createCredential())).rejects.toThrow(/Failed to fetch SeaTable metadata/);
+    });
+
+    it('falls back to `${serverUrl}/api-gateway/` when token response omits dtable_server', async () => {
+      // Matches SeaTableClient.getBaseToken's fallback so settings-tab
+      // doesn't 404 on self-hosted SeaTable where the proxy strips
+      // dtable_server from the token response.
+      mockRequestUrl
+        .mockResolvedValueOnce(mockOk({ access_token: 'bt-xxx', dtable_uuid: 'uuid-xxx' }))
+        .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
+
+      await cache.fetchTables(createCredential({ serverUrl: 'https://seatable.example.com' }));
+
+      const [, metaCall] = mockRequestUrl.mock.calls;
+      expect(metaCall[0].url).toBe('https://seatable.example.com/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
+    });
+
+    it('accepts 2xx status codes other than 200 (e.g. 201 from upstream proxies)', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce({ status: 201, json: TOKEN_RESPONSE, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0) })
+        .mockResolvedValueOnce({ status: 201, json: METADATA_RESPONSE, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0) });
+
+      await expect(cache.fetchTables(createCredential())).resolves.toHaveLength(2);
+    });
+
+    it('does not crash when the 200 response body is non-JSON (lazy r.json throws)', async () => {
+      // Simulate Obsidian's lazy `.json` getter throwing SyntaxError on
+      // an HTML maintenance page returned with status 200.
+      const throwingJsonResponse: unknown = {
+        status: 200,
+        get json() { throw new SyntaxError("Unexpected token '<'"); },
+        headers: {},
+        text: '<!DOCTYPE html><html>maintenance</html>',
+        arrayBuffer: new ArrayBuffer(0),
+      };
+      mockRequestUrl
+        .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
+        .mockResolvedValueOnce(throwingJsonResponse as Awaited<ReturnType<typeof import('obsidian').requestUrl>>);
+
+      // parseJson swallows the SyntaxError → metadata?.tables ?? [] → empty list.
+      await expect(cache.fetchTables(createCredential())).resolves.toEqual([]);
+    });
+
+    it('recovers wrapped error shape when older Obsidian builds reject on 4xx (throw:false ignored)', async () => {
+      // Simulate the old Obsidian behavior: rejection with a status-bearing error object.
+      mockRequestUrl.mockRejectedValueOnce(
+        Object.assign(new Error('Forbidden'), { status: 403, json: { error_msg: 'Invalid API token' }, headers: {}, text: '' })
+      );
+
+      await expect(cache.fetchTables(createCredential())).rejects.toThrow(/Failed to obtain SeaTable Base-Token/);
     });
 
     it('drops malformed columns and views silently', async () => {

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestUrl } from 'obsidian';
 import { SeaTableMetadataCache } from '../../src/services/seatable-metadata-cache';
 import type { SeaTableCredential } from '../../src/types';
 
-const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
+const mockRequestUrl = vi.mocked(requestUrl);
 
 function createCredential(overrides: Partial<SeaTableCredential> = {}): SeaTableCredential {
   return {
@@ -53,19 +53,11 @@ const METADATA_RESPONSE = {
 };
 
 function mockOk(body: unknown) {
-  return {
-    ok: true,
-    status: 200,
-    json: async () => body,
-  };
+  return { status: 200, json: body, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0) };
 }
 
 function mockErr(status: number, body: unknown = {}) {
-  return {
-    ok: false,
-    status,
-    json: async () => body,
-  };
+  return { status, json: body, headers: {}, text: '', arrayBuffer: new ArrayBuffer(0) };
 }
 
 describe('SeaTableMetadataCache', () => {
@@ -78,18 +70,18 @@ describe('SeaTableMetadataCache', () => {
 
   describe('fetchTables', () => {
     it('exchanges Base-Token then GETs /metadata/ on a fresh cred', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
 
       const tables = await cache.fetchTables(createCredential());
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const [tokenCall, metaCall] = mockFetch.mock.calls;
-      expect(tokenCall[0]).toBe('https://cloud.seatable.io/api/v2.1/dtable/app-access-token/');
-      expect(tokenCall[1].headers.Authorization).toBe('Token st-token-abc');
-      expect(metaCall[0]).toBe('https://cloud.seatable.io/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
-      expect(metaCall[1].headers.Authorization).toBe('Bearer bt-xxx');
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+      const [tokenCall, metaCall] = mockRequestUrl.mock.calls;
+      expect(tokenCall[0].url).toBe('https://cloud.seatable.io/api/v2.1/dtable/app-access-token/');
+      expect(tokenCall[0].headers?.Authorization).toBe('Token st-token-abc');
+      expect(metaCall[0].url).toBe('https://cloud.seatable.io/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
+      expect(metaCall[0].headers?.Authorization).toBe('Bearer bt-xxx');
       expect(tables).toHaveLength(2);
       expect(tables[0]).toEqual({
         id: '0000',
@@ -107,7 +99,7 @@ describe('SeaTableMetadataCache', () => {
     });
 
     it('reuses the cached tables across repeat calls without hitting the API', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
 
@@ -116,11 +108,11 @@ describe('SeaTableMetadataCache', () => {
       const second = await cache.fetchTables(credential);
 
       expect(first).toBe(second);
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
     });
 
     it('refetches metadata after clearForCred()', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk(METADATA_RESPONSE))
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
@@ -132,11 +124,11 @@ describe('SeaTableMetadataCache', () => {
       const refreshed = await cache.fetchTables(credential);
 
       expect(refreshed).toEqual([]);
-      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(4);
     });
 
     it('strips trailing slashes from custom server URLs and routes to dtable_server', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk({
           ...TOKEN_RESPONSE,
           dtable_server: 'https://seatable.example.com/api-gateway/',
@@ -145,26 +137,26 @@ describe('SeaTableMetadataCache', () => {
 
       await cache.fetchTables(createCredential({ serverUrl: 'https://seatable.example.com/' }));
 
-      const [tokenCall, metaCall] = mockFetch.mock.calls;
-      expect(tokenCall[0]).toBe('https://seatable.example.com/api/v2.1/dtable/app-access-token/');
-      expect(metaCall[0]).toBe('https://seatable.example.com/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
+      const [tokenCall, metaCall] = mockRequestUrl.mock.calls;
+      expect(tokenCall[0].url).toBe('https://seatable.example.com/api/v2.1/dtable/app-access-token/');
+      expect(metaCall[0].url).toBe('https://seatable.example.com/api-gateway/api/v2/dtables/uuid-xxx/metadata/');
     });
 
     it('throws with HTTP details when the Base-Token endpoint fails', async () => {
-      mockFetch.mockResolvedValueOnce(mockErr(403, { error_msg: 'Invalid API token' }));
+      mockRequestUrl.mockResolvedValueOnce(mockErr(403, { error_msg: 'Invalid API token' }));
 
       await expect(cache.fetchTables(createCredential())).rejects.toThrow(/Failed to obtain SeaTable Base-Token/);
     });
 
     it('throws when Base-Token response is missing required fields', async () => {
-      mockFetch.mockResolvedValueOnce(mockOk({ access_token: 'only' }));
+      mockRequestUrl.mockResolvedValueOnce(mockOk({ access_token: 'only' }));
 
       await expect(cache.fetchTables(createCredential()))
         .rejects.toThrow(/missing access_token or dtable_uuid/);
     });
 
     it('throws with HTTP details when the metadata endpoint fails', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockErr(500, { error_msg: 'server error' }));
 
@@ -172,7 +164,7 @@ describe('SeaTableMetadataCache', () => {
     });
 
     it('drops malformed columns and views silently', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk({
           metadata: {
@@ -201,7 +193,7 @@ describe('SeaTableMetadataCache', () => {
 
   describe('getTable', () => {
     it('returns the cached table by id', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
 
@@ -221,7 +213,7 @@ describe('SeaTableMetadataCache', () => {
       let resolveMeta!: (v: unknown) => void;
       const tokenPromise = new Promise(r => { resolveToken = r; });
       const metaPromise = new Promise(r => { resolveMeta = r; });
-      mockFetch.mockReturnValueOnce(tokenPromise).mockReturnValueOnce(metaPromise);
+      mockRequestUrl.mockReturnValueOnce(tokenPromise).mockReturnValueOnce(metaPromise);
 
       const credential = createCredential();
       const a = cache.fetchTables(credential);
@@ -234,7 +226,7 @@ describe('SeaTableMetadataCache', () => {
 
       expect(resA).toBe(resB);
       // Two fetches total: 1 token + 1 metadata. Without dedup we'd see 4.
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -243,13 +235,13 @@ describe('SeaTableMetadataCache', () => {
       vi.useFakeTimers();
       try {
         // First fetch — token + metadata.
-        mockFetch
+        mockRequestUrl
           .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
           .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
 
         const credential = createCredential();
         await cache.fetchTables(credential);
-        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockRequestUrl).toHaveBeenCalledTimes(2);
 
         // Drop the tables cache so the next fetchTables() reaches into
         // the token cache, but advance time past the refresh window so
@@ -262,11 +254,11 @@ describe('SeaTableMetadataCache', () => {
         // would require exposing private state.
         vi.advanceTimersByTime(3 * 24 * 60 * 60 * 1000);
 
-        mockFetch
+        mockRequestUrl
           .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
           .mockResolvedValueOnce(mockOk(METADATA_RESPONSE));
         await cache.fetchTables(credential);
-        expect(mockFetch).toHaveBeenCalledTimes(4);
+        expect(mockRequestUrl).toHaveBeenCalledTimes(4);
       } finally {
         vi.useRealTimers();
       }
@@ -275,7 +267,7 @@ describe('SeaTableMetadataCache', () => {
 
   describe('clear()', () => {
     it('drops every cached cred entry, forcing a re-fetch', async () => {
-      mockFetch
+      mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
         .mockResolvedValueOnce(mockOk(METADATA_RESPONSE))
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
@@ -286,7 +278,7 @@ describe('SeaTableMetadataCache', () => {
       cache.clear();
       await cache.fetchTables(credential);
 
-      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/tests/services/seatable-metadata-cache.test.ts
+++ b/tests/services/seatable-metadata-cache.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { requestUrl } from 'obsidian';
+import { requestUrl, type RequestUrlResponse } from 'obsidian';
 import { SeaTableMetadataCache } from '../../src/services/seatable-metadata-cache';
 import type { SeaTableCredential } from '../../src/types';
 
@@ -202,7 +202,7 @@ describe('SeaTableMetadataCache', () => {
       };
       mockRequestUrl
         .mockResolvedValueOnce(mockOk(TOKEN_RESPONSE))
-        .mockResolvedValueOnce(throwingJsonResponse as Awaited<ReturnType<typeof import('obsidian').requestUrl>>);
+        .mockResolvedValueOnce(throwingJsonResponse as RequestUrlResponse);
 
       // parseJson swallows the SyntaxError → metadata?.tables ?? [] → empty list.
       await expect(cache.fetchTables(createCredential())).resolves.toEqual([]);
@@ -290,7 +290,10 @@ describe('SeaTableMetadataCache', () => {
 
       const callA = cache.fetchTables(credential);
       // Drain microtasks so A's token resolves and A reaches the metadata
-      // await — A is now the in-flight entry.
+      // await — A is now the in-flight entry. Current chain (fetchTables →
+      // fetchTablesUncached → getBaseToken → request → requestUrl + json
+      // parse + token cache set) needs ~5-8 turns; 20 leaves margin for a
+      // future async layer. Bump if a new await is added to the path.
       for (let i = 0; i < 20; i++) await Promise.resolve();
 
       cache.clearForCred(credential.id);

--- a/tests/utils/api-errors.test.ts
+++ b/tests/utils/api-errors.test.ts
@@ -58,6 +58,30 @@ describe('extractApiErrorMessage', () => {
   it('treats body.error as object only when it has message', () => {
     expect(extractApiErrorMessage({ json: { error: { code: 42 } as { message?: string }, error_msg: 'x' } })).toBe('x');
   });
+
+  it('falls through to response.text when accessing response.json throws (lazy getter on non-JSON body)', () => {
+    // Obsidian's requestUrl exposes `.json` as a lazy getter that parses
+    // response.text on access. When the body is HTML (proxy 502 / captive
+    // portal), the getter throws SyntaxError. Without the defensive
+    // try/catch in extractApiErrorMessage, callers like
+    // `extractApiErrorDetails(r)` inside `throw new Error('Failed: ${...}')`
+    // would see the SyntaxError replace the intended HTTP-status message.
+    const throwingResponse: { status: number; text?: string; json?: unknown } = {
+      status: 502,
+      text: '<!DOCTYPE html><html>Bad gateway</html>',
+      get json() { throw new SyntaxError("Unexpected token '<'"); },
+    };
+    expect(extractApiErrorMessage(throwingResponse)).toBe('<!DOCTYPE html><html>Bad gateway</html>');
+  });
+
+  it('falls through to HTTP status when both json getter throws AND text is empty', () => {
+    const throwingResponse: { status: number; text?: string; json?: unknown } = {
+      status: 500,
+      text: '',
+      get json() { throw new SyntaxError('Unexpected end of JSON input'); },
+    };
+    expect(extractApiErrorMessage(throwingResponse)).toBe('HTTP 500');
+  });
 });
 
 describe('extractApiErrorDetails', () => {


### PR DESCRIPTION
## Summary

- Address all warnings shown on the Obsidian community store [Reviews](https://community.obsidian.md/plugins/auto-note-importer) (manifest, source, css, releases, behavior).
- Migrate `SeaTableMetadataCache` from native `fetch` to Obsidian `requestUrl`, then harden it for proxies / older Obsidian builds based on a self-review pass.
- Split the release workflow into `build` / `release` jobs and add SLSA build-provenance attestation so `npm install` never runs in the same job as the OIDC signing identity.
- README disclosure section corrected to match the vault APIs actually called.

## Changes

### Scorecard warnings (manifest / build / css)
- `manifest.json` — `authorUrl` repo → profile URL.
- `package.json` / `esbuild.config.mjs` — drop external `builtin-modules` dep, use Node's built-in `module.builtinModules`.
- `styles.css` — replace `text-decoration` + `text-decoration-color` with `border-bottom` (Obsidian 1.4.5 compat); remove `!important` and bump `.ani-field-error` selector specificity to (0,3,0) via `.vertical-tab-content` scope (beats theme rules at 0,2,0).

### SeaTable metadata cache robustness
Code review surfaced 7 real / latent bugs in the `fetch → requestUrl` migration; all fixed:
- `request()` wrapper recovers response shape when older Obsidian builds ignore `throw: false` and reject on 4xx/5xx (mirrors `SupabaseMetadataCache`).
- `parseJson()` swallows `SyntaxError` from the lazy `r.json` getter so proxy HTML interstitials surface as friendly `HTTP {status}` errors.
- `dtable_server` fallback unified with `SeaTableClient.getBaseToken` — when SeaTable's token response omits the gateway, both paths use `${serverUrl}/api-gateway/`. Previously settings UI 404'd while sync worked.
- Status check widened from `!== 200` to the full 2xx range (corporate proxies sometimes rewrite 200 → 201/202).
- `Accept: application/json` header added to both requests (parity with `SeaTableClient`).
- `r.json` null-safe via optional chaining.
- `fetchTables()`'s finally identity-checks the `inFlightTables` entry before delete — a `clearForCred` call mid-flight no longer wipes a follow-up promise's entry.

### Release workflow security
- Two-job split: `build` (no `id-token`, runs `npm ci --ignore-scripts`) → `release` (has `id-token: write` + `attestations: write`, no npm install). Postinstall scripts cannot mint a Sigstore attestation impersonating this repo.
- Both checkout steps use `persist-credentials: false`.
- `actions/attest-build-provenance` SHA-pinned to v2.4.0 (`e8998f9…`) instead of mutable `@v2`.
- `subject-path` includes `manifest.json` so every release asset can be verified with `gh attestation verify`.

### Docs / tests
- README: new "Permissions & Disclosures" section, corrected vault API list (removed `vault.cachedRead` / `getFiles` / `getMarkdownFiles` claims, added `getAbstractFileByPath` / `createFolder` / `adapter.exists` / change-event hooks).
- Engineering Handbook §9.7 + §8.3 reflect the new patterns (via `.private` symlink).
- 5 new vitest cases: `dtable_server` fallback, 2xx status acceptance, non-JSON body safety, throw:false recovery, `clearForCred` race fix (deterministic A-fails design).

## Test plan
- [x] `npm run build` — TypeScript + esbuild OK
- [x] `npm run test:run` — 33 files / **757 tests** pass
- [ ] Trigger the workflow on a draft tag (next minor release) and verify (a) split jobs both succeed, (b) attestation appears for `main.js` / `styles.css` / `manifest.json`, (c) artifacts download cleanly
- [ ] Community store "Review branch" against `chore/scorecard-cleanup` and confirm Manifest / Source Code / CSS Lint warnings clear; Releases attestation recs remain (apply at next release)
- [ ] Manual smoke: settings tab on Obsidian Mobile, verify error color visible inside Minimal theme

## Notes
- 1.0.0 release artifacts cannot be retroactively attested (Sigstore disallows post-hoc provenance). Attestation kicks in from the next release tag.
- A few finding categories were intentionally **not** fixed (low value vs scope): `seatable-client.ts` mirrors the same `!== 200` narrow check — left for a separate PR if needed.