### PR TITLE
feat: cache last-verified-at to skip redundant verifySetup probe

### DIFF
--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -7,6 +7,7 @@
  *
  * @handbook 5.1-ui-components
  * @handbook 4.4-provider-abstraction
+ * @tested tests/ui/settings-tab-verification-cache.test.ts
  * @tested e2e:tests/e2e/run-settings-e2e.mjs
  * @tested e2e:tests/e2e/run-seatable-settings-e2e.mjs
  * @tested e2e:tests/e2e/run-supabase-settings-e2e.mjs
@@ -45,16 +46,18 @@ export interface SettingsPlugin extends Plugin {
 /**
  * Transient UI state for the credential add/edit form. Tracks whether
  * the active form has a pending setup requirement (e.g. Supabase RPC
- * not installed), references to the banner host element and Save button,
- * in-flight guards to prevent concurrent click races, and a cleanups
- * array for any event listeners that must be detached when the form is
- * disposed or re-rendered (prevents listener accumulation across
- * type-switches and re-displays). Owned by the settings tab; reset via
- * resetCredentialFormUi() when a credential form opens, and torn down
- * (cleanups invoked) by display().
+ * not installed), the recent successful setup verification fingerprint,
+ * references to the banner host element and Save button, in-flight guards
+ * to prevent concurrent click races, and a cleanups array for any event
+ * listeners that must be detached when the form is disposed or re-rendered
+ * (prevents listener accumulation across type-switches and re-displays).
+ * Owned by the settings tab; reset via resetCredentialFormUi() when a
+ * credential form opens, and torn down (cleanups invoked) by display().
  */
 interface CredentialFormUiState {
   setupRequirement: SetupRequirement | null;
+  lastVerifiedAt: number | null;
+  lastVerifiedFingerprint: string | null;
   bannerHost: HTMLElement | null;
   saveButton: HTMLButtonElement | null;
   testButton: HTMLButtonElement | null;
@@ -67,6 +70,8 @@ interface CredentialFormUiState {
  * Settings tab for the Auto Note Importer plugin.
  */
 export class AutoNoteImporterSettingTab extends PluginSettingTab {
+  private static readonly SETUP_VERIFICATION_FRESH_MS = 60_000;
+
   plugin: SettingsPlugin;
   private fieldCache: FieldCache;
   private seatableMetadataCache: SeaTableMetadataCache;
@@ -389,6 +394,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // type-switches (which re-call renderCredentialAddDetails on the
     // same containerEl) would accumulate listeners.
     const inputResetHandler = (): void => {
+      this.invalidateCredentialFormVerification();
       if (this.credentialFormUi?.setupRequirement) {
         this.clearFormSetupRequirement();
       }
@@ -523,6 +529,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // type-switches (which re-call renderCredentialAddDetails on the
     // same containerEl) would accumulate listeners.
     const inputResetHandler = (): void => {
+      this.invalidateCredentialFormVerification();
       if (this.credentialFormUi?.setupRequirement) {
         this.clearFormSetupRequirement();
       }
@@ -599,10 +606,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     try {
       const result = await renderer.testConnection(credential);
       if (!result.success) {
+        this.invalidateCredentialFormVerification();
         new Notice(`Auto Note Importer: Connection failed \u2014 ${result.error}`);
         return;
       }
       if (result.needsSetup) {
+        this.invalidateCredentialFormVerification();
         // Suppress the "Connection OK" Notice \u2014 the inline banner is the
         // contextual surface. Render banner inside form host, disable
         // Save until verify succeeds.
@@ -615,9 +624,11 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       if (this.credentialFormUi?.setupRequirement) {
         this.clearFormSetupRequirement();
       }
+      this.markCredentialVerified(credential);
       const detail = result.detail ? ` ${result.detail}` : '';
       new Notice(`Auto Note Importer: Connection OK.${detail}`);
     } catch (error) {
+      this.invalidateCredentialFormVerification();
       const message = error instanceof Error ? error.message : 'Unknown error';
       new Notice(`Auto Note Importer: Connection test errored \u2014 ${message}`);
     } finally {
@@ -1301,6 +1312,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       banner,
       credential,
       () => {
+        this.markCredentialVerified(credential);
         new Notice('Auto Note Importer: Setup confirmed — you can save now.');
         onSuccess();   // clearFormSetupRequirement removes the host (covers banner)
       },
@@ -1347,6 +1359,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     this.tearDownCredentialFormUi();
     this.credentialFormUi = {
       setupRequirement: null,
+      lastVerifiedAt: null,
+      lastVerifiedFingerprint: null,
       bannerHost: null,
       saveButton: null,
       testButton: null,
@@ -1419,6 +1433,12 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     formHostEl: HTMLElement,
   ): Promise<'proceed' | 'blocked'> {
     if (!renderer.verifySetup) return 'proceed';
+    if (this.hasRecentCredentialVerification(credential)) {
+      if (this.credentialFormUi?.setupRequirement) {
+        this.clearFormSetupRequirement();
+      }
+      return 'proceed';
+    }
     if (this.credentialFormUi?.isSaving) return 'blocked';   // re-entry guard
     if (this.credentialFormUi) this.credentialFormUi.isSaving = true;
 
@@ -1437,13 +1457,16 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     try {
       const result = await renderer.verifySetup(credential);
       if (!result.success) {
+        this.invalidateCredentialFormVerification();
         new Notice(`Auto Note Importer: Could not verify setup before save — ${result.error}`);
         return 'blocked';
       }
       if (result.needsSetup) {
+        this.invalidateCredentialFormVerification();
         this.renderSetupBannerForRequirement(result.needsSetup, credential, formHostEl);
         return 'blocked';
       }
+      this.markCredentialVerified(credential);
       // Save-time verify can also clear a stale banner — e.g. user
       // installed the RPC externally then clicked Save without Verify
       // first (Codex P2, PR #92).
@@ -1452,6 +1475,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       }
       return 'proceed';
     } catch (error) {
+      this.invalidateCredentialFormVerification();
       const message = error instanceof Error ? error.message : 'Unknown error';
       new Notice(`Auto Note Importer: Could not verify setup before save — ${message}`);
       return 'blocked';
@@ -1468,6 +1492,60 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         saveBtn.textContent = originalSaveText ?? 'Save';
       }
     }
+  }
+
+  private hasRecentCredentialVerification(credential: Credential): boolean {
+    if (!this.credentialFormUi?.lastVerifiedAt || !this.credentialFormUi.lastVerifiedFingerprint) {
+      return false;
+    }
+    const ageMs = Date.now() - this.credentialFormUi.lastVerifiedAt;
+    return (
+      ageMs >= 0 &&
+      ageMs <= AutoNoteImporterSettingTab.SETUP_VERIFICATION_FRESH_MS &&
+      this.credentialFormUi.lastVerifiedFingerprint === this.getCredentialVerificationFingerprint(credential)
+    );
+  }
+
+  private markCredentialVerified(credential: Credential): void {
+    if (!this.credentialFormUi) return;
+    this.credentialFormUi.lastVerifiedAt = Date.now();
+    this.credentialFormUi.lastVerifiedFingerprint = this.getCredentialVerificationFingerprint(credential);
+  }
+
+  private invalidateCredentialFormVerification(): void {
+    if (!this.credentialFormUi) return;
+    this.credentialFormUi.lastVerifiedAt = null;
+    this.credentialFormUi.lastVerifiedFingerprint = null;
+  }
+
+  private getCredentialVerificationFingerprint(credential: Credential): string {
+    const parts = (() => {
+      switch (credential.type) {
+        case 'airtable':
+          return [credential.type, credential.apiKey];
+        case 'seatable':
+          return [credential.type, credential.serverUrl, credential.apiToken];
+        case 'supabase':
+          return [credential.type, credential.projectUrl, credential.apiKey];
+        case 'notion':
+          return [credential.type, credential.integrationToken];
+        case 'custom-api':
+          return [credential.type, credential.baseUrl, credential.authHeader, credential.authValue];
+        default: {
+          const _exhaustive: never = credential;
+          return [_exhaustive];
+        }
+      }
+    })();
+    return AutoNoteImporterSettingTab.hashCredentialFingerprint(parts.map(p => p.trim()).join('\0'));
+  }
+
+  private static hashCredentialFingerprint(value: string): string {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+      hash = (hash * 31 + value.charCodeAt(i)) % 2147483647;
+    }
+    return hash.toString(36);
   }
 
   /**

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1533,7 +1533,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           return [credential.type, credential.baseUrl, credential.authHeader, credential.authValue];
         default: {
           const _exhaustive: never = credential;
-          return [_exhaustive];
+          throw new Error(`Unknown credential type: ${String(_exhaustive)}`);
         }
       }
     })();

--- a/tests/__mocks__/obsidian.mock.ts
+++ b/tests/__mocks__/obsidian.mock.ts
@@ -16,6 +16,120 @@ export const MarkdownView = vi.fn();
 
 export const requestUrl = vi.fn();
 
+export const setIcon = vi.fn();
+
+export class PluginSettingTab {
+  app: unknown;
+  plugin: unknown;
+  containerEl: unknown;
+
+  constructor(app: unknown, plugin: unknown) {
+    this.app = app;
+    this.plugin = plugin;
+    this.containerEl = {};
+  }
+
+  display(): void {}
+}
+
+export class Setting {
+  settingEl = {
+    addClass: vi.fn(),
+  };
+
+  constructor(_containerEl?: unknown) {}
+
+  setName(): this { return this; }
+  setDesc(): this { return this; }
+  setClass(): this { return this; }
+
+  addButton(callback: (button: {
+    buttonEl: { disabled: boolean; textContent: string | null };
+    setButtonText: (text: string) => unknown;
+    setCta: () => unknown;
+    setDisabled: (disabled: boolean) => unknown;
+    onClick: (handler: () => unknown) => unknown;
+  }) => unknown): this {
+    const button = {
+      buttonEl: { disabled: false, textContent: null },
+      setButtonText(text: string) {
+        this.buttonEl.textContent = text;
+        return this;
+      },
+      setCta() { return this; },
+      setDisabled(disabled: boolean) {
+        this.buttonEl.disabled = disabled;
+        return this;
+      },
+      onClick(_handler: () => unknown) { return this; },
+    };
+    callback(button);
+    return this;
+  }
+
+  addText(callback: (text: {
+    inputEl: unknown;
+    setValue: (value: string) => unknown;
+    setPlaceholder: (value: string) => unknown;
+    onChange: (handler: (value: string) => unknown) => unknown;
+  }) => unknown): this {
+    const text = {
+      inputEl: {},
+      setValue(_value: string) { return this; },
+      setPlaceholder(_value: string) { return this; },
+      onChange(_handler: (value: string) => unknown) { return this; },
+    };
+    callback(text);
+    return this;
+  }
+
+  addDropdown(callback: (dropdown: {
+    addOption: (value: string, label: string) => unknown;
+    setValue: (value: string) => unknown;
+    onChange: (handler: (value: string) => unknown) => unknown;
+  }) => unknown): this {
+    const dropdown = {
+      addOption(_value: string, _label: string) { return this; },
+      setValue(_value: string) { return this; },
+      onChange(_handler: (value: string) => unknown) { return this; },
+    };
+    callback(dropdown);
+    return this;
+  }
+
+  addToggle(callback: (toggle: {
+    setValue: (value: boolean) => unknown;
+    onChange: (handler: (value: boolean) => unknown) => unknown;
+  }) => unknown): this {
+    const toggle = {
+      setValue(_value: boolean) { return this; },
+      onChange(_handler: (value: boolean) => unknown) { return this; },
+    };
+    callback(toggle);
+    return this;
+  }
+
+  addExtraButton(callback: (button: unknown) => unknown): this {
+    callback({});
+    return this;
+  }
+}
+
+export class AbstractInputSuggest<T> {
+  app: unknown;
+  inputEl: unknown;
+
+  constructor(app: unknown, inputEl: unknown) {
+    this.app = app;
+    this.inputEl = inputEl;
+  }
+
+  getSuggestions(_query: string): T[] { return []; }
+  renderSuggestion(_value: T, _el: HTMLElement): void {}
+  selectSuggestion(_value: T): void {}
+  close(): void {}
+}
+
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/$/, '');
 }

--- a/tests/ui/settings-tab-verification-cache.test.ts
+++ b/tests/ui/settings-tab-verification-cache.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @covers src/ui/settings-tab.ts
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CredentialFormRenderer, SupabaseCredential } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/types';
+import { AutoNoteImporterSettingTab } from '../../src/ui/settings-tab';
+import { FieldCache, SeaTableMetadataCache, SupabaseMetadataCache } from '../../src/services';
+
+type TestableSettingsTab = {
+  resetCredentialFormUi(): void;
+  runConnectionTest(
+    renderer: CredentialFormRenderer,
+    credential: SupabaseCredential,
+    formHostEl: HTMLElement,
+  ): Promise<void>;
+  verifyCredentialBeforeSave(
+    renderer: CredentialFormRenderer,
+    credential: SupabaseCredential,
+    formHostEl: HTMLElement,
+  ): Promise<'proceed' | 'blocked'>;
+  invalidateCredentialFormVerification(): void;
+};
+
+function createTab(): TestableSettingsTab {
+  const plugin = {
+    settings: { ...DEFAULT_SETTINGS },
+    saveSettings: vi.fn(),
+  };
+  const tab = new AutoNoteImporterSettingTab(
+    {} as never,
+    plugin as never,
+    new FieldCache(),
+    new SeaTableMetadataCache(),
+    new SupabaseMetadataCache(),
+  ) as unknown as TestableSettingsTab;
+  tab.resetCredentialFormUi();
+  return tab;
+}
+
+function createRenderer(): CredentialFormRenderer {
+  return {
+    type: 'supabase',
+    label: 'Supabase',
+    renderFields: vi.fn(),
+    build: vi.fn(),
+    testConnection: vi.fn().mockResolvedValue({ success: true }),
+    verifySetup: vi.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+function createCredential(overrides: Partial<SupabaseCredential> = {}): SupabaseCredential {
+  return {
+    id: 'cred-1',
+    name: 'Supabase',
+    type: 'supabase',
+    projectUrl: ' https://example.supabase.co ',
+    apiKey: ' publishable-key ',
+    ...overrides,
+  };
+}
+
+function mockNow(value: number): { advance(ms: number): void } {
+  let now = value;
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
+  return {
+    advance(ms: number): void {
+      now += ms;
+    },
+  };
+}
+
+describe('settings-tab setup verification freshness cache', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips save-time verifySetup after successful Test within the freshness window', async () => {
+    mockNow(1_000);
+    const tab = createTab();
+    const renderer = createRenderer();
+
+    await tab.runConnectionTest(renderer, createCredential(), {} as HTMLElement);
+    const gate = await tab.verifyCredentialBeforeSave(
+      renderer,
+      createCredential({ projectUrl: 'https://example.supabase.co', apiKey: 'publishable-key' }),
+      {} as HTMLElement,
+    );
+
+    expect(gate).toBe('proceed');
+    expect(renderer.testConnection).toHaveBeenCalledTimes(1);
+    expect(renderer.verifySetup).not.toHaveBeenCalled();
+  });
+
+  it('runs save-time verifySetup after the freshness window expires', async () => {
+    const clock = mockNow(1_000);
+    const tab = createTab();
+    const renderer = createRenderer();
+
+    await tab.runConnectionTest(renderer, createCredential(), {} as HTMLElement);
+    clock.advance(60_001);
+    const gate = await tab.verifyCredentialBeforeSave(renderer, createCredential(), {} as HTMLElement);
+
+    expect(gate).toBe('proceed');
+    expect(renderer.testConnection).toHaveBeenCalledTimes(1);
+    expect(renderer.verifySetup).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs save-time verifySetup when credential fingerprint changes', async () => {
+    mockNow(1_000);
+    const tab = createTab();
+    const renderer = createRenderer();
+
+    await tab.runConnectionTest(renderer, createCredential(), {} as HTMLElement);
+    const gate = await tab.verifyCredentialBeforeSave(
+      renderer,
+      createCredential({ apiKey: 'changed-key' }),
+      {} as HTMLElement,
+    );
+
+    expect(gate).toBe('proceed');
+    expect(renderer.verifySetup).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs save-time verifySetup after field-edit invalidation', async () => {
+    mockNow(1_000);
+    const tab = createTab();
+    const renderer = createRenderer();
+
+    await tab.runConnectionTest(renderer, createCredential(), {} as HTMLElement);
+    tab.invalidateCredentialFormVerification();
+    const gate = await tab.verifyCredentialBeforeSave(renderer, createCredential(), {} as HTMLElement);
+
+    expect(gate).toBe('proceed');
+    expect(renderer.testConnection).toHaveBeenCalledTimes(1);
+    expect(renderer.verifySetup).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Cache a 60s freshness fingerprint (`lastVerifiedAt` + a secret-field `lastVerifiedFingerprint`) on the credential form so a successful Test / Verify lets the next Save skip the redundant `verifySetup` probe. Supabase is the only provider that implements `verifySetup`, so it's the only one materially affected.
- Invalidate on every field edit, probe failure, and `needsSetup` — and the fingerprint changes whenever a secret does — so a changed or bad credential can never ride a stale "verified" result past the save gate. The cache is safe because `testConnection` and `verifySetup` share the same probe (symmetric by construction).
- Add `tests/ui/settings-tab-verification-cache.test.ts` (in-window skip, out-of-window re-probe, fingerprint-change re-probe, field-edit invalidation) + `obsidian.mock.ts` test infra.

## Test plan
- [x] `npm run test:run` — 787 tests pass (incl. 4 new cache tests)
- [x] `npm run build` / `typecheck` / `lint` — clean
- [x] E2E — Airtable (15 passed / 0 failed) + SeaTable (14/14) green on this build; Supabase suite blocked by an unreachable e2e project (infra, unrelated). The Supabase-only verify-cache path is covered by the 4 unit tests.

Closes #93