### PR TITLE
refactor: unify exhaustiveness guards behind assertNever helper

### DIFF
--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -7,7 +7,7 @@
  */
 
 import { Notice } from "obsidian";
-import { areValuesEqual } from '../utils';
+import { areValuesEqual, assertNever } from '../utils';
 import type { LegacySettings, ConflictInfo, SyncResult, DatabaseProvider } from '../types';
 
 /**
@@ -80,10 +80,8 @@ export class ConflictResolver {
       case 'manual':
         return this.resolveManual(conflicts, recordId);
 
-      default: {
-        const _exhaustive: never = this.settings.conflictResolution;
-        throw new Error(`Unknown conflict resolution mode: ${_exhaustive}`);
-      }
+      default:
+        return assertNever(this.settings.conflictResolution, 'Unknown conflict resolution mode');
     }
   }
 

--- a/src/core/sync-orchestrator.ts
+++ b/src/core/sync-orchestrator.ts
@@ -22,7 +22,7 @@ import { FieldCache } from '../services';
 import { ConflictResolver } from './conflict-resolver';
 import { FrontmatterParser, FileWatcher } from '../file-operations';
 import { parseTemplate, buildMarkdownContent, generateBasesContent, resolveBasesFilePath, collectFieldNames } from '../builders';
-import { sanitizeFileName, sanitizeSubfolderValue, validateAndSanitizeFilename } from '../utils';
+import { sanitizeFileName, sanitizeSubfolderValue, validateAndSanitizeFilename, assertNever } from '../utils';
 
 export interface StatusBarHandle {
   setText(text: string): void;
@@ -126,10 +126,8 @@ export class SyncOrchestrator {
           break;
         }
 
-        default: {
-          const _exhaustive: never = mode;
-          throw new Error(`Unknown sync mode: ${_exhaustive}`);
-        }
+        default:
+          assertNever(mode, 'Unknown sync mode');
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -166,10 +164,8 @@ export class SyncOrchestrator {
         return this.collectMarkdownFiles(folder);
       }
 
-      default: {
-        const _exhaustive: never = scope;
-        throw new Error(`Unknown sync scope: ${_exhaustive}`);
-      }
+      default:
+        return assertNever(scope, 'Unknown sync scope');
     }
   }
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -34,6 +34,7 @@ import { FolderSuggest, FileSuggest } from './suggest';
 import { generateId } from '../utils/object-utils';
 import { validateFolderPath } from '../utils/validation';
 import { debounce } from '../utils/debounce';
+import { assertNever } from '../utils/assert';
 
 /**
  * Interface for the plugin that the settings tab needs.
@@ -1410,10 +1411,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         }
         return;
       }
-      default: {
-        const _exhaustive: never = needsSetup.kind;
-        throw new Error(`Unhandled setup requirement kind: ${String(_exhaustive)}`);
-      }
+      default:
+        return assertNever(needsSetup.kind, 'Unhandled setup requirement kind');
     }
   }
 
@@ -1531,10 +1530,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           return [credential.type, credential.integrationToken];
         case 'custom-api':
           return [credential.type, credential.baseUrl, credential.authHeader, credential.authValue];
-        default: {
-          const _exhaustive: never = credential;
-          throw new Error(`Unknown credential type: ${String(_exhaustive)}`);
-        }
+        default:
+          return assertNever(credential, 'Unknown credential type');
       }
     })();
     return AutoNoteImporterSettingTab.hashCredentialFingerprint(parts.map(p => p.trim()).join('\0'));

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,17 @@
+/**
+ * Compile-time exhaustiveness assertion.
+ *
+ * Call in a `switch` / `if` default branch where every case is handled: the
+ * argument narrows to `never`, so a later union extension that misses a case
+ * fails to compile at the call site. Throws at runtime as a defensive net for
+ * the (statically unreachable) bypass.
+ *
+ * For branches that must NOT throw — a fail-closed UI fallback, a defensive
+ * migration skip — use `x satisfies never` plus the fallback instead (§6.3).
+ *
+ * @handbook 6.3-exhaustive-switch
+ * @tested tests/utils/assert.test.ts
+ */
+export function assertNever(value: never, label = 'Unhandled exhaustiveness case'): never {
+  throw new Error(`${label}: ${String(value)}`);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,4 +34,6 @@ export {
 
 export { debounce } from './debounce';
 
+export { assertNever } from './assert';
+
 export { migrateSettings, hydrateConfigDefaults } from './migration';

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -155,7 +155,8 @@ function buildCredentialFromRecord(raw: Record<string, unknown>): Credential | u
   }
 
   const base = { id, name: readString(raw, 'name', '') };
-  switch (type as CredentialType) {
+  const credType = type as CredentialType;
+  switch (credType) {
     case 'airtable':
       return { ...base, type: 'airtable', apiKey: readString(raw, 'apiKey', '') };
     case 'seatable':
@@ -180,9 +181,11 @@ function buildCredentialFromRecord(raw: Record<string, unknown>): Credential | u
         authValue: readString(raw, 'authValue', ''),
       };
     default: {
-      // Compile-time exhaustiveness guard — unreachable at runtime (CREDENTIAL_TYPES.includes guards above).
-      const _exhaustive: never = type as never;
-      void _exhaustive;
+      // Real compile-time exhaustiveness guard: credType narrows to never once
+      // every CredentialType has a case. Returns undefined (not throw) so a
+      // malformed legacy setting is skipped rather than fatal — the
+      // CREDENTIAL_TYPES.includes() check above already gates the runtime path.
+      credType satisfies never;
       return undefined;
     }
   }

--- a/tests/utils/assert.test.ts
+++ b/tests/utils/assert.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the assertNever exhaustiveness helper.
+ * @covers src/utils/assert.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertNever } from '../../src/utils/assert';
+
+describe('assertNever', () => {
+  it('throws with the default label and the offending value', () => {
+    expect(() => assertNever('archived' as never)).toThrow(
+      'Unhandled exhaustiveness case: archived',
+    );
+  });
+
+  it('throws with a custom label', () => {
+    expect(() => assertNever('archived' as never, 'Unknown sync scope')).toThrow(
+      'Unknown sync scope: archived',
+    );
+  });
+
+  it('stringifies non-string values', () => {
+    expect(() => assertNever(42 as never)).toThrow('Unhandled exhaustiveness case: 42');
+    expect(() => assertNever({ k: 1 } as never)).toThrow(
+      'Unhandled exhaustiveness case: [object Object]',
+    );
+  });
+
+  it('has a never return type usable in a typed default branch', () => {
+    // Compile-time contract: a fully-handled union narrows to never in the
+    // default branch, so assertNever(x) type-checks. A missing case would
+    // make x a real type and fail to compile here.
+    type Scope = 'a' | 'b';
+    const classify = (s: Scope): number => {
+      switch (s) {
+        case 'a':
+          return 1;
+        case 'b':
+          return 2;
+        default:
+          return assertNever(s);
+      }
+    };
+    expect(classify('a')).toBe(1);
+    expect(classify('b')).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/utils/assert.ts` — a shared `assertNever(value: never, label?)` helper whose `never` parameter enforces switch/if exhaustiveness at compile time (a case missed after a union extension fails to compile) and throws at runtime.
- Route the 5 throwing exhaustiveness guards (sync mode/scope, conflict mode, setup-requirement kind, credential type) through it, preserving each error message.
- Upgrade `migration.ts`'s fake `type as never` guard to a real `credType satisfies never` one — it now actually catches a missing case at compile time, while keeping its non-throwing `return undefined` fallback for malformed legacy settings.
- Leave `settings-tab.ts`'s `filterMode satisfies never` (non-throwing, fail-closed) as the other documented form.

## Test plan
- [x] `npm run typecheck` — clean (proves the `never` narrowing holds at every migrated site, i.e. every switch is genuinely exhaustive)
- [x] `npm run build` / `npm run lint` — clean
- [x] `npm run test:run` — 791 tests pass (incl. 4 new `assertNever` tests)
- [ ] E2E — n/a: the change is confined to statically-unreachable `default` branches plus a throw-only helper, so there is zero reachable runtime behavior change for E2E to exercise.

Closes #110