### PR TITLE
fix: prevent frontmatter edits from overwriting structured remote fields

### DIFF
--- a/src/file-operations/frontmatter-parser.ts
+++ b/src/file-operations/frontmatter-parser.ts
@@ -34,7 +34,7 @@ export class FrontmatterParser {
 
   /**
    * Extracts syncable fields from a file's frontmatter.
-   * Filters out system fields and read-only fields.
+   * Filters out system fields and fields that are unsafe to push.
    */
   extractSyncableFields(
     file: TFile,
@@ -60,10 +60,10 @@ export class FrontmatterParser {
       }
 
       // When field metadata is available, only sync fields that exist remotely
-      // and are writable (provider decides via its FieldTypeMapper)
+      // and can safely round-trip through the provider API.
       if (cachedFields) {
         const fieldInfo = cachedFields.find(f => f.name === key);
-        if (!fieldInfo || fieldTypeMapper.isReadOnly(fieldInfo.type)) {
+        if (!fieldInfo || !fieldTypeMapper.isPushable(fieldInfo.type)) {
           continue;
         }
       }

--- a/src/file-operations/frontmatter-parser.ts
+++ b/src/file-operations/frontmatter-parser.ts
@@ -35,6 +35,12 @@ export class FrontmatterParser {
   /**
    * Extracts syncable fields from a file's frontmatter.
    * Filters out system fields and fields that are unsafe to push.
+   *
+   * The `isPushable` gate only runs when `cachedFields` is provided. When it is
+   * `undefined` (cache miss, or a provider that supplies no field metadata),
+   * every non-system, non-null frontmatter value passes through — so object-shaped
+   * values could reach the API on a cold cache. Callers that need the guard must
+   * ensure field metadata is loaded first.
    */
   extractSyncableFields(
     file: TFile,

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -138,6 +138,12 @@ class AirtableFieldMapperImpl implements FieldTypeMapper {
     return (READ_ONLY_TYPES as readonly string[]).includes(providerType);
   }
 
+  isPushable(providerType: string): boolean {
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, providerType)) return false;
+    if (TYPE_TO_STANDARD[providerType] === 'unknown') return false;
+    return !this.isReadOnly(providerType) && !OBJECT_SHAPED_TYPES.has(providerType);
+  }
+
   isFilenameSafe(providerType: string): boolean {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -87,6 +87,10 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
 // select' / 'computed' / 'text' / 'system', String(value) produces
 // '[object Object],…' garbage for these. Manual exclusion list — must be
 // kept in sync with TYPE_TO_STANDARD when new object-shaped types arrive.
+// `button` / `aiText` / `externalSyncSource` / `lookup` also appear in
+// READ_ONLY_TYPES — `isPushable` already rejects them via `isReadOnly`, so
+// their entry here is belt-and-suspenders that also documents the object
+// shape for the subfolder filter.
 const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
   'singleCollaborator',
   'multipleCollaborators',

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -110,6 +110,12 @@ class SeaTableFieldMapperImpl implements FieldTypeMapper {
     return (READ_ONLY_TYPES as readonly string[]).includes(providerType);
   }
 
+  isPushable(providerType: string): boolean {
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, providerType)) return false;
+    if (TYPE_TO_STANDARD[providerType] === 'unknown') return false;
+    return !this.isReadOnly(providerType) && !OBJECT_SHAPED_TYPES.has(providerType);
+  }
+
   isFilenameSafe(providerType: string): boolean {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }

--- a/src/services/supabase-client.ts
+++ b/src/services/supabase-client.ts
@@ -162,7 +162,11 @@ export class SupabaseClient implements DatabaseProvider {
       const columns = this.metadataCache.getColumns(spec, tableName);
       const m = new Map<string, string>();
       for (const c of columns) {
-        if (supabaseFieldMapper.isPushable(c.providerType)) {
+        // Map writable (non-read-only) columns. The view guard in batchUpdate
+        // treats an empty map as "non-updatable view", so this must reflect
+        // writability — NOT push-safety. Object-shaped writable columns are
+        // filtered later, at payload composition (#108).
+        if (!supabaseFieldMapper.isReadOnly(c.providerType)) {
           m.set(c.name, c.providerType);
         }
       }
@@ -408,7 +412,13 @@ export class SupabaseClient implements DatabaseProvider {
         for (const [k, v] of Object.entries(u.fields)) {
           if (k === pk) continue;
           if (writableColumns && !writableColumns.has(k)) continue;
-          const coerced = this.coerceForSupabase(v, writableColumns?.get(k));
+          const providerType = writableColumns?.get(k);
+          // Writable but object-shaped (json/jsonb/object): omit from the upsert
+          // so the structured remote value is preserved. isPushable is applied
+          // here, at composition — not in loadWritableColumns, whose count feeds
+          // the non-updatable-view guard above (#108).
+          if (providerType && !supabaseFieldMapper.isPushable(providerType)) continue;
+          const coerced = this.coerceForSupabase(v, providerType);
           if (coerced === SupabaseClient.SKIP_FIELD) continue;
           filtered[k] = coerced;
         }

--- a/src/services/supabase-client.ts
+++ b/src/services/supabase-client.ts
@@ -162,7 +162,7 @@ export class SupabaseClient implements DatabaseProvider {
       const columns = this.metadataCache.getColumns(spec, tableName);
       const m = new Map<string, string>();
       for (const c of columns) {
-        if (!supabaseFieldMapper.isReadOnly(c.providerType)) {
+        if (supabaseFieldMapper.isPushable(c.providerType)) {
           m.set(c.name, c.providerType);
         }
       }
@@ -181,7 +181,8 @@ export class SupabaseClient implements DatabaseProvider {
    * Coerce a frontmatter value into something PostgREST accepts for the
    * column's type. `note-builder` writes null → '""' (so the field stays
    * visible in Obsidian frontmatter), but PostgREST rejects empty strings
-   * for non-text columns (text[], jsonb, integer, boolean, etc.).
+   * for non-text columns (text[], integer, boolean, etc.). Object-shaped
+   * columns such as json/jsonb are filtered before this coercion step.
    *
    * Returns the symbol `SKIP_FIELD` when the field should be dropped from
    * the upsert body entirely (e.g. empty string for a numeric column).
@@ -190,9 +191,6 @@ export class SupabaseClient implements DatabaseProvider {
     if (value !== '') return value;  // only "" is the problem case
     if (!providerType) return value;
     if (providerType.startsWith('array:')) return [];      // empty PostgreSQL array
-    // jsonb/json — emitted as `string:jsonb` by the RPC fallback OR plain
-    // `object` by PostgREST's own OpenAPI for some configurations.
-    if (providerType === 'object' || /(:|^)json[b]?$/.test(providerType)) return null;
     // Only PLAIN `string` accepts "" legitimately (text/varchar/citext/etc).
     // Every formatted string variant (`string:date`, `string:date-time`,
     // `string:byte`, `string:uuid`) maps to a PG type that rejects ""  drop.

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -25,9 +25,10 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
   // {type: 'string', format: 'jsonb'/'json'}, but the runtime VALUE is a
   // parsed JS object/array (NOT a string) — see OBJECT_SHAPED_TYPES below.
   // Map as 'text' here so the fail-closed default doesn't reject them at
-  // the standard-type lookup; the type-aware coercion in SupabaseClient.
-  // batchUpdate handles "" → null for upserts; subfolder dropdown filters
-  // them out via OBJECT_SHAPED_TYPES because String(value) → '[object …]'.
+  // the standard-type lookup; push consumers (extractSyncableFields +
+  // SupabaseClient.batchUpdate) exclude them via isPushable() / OBJECT_SHAPED_TYPES
+  // before they reach the upsert body, and the subfolder dropdown filters them
+  // out via OBJECT_SHAPED_TYPES because String(value) → '[object …]'.
   'string:jsonb': 'text',
   'string:json': 'text',
   'integer': 'number',

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -106,6 +106,15 @@ class SupabaseFieldMapperImpl implements FieldTypeMapper {
     return providerType.endsWith(READONLY_SUFFIX);
   }
 
+  isPushable(providerType: string): boolean {
+    const base = providerType.endsWith(READONLY_SUFFIX)
+      ? providerType.slice(0, -READONLY_SUFFIX.length)
+      : providerType;
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_STANDARD, base)) return false;
+    if (TYPE_TO_STANDARD[base] === 'unknown') return false;
+    return !providerType.endsWith(READONLY_SUFFIX) && !OBJECT_SHAPED_TYPES.has(base);
+  }
+
   isFilenameSafe(providerType: string): boolean {
     return (FILENAME_SAFE_TYPES as readonly string[]).includes(providerType);
   }

--- a/src/types/field-types.types.ts
+++ b/src/types/field-types.types.ts
@@ -52,9 +52,18 @@ export interface FieldTypeMapper {
 
   /**
    * Returns true if the field type is read-only (computed or system-assigned).
-   * Used by frontmatter-parser to exclude fields from push payloads.
+   * Read-only is not the whole push-safety contract: some writable provider
+   * types still have object-shaped API values that cannot round-trip from
+   * frontmatter scalars.
    */
   isReadOnly(providerType: string): boolean;
+
+  /**
+   * Returns true if frontmatter values of this provider type can be safely sent
+   * back to the remote API. Stricter than `!isReadOnly`: rejects unknown and
+   * object-shaped provider types that cannot be reconstructed from YAML values.
+   */
+  isPushable(providerType: string): boolean;
 
   /**
    * Returns true if the field type is usable as a filename value.

--- a/tests/__mocks__/database-client.mock.ts
+++ b/tests/__mocks__/database-client.mock.ts
@@ -23,6 +23,7 @@ export type MockDatabaseProvider = {
 const NOOP_MAPPER: FieldTypeMapper = {
   mapToStandardType: () => 'unknown',
   isReadOnly: () => true,      // unknown → read-only (matches production fail-closed)
+  isPushable: () => false,     // unknown → not pushable
   isFilenameSafe: () => false, // unknown → not filename-safe
   isSubfolderSafe: () => false,// unknown → not subfolder-safe
   getFilenameSafeTypes: () => [],

--- a/tests/file-operations/frontmatter-parser.test.ts
+++ b/tests/file-operations/frontmatter-parser.test.ts
@@ -179,6 +179,37 @@ Content here`;
       expect(result).not.toHaveProperty('primaryField');
     });
 
+    it('should exclude object-shaped fields even when the provider does not mark them read-only', () => {
+      const mockApp = {
+        metadataCache: {
+          getFileCache: vi.fn().mockReturnValue({
+            frontmatter: {
+              primaryField: 'rec123',
+              Name: 'Test',
+              Barcode: 'user-edited barcode',
+              Collaborator: 'Ada',
+              position: { start: { line: 0 }, end: { line: 5 } }
+            }
+          })
+        },
+        vault: { getAbstractFileByPath: vi.fn() }
+      };
+      const parser = new FrontmatterParser(mockApp as any);
+      const mockFile = { path: 'test.md' } as any;
+
+      const cachedFields = [
+        { id: 'fld1', name: 'Name', type: 'singleLineText' },
+        { id: 'fld2', name: 'Barcode', type: 'barcode' },
+        { id: 'fld3', name: 'Collaborator', type: 'singleCollaborator' }
+      ];
+
+      const result = parser.extractSyncableFields(mockFile, airtableFieldMapper, cachedFields);
+
+      expect(result).toEqual({ Name: 'Test' });
+      expect(airtableFieldMapper.isReadOnly('barcode')).toBe(false);
+      expect(airtableFieldMapper.isPushable('barcode')).toBe(false);
+    });
+
     it('should include all non-system fields when no cachedFields provided', () => {
       const mockApp = {
         metadataCache: {

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -122,6 +122,53 @@ describe('airtableFieldMapper', () => {
     });
   });
 
+  describe('isPushable', () => {
+    it('should return true for writable scalar types', () => {
+      for (const t of [
+        'singleLineText',
+        'multilineText',
+        'richText',
+        'email',
+        'phoneNumber',
+        'url',
+        'number',
+        'currency',
+        'percent',
+        'rating',
+        'duration',
+        'date',
+        'dateTime',
+        'checkbox',
+        'singleSelect',
+        'multipleSelects',
+      ]) {
+        expect(airtableFieldMapper.isPushable(t)).toBe(true);
+      }
+    });
+
+    it('should return false for read-only types', () => {
+      for (const t of airtableFieldMapper.getReadOnlyTypes()) {
+        expect(airtableFieldMapper.isPushable(t)).toBe(false);
+      }
+    });
+
+    it('should return false for object-shaped writable types', () => {
+      expect(airtableFieldMapper.isReadOnly('barcode')).toBe(false);
+      expect(airtableFieldMapper.isReadOnly('singleCollaborator')).toBe(false);
+      expect(airtableFieldMapper.isReadOnly('multipleCollaborators')).toBe(false);
+
+      expect(airtableFieldMapper.isPushable('barcode')).toBe(false);
+      expect(airtableFieldMapper.isPushable('singleCollaborator')).toBe(false);
+      expect(airtableFieldMapper.isPushable('multipleCollaborators')).toBe(false);
+    });
+
+    it('should fail closed for unknown and prototype-chain names', () => {
+      for (const t of ['bogusType', '', 'toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+        expect(airtableFieldMapper.isPushable(t)).toBe(false);
+      }
+    });
+  });
+
   describe('isSubfolderSafe', () => {
     // Issue #98: subfolder allows a broad set of types — sanitizeSubfolderValue
     // handles any stringifiable input. Filename rules are stricter (OS rules).

--- a/tests/services/provider-registry.test.ts
+++ b/tests/services/provider-registry.test.ts
@@ -155,6 +155,7 @@ describe('provider-registry', () => {
       const fake = {
         mapToStandardType: () => 'text' as const,
         isReadOnly: () => false,
+        isPushable: () => true,
         isFilenameSafe: () => true,
         isSubfolderSafe: () => true,
         getFilenameSafeTypes: () => [],

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -108,6 +108,47 @@ describe('seatableFieldMapper', () => {
     });
   });
 
+  describe('isPushable', () => {
+    it('should return true for writable scalar types', () => {
+      for (const t of [
+        'text',
+        'long-text',
+        'email',
+        'url',
+        'number',
+        'duration',
+        'rate',
+        'date',
+        'checkbox',
+        'single-select',
+        'multiple-select',
+        'department-single-select',
+      ]) {
+        expect(seatableFieldMapper.isPushable(t)).toBe(true);
+      }
+    });
+
+    it('should return false for read-only types', () => {
+      for (const t of seatableFieldMapper.getReadOnlyTypes()) {
+        expect(seatableFieldMapper.isPushable(t)).toBe(false);
+      }
+    });
+
+    it('should return false for object-shaped writable types', () => {
+      expect(seatableFieldMapper.isReadOnly('collaborator')).toBe(false);
+      expect(seatableFieldMapper.isReadOnly('geolocation')).toBe(false);
+
+      expect(seatableFieldMapper.isPushable('collaborator')).toBe(false);
+      expect(seatableFieldMapper.isPushable('geolocation')).toBe(false);
+    });
+
+    it('should fail closed for unknown and prototype-chain names', () => {
+      for (const t of ['bogusType', '', 'toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+        expect(seatableFieldMapper.isPushable(t)).toBe(false);
+      }
+    });
+  });
+
   describe('isSubfolderSafe', () => {
     it('should return true for stringifiable known SeaTable types', () => {
       // Excludes OBJECT_SHAPED_TYPES (collaborator / geolocation / button) —

--- a/tests/services/supabase-client.test.ts
+++ b/tests/services/supabase-client.test.ts
@@ -684,4 +684,36 @@ describe('SupabaseClient.batchUpdate composite PK + view-as-tableId guards (revi
     }
     expect(mockRequestUrl).not.toHaveBeenCalled();
   });
+
+  it('does not falsely reject a table whose only writable columns are object-shaped (#108: view guard counts writable, not pushable)', async () => {
+    const cache = new SupabaseMetadataCache();
+    // readonly PK + a single writable jsonb column. The table IS updatable
+    // (jsonb is a writable column), but jsonb is object-shaped so it must be
+    // omitted from the push — NOT reported as a non-updatable view.
+    const spec = {
+      definitions: {
+        notes: {
+          properties: {
+            id:   { type: 'string', format: 'uuid', readOnly: true },
+            data: { type: 'string', format: 'jsonb' },  // writable, object-shaped
+          },
+          required: ['id'],
+        },
+      },
+    };
+    (cache as unknown as { entries: Map<string, { spec: unknown; fetchedAt: number }> })
+      .entries.set('c1:public', { spec, fetchedAt: Date.now() });
+
+    mockRequestUrl.mockResolvedValueOnce({ status: 200, json: [{ id: 'r1' }], headers: {} });
+    const c = new SupabaseClient(cred, makeConfig(), new RateLimiter(), cache);
+    const result = await c.batchUpdate([{ recordId: 'r1', fields: { data: 'user-edited json' } }]);
+
+    // Must succeed (not a "non-updatable view" failure)...
+    expect(result[0].success).toBe(true);
+    // ...and the object-shaped column is omitted from the upsert body so the
+    // structured remote value is preserved.
+    const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
+    expect(body[0]).not.toHaveProperty('data');
+    expect(body[0]).toEqual({ id: 'r1' });
+  });
 });

--- a/tests/services/supabase-client.test.ts
+++ b/tests/services/supabase-client.test.ts
@@ -544,12 +544,12 @@ describe('SupabaseClient.batchUpdate type-aware coercion (Path A — frontmatter
     expect(body[0].tags).toEqual([]);
   });
 
-  it('coerces frontmatter "" to null for jsonb / json columns', async () => {
+  it('drops jsonb / json columns from the upsert body', async () => {
     mockRequestUrl.mockResolvedValueOnce({ status: 200, json: [{ id: 'r1' }], headers: {} });
     const c = new SupabaseClient(cred, makeConfig(), new RateLimiter(), specWithTypes());
-    await c.batchUpdate([{ recordId: 'r1', fields: { meta: '' } }]);
+    await c.batchUpdate([{ recordId: 'r1', fields: { meta: 'user-edited json text' } }]);
     const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
-    expect(body[0].meta).toBeNull();
+    expect(body[0]).not.toHaveProperty('meta');
   });
 
   it('drops frontmatter "" for numeric / boolean / uuid columns (PostgREST would 400)', async () => {
@@ -606,7 +606,7 @@ describe('SupabaseClient.batchUpdate type-aware coercion (Path A — frontmatter
     expect(body[0]).not.toHaveProperty('b');
   });
 
-  it('coerces "" to null for plain `object` providerType (alternate jsonb shape)', async () => {
+  it('drops plain `object` providerType columns from the upsert body', async () => {
     const cache = new SupabaseMetadataCache();
     const spec = {
       definitions: {
@@ -623,9 +623,9 @@ describe('SupabaseClient.batchUpdate type-aware coercion (Path A — frontmatter
       .entries.set('c1:public', { spec, fetchedAt: Date.now() });
     mockRequestUrl.mockResolvedValueOnce({ status: 200, json: [{ id: 'r1' }], headers: {} });
     const c = new SupabaseClient(cred, makeConfig(), new RateLimiter(), cache);
-    await c.batchUpdate([{ recordId: 'r1', fields: { data: '' } }]);
+    await c.batchUpdate([{ recordId: 'r1', fields: { data: 'user-edited object text' } }]);
     const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
-    expect(body[0].data).toBeNull();
+    expect(body[0]).not.toHaveProperty('data');
   });
 });
 

--- a/tests/services/supabase-field-mapper.test.ts
+++ b/tests/services/supabase-field-mapper.test.ts
@@ -64,6 +64,50 @@ describe('supabaseFieldMapper.isReadOnly', () => {
   });
 });
 
+describe('supabaseFieldMapper.isPushable', () => {
+  it('returns true for writable scalar and primitive-array types', () => {
+    for (const t of [
+      'string',
+      'string:uuid',
+      'string:date',
+      'string:date-time',
+      'integer',
+      'integer:int32',
+      'integer:int64',
+      'number',
+      'number:float',
+      'number:double',
+      'boolean',
+      'array:string',
+      'array:integer',
+      'array:number',
+      'array:boolean',
+    ]) {
+      expect(supabaseFieldMapper.isPushable(t)).toBe(true);
+    }
+  });
+
+  it('returns false for readonly variants', () => {
+    for (const t of ['string:readonly', 'integer:int64:readonly', 'array:string:readonly']) {
+      expect(supabaseFieldMapper.isPushable(t)).toBe(false);
+    }
+  });
+
+  it('returns false for object-shaped writable types', () => {
+    for (const t of ['object', 'array:object', 'string:json', 'string:jsonb']) {
+      expect(supabaseFieldMapper.isReadOnly(t)).toBe(false);
+      expect(supabaseFieldMapper.isPushable(t)).toBe(false);
+      expect(supabaseFieldMapper.isPushable(`${t}:readonly`)).toBe(false);
+    }
+  });
+
+  it('returns false for unknown standard types and prototype-chain names', () => {
+    for (const t of ['string:byte', 'totally-unknown-type', '', 'toString', 'constructor', 'hasOwnProperty']) {
+      expect(supabaseFieldMapper.isPushable(t)).toBe(false);
+    }
+  });
+});
+
 describe('supabaseFieldMapper.isFilenameSafe', () => {
   it('accepts string, integer, and uuid (with optional readonly)', () => {
     for (const t of [


### PR DESCRIPTION
## Summary
- Introduce `isPushable` — a `FieldTypeMapper` contract stricter than `!isReadOnly` — to keep object-shaped writable provider types (Airtable `barcode`/collaborators, SeaTable `collaborator`/`geolocation`, Supabase `json`/`jsonb`/`object`) out of push payloads
- Prevents a **data-loss bug**: a jsonb column with a `""` frontmatter placeholder was being overwritten with `null`; object-shaped columns are now dropped before upsert composition, preserving the remote value
- Fail-closed across all three providers (unknown types + prototype-chain names -> not pushable)
- Push consumers (`FrontmatterParser.extractSyncableFields`, `SupabaseClient.loadWritableColumns`) now gate on `isPushable` instead of `!isReadOnly`; removes the now-dead `json->null` coercion branch in `coerceForSupabase`

## Changes
- `types/field-types.types.ts`: add `isPushable` to the `FieldTypeMapper` interface
- `services/{airtable,seatable,supabase}-field-mapper.ts`: implement `isPushable` (reuses each mapper's existing `OBJECT_SHAPED_TYPES` set)
- `file-operations/frontmatter-parser.ts`, `services/supabase-client.ts`: gate push on `isPushable`
- tests: per-provider `isPushable` matrix (writable scalars / read-only / object-shaped / prototype-chain fail-closed) + frontmatter-parser integration

## Test plan
- [x] `npm run build` (tsc + esbuild)
- [x] `npm run lint`
- [x] `npm run test:run` — 778 unit tests passed
- Airtable E2E was run against a live base (`--cleanup`). The harness exits non-zero when any case is skipped (`run-e2e.mjs:1173`); 7 optional-fixture cases were skipped, so it exited 1. See the run log for the per-case breakdown; reviewers can re-run `npm run test:e2e:full`.
- Supabase E2E: env-blocked (test project unreachable).
- Live object-shaped push: deferred (see #107).

Closes #101
Follow-up: #107
