### PR TITLE
test: add cross-provider FieldTypeMapper parity contract

### DIFF
--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -8,6 +8,7 @@
  * @handbook 4.4-provider-abstraction
  * @handbook 7.3-read-only-field-protection
  * @tested tests/services/airtable-field-mapper.test.ts
+ * @tested tests/services/mapper-parity.test.ts
  */
 
 import type { FieldTypeMapper, StandardFieldType } from '../types';

--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -16,10 +16,10 @@ import type { FieldTypeMapper, StandardFieldType } from '../types';
 // value is server-computed) but still safe to use as a filename source
 // because the computed value is stable and typically text-like.
 const FILENAME_SAFE_TYPES = [
+  'formula',
+  'number',
   'singleLineText',
   'singleSelect',
-  'number',
-  'formula',
 ] as const;
 
 const READ_ONLY_TYPES = [

--- a/src/services/provider-registry.ts
+++ b/src/services/provider-registry.ts
@@ -11,6 +11,7 @@
  *
  * @handbook 4.4-provider-abstraction
  * @tested tests/services/provider-registry.test.ts
+ * @tested tests/services/mapper-parity.test.ts
  * @tested e2e:tests/e2e/run-seatable-e2e.mjs
  */
 

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -8,6 +8,7 @@
  * @handbook 4.4-provider-abstraction
  * @handbook 7.3-read-only-field-protection
  * @tested tests/services/seatable-field-mapper.test.ts
+ * @tested tests/services/mapper-parity.test.ts
  * @tested e2e:tests/e2e/run-seatable-e2e.mjs
  */
 

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -18,11 +18,11 @@ import type { FieldTypeMapper, StandardFieldType } from '../types';
 // `formula` appear here AND in READ_ONLY_TYPES below: they're great
 // stable identifiers but the sync pipeline must not push to them.
 const FILENAME_SAFE_TYPES = [
-  'text',
-  'single-select',
-  'number',
   'auto-number',
   'formula',
+  'number',
+  'single-select',
+  'text',
 ] as const;
 
 const READ_ONLY_TYPES = [

--- a/src/services/supabase-field-mapper.ts
+++ b/src/services/supabase-field-mapper.ts
@@ -9,6 +9,7 @@
  * @handbook 4.4-provider-abstraction
  * @handbook 7.3-read-only-field-protection
  * @tested tests/services/supabase-field-mapper.test.ts
+ * @tested tests/services/mapper-parity.test.ts
  */
 
 import type { FieldTypeMapper, StandardFieldType } from '../types';

--- a/src/types/field-types.types.ts
+++ b/src/types/field-types.types.ts
@@ -83,14 +83,16 @@ export interface FieldTypeMapper {
   isSubfolderSafe(providerType: string): boolean;
 
   /**
-   * Returns all known provider-specific types that pass `isFilenameSafe`.
-   * Enables UIs to enumerate the whitelist without guessing.
+   * Returns all known provider-specific types that pass `isFilenameSafe`,
+   * sorted and deduplicated. Enables UIs to enumerate the whitelist without
+   * guessing.
    */
   getFilenameSafeTypes(): readonly string[];
 
   /**
-   * Returns all known provider-specific types that pass `isSubfolderSafe`.
-   * Used by settings-tab to filter the subfolder field dropdown.
+   * Returns all known provider-specific types that pass `isSubfolderSafe`,
+   * sorted and deduplicated. Used by settings-tab to filter the subfolder
+   * field dropdown.
    */
   getSubfolderSafeTypes(): readonly string[];
 

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -294,10 +294,10 @@ describe('airtableFieldMapper', () => {
     it('should return exactly the 4 filename-safe types', () => {
       const types = airtableFieldMapper.getFilenameSafeTypes();
       expect(types).toEqual([
+        'formula',
+        'number',
         'singleLineText',
         'singleSelect',
-        'number',
-        'formula',
       ]);
     });
 

--- a/tests/services/mapper-parity.test.ts
+++ b/tests/services/mapper-parity.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Cross-provider FieldTypeMapper contract tests.
+ * @covers src/services/provider-registry.ts
+ * @covers src/services/airtable-field-mapper.ts
+ * @covers src/services/seatable-field-mapper.ts
+ * @covers src/services/supabase-field-mapper.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CREDENTIAL_TYPES,
+  type CredentialType,
+  type FieldTypeMapper,
+  type StandardFieldType,
+} from '../../src/types';
+import {
+  getFieldTypeMapper,
+  hasFieldTypeMapper,
+} from '../../src/services/provider-registry';
+
+const PROTOTYPE_CHAIN_NAMES = [
+  'toString',
+  'constructor',
+  'hasOwnProperty',
+  'valueOf',
+  '__proto__',
+] as const;
+
+const UNSAFE_SUBFOLDER_STANDARD_TYPES: ReadonlySet<StandardFieldType> = new Set([
+  'attachment',
+  'link',
+  'unknown',
+]);
+
+type MapperCase = {
+  type: CredentialType;
+  mapper: FieldTypeMapper;
+};
+
+function getRegisteredMapperCases(): MapperCase[] {
+  return CREDENTIAL_TYPES
+    .filter(hasFieldTypeMapper)
+    .map(type => ({
+      type,
+      mapper: getFieldTypeMapper(type),
+    }));
+}
+
+function expectSortedUnique(provider: CredentialType, method: string, types: readonly string[]): void {
+  expect(
+    [...types],
+    `${provider}.${method}() should be sorted`,
+  ).toEqual([...types].sort());
+  expect(
+    new Set(types).size,
+    `${provider}.${method}() should not contain duplicates`,
+  ).toBe(types.length);
+}
+
+function assertFieldTypeMapperContract(provider: CredentialType, mapper: FieldTypeMapper): void {
+  for (const type of mapper.getFilenameSafeTypes()) {
+    expect(
+      mapper.isSubfolderSafe(type),
+      `${provider}: filename-safe type "${type}" must also be subfolder-safe`,
+    ).toBe(true);
+  }
+
+  for (const type of mapper.getSubfolderSafeTypes()) {
+    const standardType = mapper.mapToStandardType(type);
+    expect(
+      UNSAFE_SUBFOLDER_STANDARD_TYPES.has(standardType),
+      `${provider}: subfolder-safe type "${type}" maps to unsafe standard type "${standardType}"`,
+    ).toBe(false);
+  }
+
+  for (const type of PROTOTYPE_CHAIN_NAMES) {
+    expect(
+      mapper.isReadOnly(type),
+      `${provider}: inherited name "${type}" must fail closed as read-only`,
+    ).toBe(true);
+    expect(
+      mapper.isFilenameSafe(type),
+      `${provider}: inherited name "${type}" must not be filename-safe`,
+    ).toBe(false);
+    expect(
+      mapper.isSubfolderSafe(type),
+      `${provider}: inherited name "${type}" must not be subfolder-safe`,
+    ).toBe(false);
+  }
+
+  expectSortedUnique(provider, 'getFilenameSafeTypes', mapper.getFilenameSafeTypes());
+  expectSortedUnique(provider, 'getSubfolderSafeTypes', mapper.getSubfolderSafeTypes());
+}
+
+describe('FieldTypeMapper parity', () => {
+  const mapperCases = getRegisteredMapperCases();
+
+  it('discovers all production mappers registered in provider-registry', () => {
+    expect(mapperCases.map(c => c.type)).toEqual(expect.arrayContaining([
+      'airtable',
+      'seatable',
+      'supabase',
+    ]));
+  });
+
+  it.each(mapperCases)('enforces shared mapper contract for $type', ({ type, mapper }) => {
+    assertFieldTypeMapperContract(type, mapper);
+  });
+});

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -252,11 +252,11 @@ describe('seatableFieldMapper', () => {
     it('should return exactly the 5 filename-safe types', () => {
       const types = seatableFieldMapper.getFilenameSafeTypes();
       expect(types).toEqual([
-        'text',
-        'single-select',
-        'number',
         'auto-number',
         'formula',
+        'number',
+        'single-select',
+        'text',
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Add `tests/services/mapper-parity.test.ts` — a registry-driven cross-provider contract that, for every registered `FieldTypeMapper`, asserts: filename-safe ⊆ subfolder-safe, no subfolder-safe type maps to `attachment`/`link`/`unknown`, prototype-chain names fail closed, and both enumerations are sorted + unique. Auto-extends to future providers (Notion #11) the moment they register a mapper.
- Sort `FILENAME_SAFE_TYPES` in the Airtable and SeaTable mappers for deterministic output (display-only; membership is via `.includes()`, so order carries no logic).
- Wire bidirectional `@tested` markers from the 3 mappers + `provider-registry` to the new parity test.

## Test plan
- [x] `npm run test:run` — 783 tests pass (incl. 4 new parity tests)
- [x] `npm run build` / `typecheck` / `lint` — clean
- [x] E2E — Airtable (15 passed / 0 failed) + SeaTable (14/14) green on this build; Supabase suite blocked by an unreachable e2e project (infra, unrelated)

Closes #103