### PR TITLE
fix: use createDiv shorthand in suggest renderers

### DIFF
--- a/src/ui/suggest/file-suggest.ts
+++ b/src/ui/suggest/file-suggest.ts
@@ -27,7 +27,7 @@ export class FileSuggest extends AbstractInputSuggest<string> {
   }
 
   public override renderSuggestion(path: string, el: HTMLElement): void {
-    el.createEl("div", { text: path });
+    el.createDiv({ text: path });
   }
 
   public override selectSuggestion(path: string): void {

--- a/src/ui/suggest/folder-suggest.ts
+++ b/src/ui/suggest/folder-suggest.ts
@@ -27,7 +27,7 @@ export class FolderSuggest extends AbstractInputSuggest<string> {
   }
 
   public override renderSuggestion(path: string, el: HTMLElement): void {
-    el.createEl("div", { text: path });
+    el.createDiv({ text: path });
   }
 
   public override selectSuggestion(path: string): void {


### PR DESCRIPTION
## Summary

- Clears the 2 `obsidianmd/prefer-create-el` warnings the community directory scanner reported after #115 was merged
- `el.createEl("div", { text })` → `el.createDiv({ text })` in both suggest renderers
- Verified by reproducing the scanner locally (eslint 9 + `eslint-plugin-obsidianmd` 0.4.1 against the repo's `manifest.json` + obsidian 1.13.1 typings): `prefer-create-el` goes 2 → 0

## Note on the reported message

The scan output quoted in #114 reads *"Uses `document.createElement` instead of Obsidian's `createEl` helpers"* — that is the rule's **description**, not the finding. The actual message is:

```
Use 'el.createDiv({ text: path })' instead of 'el.createEl("div", { text: path })'
```

There is no `document.createElement` anywhere in `src/`. The rule maps `div` → `createDiv` and `span` → `createSpan` and flags the generic `createEl` form for those two tags.

## Test plan

- [x] `npm run build` — tsc + esbuild, exit 0
- [x] `npm run lint` — exit 0
- [x] `npm run test:run` — 800/800
- [x] Local scanner reproduction — `obsidianmd/prefer-create-el`: 2 → 0

Related: #114 (the remaining `prefer-setting-definitions` warning is tracked there)