### PR TITLE
chore: bump CI artifact and attest actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ jobs:
           npm run build
 
       - name: Upload build artifacts
-        # SHA-pinned (v4.6.2) for supply-chain hardening consistency
+        # SHA-pinned (v7.0.1) for supply-chain hardening consistency
         # with the attest step. Bump SHA together with comment.
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: plugin-build
           path: |
@@ -71,14 +71,14 @@ jobs:
           persist-credentials: false
 
       - name: Download build artifacts
-        # SHA-pinned (v4.3.0).
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # SHA-pinned (v8.0.1).
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: plugin-build
 
       - name: Attest build provenance
-        # SHA-pinned (v2.4.0). When bumping, update both SHA and comment.
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        # SHA-pinned (v4.1.0). When bumping, update both SHA and comment.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: |
             main.js


### PR DESCRIPTION
## Summary
- GitHub forces Node.js 20 actions onto the Node.js 24 runtime starting **2026-06-02**, and removes Node 20 from runners on **2026-09-16**. The `1.0.1` release run emitted deprecation warnings for three actions.
- Bumps the three SHA-pinned actions in `release.yml` that still ran on Node 20 to their latest Node 24 releases.
- Verified each pin resolves to its claimed version tag and that our usage is unaffected by the major-version breaking changes.

## Changes
- `actions/upload-artifact` v4.6.2 → **v7.0.1** (`043fb46`) — Node 24; default `archive` behavior preserved (we upload by `name` with a multi-file zipped path).
- `actions/download-artifact` v4.3.0 → **v8.0.1** (`3e5f45b`) — Node 24; name-based download path unchanged; hash-mismatch now defaults to `error`, reinforcing this workflow's supply-chain hardening.
- `actions/attest-build-provenance` v2.4.0 → **v4.1.0** (`a2bbfa2`) — Node 24 sub-actions; `subject-path` input preserved.
- SHA-pin comments updated alongside each SHA (workflow convention).

## Breaking-change assessment
- **download v5** breaking change affects downloads **by ID** only; we download by `name` (docs: by-name path "unchanged").
- **upload v7 / download v8** ESM migration is transparent to callers.
- All three require Actions Runner ≥ 2.327.1; `ubuntu-latest` always satisfies this.
- Repo-wide audit: other workflows already use `actions/checkout@v6` (Node 24) — no further changes needed.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`)
- [x] Each pinned SHA cross-checked against its version tag via `gh api`
- [x] Repo-wide `uses:` audit — only these 3 actions ran on Node 20
- [ ] End-to-end validation occurs on the next tag push (release workflow run)

Proactive follow-up from the `1.0.1` release; no tracked issue.