### PR TITLE
feat: adopt declarative settings definitions for Obsidian 1.13

### DIFF
--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -9,6 +9,7 @@
  * @handbook 4.4-provider-abstraction
  * @tested tests/ui/settings-tab-verification-cache.test.ts
  * @tested tests/ui/settings-tab-handlers.test.ts
+ * @tested tests/ui/settings-tab-definitions.test.ts
  * @tested e2e:tests/e2e/run-settings-e2e.mjs
  * @tested e2e:tests/e2e/run-seatable-settings-e2e.mjs
  * @tested e2e:tests/e2e/run-supabase-settings-e2e.mjs

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -130,12 +130,36 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     return this.plugin.settings.credentials.find(c => c.id === config.credentialId);
   }
 
+  /**
+   * Re-render the tab through whichever path the host is actually using.
+   *
+   * Every interaction handler must go through here, never `display()`
+   * directly: on Obsidian >= 1.13 the tab is rendered from
+   * `getSettingDefinitions()`, and calling `display()` would `empty()` the
+   * container the host owns and repaint the imperative tree outside the
+   * settings-definition lifecycle — the declarative structure would survive
+   * only until the user's first click.
+   *
+   * `update()` re-reads the definitions and repaints; it does not exist
+   * before 1.13, where `display()` is the real render path.
+   */
+  private requestRerender(): void {
+    const update = (this as { update?: () => void }).update;
+    if (typeof update === 'function') {
+      update.call(this);
+      return;
+    }
+    // The pre-1.13 render path. This is the one place display() may still
+    // be called directly — everywhere else must route through here.
+    this.display();
+  }
+
   private debounceDisplay(delay = 100): void {
     if (this.debounceTimer) {
       window.clearTimeout(this.debounceTimer);
     }
     this.debounceTimer = window.setTimeout(() => {
-      this.display();
+      this.requestRerender();
     }, delay);
   }
 
@@ -210,6 +234,8 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           name: 'Debug logging',
           desc: 'Verbose sync logging to the developer console.',
           aliases: ['debug', 'log', 'console'],
+          // No cleanup returned: this section registers no listeners
+          // outside the host DOM, which the next render empties anyway.
           render: (setting) => {
             this.renderDebugSettings(this.claimSettingHost(setting));
           },
@@ -221,6 +247,9 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           name: 'Sync configurations',
           desc: 'Per-configuration connection, file, Bases, and bidirectional sync settings.',
           aliases: ['config', 'sync', 'folder', 'template', 'bases', 'bidirectional', 'conflict'],
+          // No cleanup returned: same as Debug — nothing outlives the host
+          // DOM. Only the credential form registers listeners that need an
+          // explicit tear-down.
           render: (setting) => {
             const host = this.claimSettingHost(setting);
             this.renderTabBar(host);
@@ -236,9 +265,14 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
               return;
             }
 
-            // Async connection cards capture this generation and bail if it
-            // moved, so bump it here exactly as display() does — a declarative
-            // re-render must invalidate the previous render's in-flight fetch.
+            // Async connection cards capture this generation and bail if
+            // it moved, so a declarative re-render must invalidate the
+            // previous render's in-flight fetch. Bumped here rather than in
+            // getSettingDefinitions() because only the render callback runs
+            // on an actual render — the definitions are also built for
+            // search indexing alone. Narrower than display()'s
+            // unconditional bump, which is fine: every async card lives
+            // inside renderConfigCardStack, below this guard.
             this.renderGeneration++;
             this.renderConfigHeader(host, config);
             this.renderConfigCardStack(host, config, credential);
@@ -407,7 +441,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       const addBtn = addContainer.createEl('button', { text: '+ Add credential' });
       addBtn.addEventListener('click', () => {
         this.addingCredential = true;
-        this.display();
+        this.requestRerender();
       });
     }
   }
@@ -433,7 +467,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       const setLink = keyCell.createSpan({ cls: 'ani-cred-key-set', text: 'Set credential' });
       setLink.addEventListener('click', () => {
         this.editingCredentialId = cred.id;
-        this.display();
+        this.requestRerender();
       });
     } else {
       keyCell.createSpan({ cls: 'ani-cred-key-na', text: '\u2014' });
@@ -446,7 +480,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     editBtn.title = 'Edit credential';
     editBtn.addEventListener('click', () => {
       this.editingCredentialId = cred.id;
-      this.display();
+      this.requestRerender();
     });
 
     const isPendingDelete = this.pendingDeleteCredentialId === cred.id;
@@ -472,13 +506,13 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         return;
       }
       this.pendingDeleteCredentialId = cred.id;
-      this.display();
+      this.requestRerender();
       return;
     }
     this.pendingDeleteCredentialId = null;
     this.plugin.settings.credentials = this.plugin.settings.credentials.filter(c => c.id !== cred.id);
     await this.plugin.saveSettings();
-    this.display();
+    this.requestRerender();
   }
 
   private renderCredentialEditRow(containerEl: HTMLElement, cred: Credential): void {
@@ -543,7 +577,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           }
           await this.plugin.saveSettings();
           this.editingCredentialId = null;
-          this.display();
+          this.requestRerender();
         });
       })
       .addButton(button => {
@@ -564,7 +598,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setButtonText('Cancel')
         .onClick(() => {
           this.editingCredentialId = null;
-          this.display();
+          this.requestRerender();
         }));
   }
 
@@ -626,7 +660,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .onClick(() => {
             this.addingCredential = false;
             this.addingCredentialType = 'airtable';
-            this.display();
+            this.requestRerender();
           }));
       return;
     }
@@ -675,7 +709,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
           this.addingCredential = false;
           this.addingCredentialType = 'airtable';
-          this.display();
+          this.requestRerender();
         });
       })
       .addButton(button => {
@@ -697,7 +731,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .onClick(() => {
           this.addingCredential = false;
           this.addingCredentialType = 'airtable';
-          this.display();
+          this.requestRerender();
         }));
   }
 
@@ -789,14 +823,14 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
   private async activateConfig(configId: string): Promise<void> {
     this.plugin.settings.activeConfigId = configId;
     await this.plugin.saveSettings();
-    this.display();
+    this.requestRerender();
   }
 
   private async addConfigFromTabBar(): Promise<void> {
     if (this.plugin.settings.credentials.length === 0) {
       new Notice('Auto Note Importer: Add a credential first before creating a configuration.');
       this.addingCredential = true;
-      this.display();
+      this.requestRerender();
       return;
     }
     const { configs } = this.plugin.settings;
@@ -813,7 +847,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     this.plugin.settings.configs.push(newConfig);
     this.plugin.settings.activeConfigId = newConfig.id;
     await this.plugin.saveSettings();
-    this.display();
+    this.requestRerender();
   }
 
   // ─── Config Header ─────────────────────────────────────────────────
@@ -895,7 +929,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
           .onClick(async () => {
             if (!isPending) {
               this.pendingDeleteConfigId = config.id;
-              this.display();
+              this.requestRerender();
               return;
             }
             const { configs } = this.plugin.settings;
@@ -907,7 +941,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
             this.plugin.settings.configs = configs.filter(c => c.id !== config.id);
             this.plugin.settings.activeConfigId = this.plugin.settings.configs[0]?.id ?? '';
             await this.plugin.saveSettings();
-            this.display();
+            this.requestRerender();
           });
         if (isPending) {
           button.buttonEl.addClass('mod-destructive');
@@ -918,7 +952,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
         .setButtonText('Cancel')
         .onClick(() => {
           this.pendingDeleteConfigId = null;
-          this.display();
+          this.requestRerender();
         }));
     }
     setting.settingEl.addClass('ani-delete-config');
@@ -956,7 +990,7 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       } else {
         this.expandedSections.add(sectionId);
       }
-      this.display();
+      this.requestRerender();
     });
 
     if (isExpanded) {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -15,7 +15,7 @@
  */
 
 import { App, PluginSettingTab, Setting, Notice, setIcon } from "obsidian";
-import type { ExtraButtonComponent, Plugin } from "obsidian";
+import type { ExtraButtonComponent, Plugin, SettingDefinitionItem } from "obsidian";
 import {
   FieldCache,
   SeaTableMetadataCache,
@@ -165,6 +165,101 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     }
   }
 
+  /**
+   * Declarative settings definitions (Obsidian >= 1.13).
+   *
+   * When this returns a non-empty array the host renders from it and never
+   * calls `display()`; on older Obsidian the method simply is not called and
+   * `display()` runs instead. That is why `minAppVersion` stays at 1.4.10 —
+   * the typings sanction keeping `display()` "as a fallback for plugins that
+   * need to support Obsidian versions older than 1.13.0".
+   *
+   * Each section is a group whose single `render` item delegates to the same
+   * private renderer `display()` uses, so the two entry points cannot drift.
+   * The declared `name` / `desc` / `aliases` are what Obsidian's settings
+   * search indexes — the reason the directory scanner asks for this API
+   * (obsidianmd/settings-tab/prefer-setting-definitions).
+   *
+   * Must stay side-effect free: the host also calls this once at tab
+   * registration purely to build the search index, with no render to follow.
+   */
+  getSettingDefinitions(): SettingDefinitionItem[] {
+    const groups: SettingDefinitionItem[] = [
+      {
+        // No `heading` — renderCredentialsSection draws its own, and the
+        // group heading would render a second copy above it.
+        type: 'group',
+        items: [{
+          name: 'Credentials',
+          desc: 'API keys and tokens for Airtable, SeaTable, and Supabase.',
+          aliases: ['api key', 'api token', 'airtable', 'seatable', 'supabase', 'credential'],
+          render: (setting) => {
+            const host = this.claimSettingHost(setting);
+            this.renderCredentialsSection(host);
+            // The credential form registers listeners on the host it just
+            // built; tearing it down here keeps a re-render from stacking
+            // duplicates the way display() avoids via tearDown + empty().
+            return () => this.tearDownCredentialFormUi();
+          },
+        }],
+      },
+      {
+        type: 'group',
+        items: [{
+          name: 'Debug logging',
+          desc: 'Verbose sync logging to the developer console.',
+          aliases: ['debug', 'log', 'console'],
+          render: (setting) => {
+            this.renderDebugSettings(this.claimSettingHost(setting));
+          },
+        }],
+      },
+      {
+        type: 'group',
+        items: [{
+          name: 'Sync configurations',
+          desc: 'Per-configuration connection, file, Bases, and bidirectional sync settings.',
+          aliases: ['config', 'sync', 'folder', 'template', 'bases', 'bidirectional', 'conflict'],
+          render: (setting) => {
+            const host = this.claimSettingHost(setting);
+            this.renderTabBar(host);
+
+            const config = this.activeConfig;
+            const credential = this.activeCredential;
+            if (!config || !credential) {
+              if (this.plugin.settings.configs.length === 0) {
+                new Setting(host)
+                  .setName('No configuration')
+                  .setDesc('Add a configuration using the + tab above.');
+              }
+              return;
+            }
+
+            // Async connection cards capture this generation and bail if it
+            // moved, so bump it here exactly as display() does — a declarative
+            // re-render must invalidate the previous render's in-flight fetch.
+            this.renderGeneration++;
+            this.renderConfigHeader(host, config);
+            this.renderConfigCardStack(host, config, credential);
+            this.renderDeleteConfigButton(host, config);
+          },
+        }],
+      },
+    ];
+    return groups;
+  }
+
+  /**
+   * Turns a declarative setting row into a plain container for the imperative
+   * renderers. They build their own headings and layout, so the row's default
+   * name/control scaffolding is cleared out first.
+   */
+  private claimSettingHost(setting: Setting): HTMLElement {
+    setting.settingEl.empty();
+    setting.settingEl.addClass('ani-declarative-host');
+    return setting.settingEl;
+  }
+
   display(): void {
     this.renderGeneration++;
     this.tearDownCredentialFormUi();
@@ -195,7 +290,22 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
     // Config header: name, enabled toggle, credential selector
     this.renderConfigHeader(containerEl, config);
 
-    // Summary card stack
+    this.renderConfigCardStack(containerEl, config, credential);
+
+    // Delete config button
+    this.renderDeleteConfigButton(containerEl, config);
+  }
+
+  /**
+   * The per-config summary card stack. Extracted from `display()` so the
+   * declarative `getSettingDefinitions()` path renders the exact same
+   * cards — the two entry points must not drift.
+   */
+  private renderConfigCardStack(
+    containerEl: HTMLElement,
+    config: ConfigEntry,
+    credential: Credential,
+  ): void {
     const cardStack = containerEl.createDiv({ cls: 'ani-card-stack' });
 
     // The card renders by credential type alone — missing secrets just
@@ -256,9 +366,6 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
       badge: config.bidirectionalSync ? { status: 'ok', text: 'On' } : { status: 'off', text: 'Off' },
       renderContent: (c) => this.renderBidirectionalSyncSettings(c, config),
     });
-
-    // Delete config button
-    this.renderDeleteConfigButton(containerEl, config);
   }
 
   // ─── Credentials Section ───────────────────────────────────────────

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -209,90 +209,85 @@ export class AutoNoteImporterSettingTab extends PluginSettingTab {
    * registration purely to build the search index, with no render to follow.
    */
   getSettingDefinitions(): SettingDefinitionItem[] {
-    const groups: SettingDefinitionItem[] = [
-      {
-        // No `heading` — renderCredentialsSection draws its own, and the
-        // group heading would render a second copy above it.
-        type: 'group',
-        items: [{
-          name: 'Credentials',
-          desc: 'API keys and tokens for Airtable, SeaTable, and Supabase.',
-          aliases: ['api key', 'api token', 'airtable', 'seatable', 'supabase', 'credential'],
-          render: (setting) => {
-            const host = this.claimSettingHost(setting);
-            this.renderCredentialsSection(host);
-            // The credential form registers listeners on the host it just
-            // built; tearing it down here keeps a re-render from stacking
-            // duplicates the way display() avoids via tearDown + empty().
-            return () => this.tearDownCredentialFormUi();
-          },
-        }],
-      },
-      {
-        type: 'group',
-        items: [{
-          name: 'Debug logging',
-          desc: 'Verbose sync logging to the developer console.',
-          aliases: ['debug', 'log', 'console'],
-          // No cleanup returned: this section registers no listeners
-          // outside the host DOM, which the next render empties anyway.
-          render: (setting) => {
-            this.renderDebugSettings(this.claimSettingHost(setting));
-          },
-        }],
-      },
-      {
-        type: 'group',
-        items: [{
-          name: 'Sync configurations',
-          desc: 'Per-configuration connection, file, Bases, and bidirectional sync settings.',
-          aliases: ['config', 'sync', 'folder', 'template', 'bases', 'bidirectional', 'conflict'],
-          // No cleanup returned: same as Debug — nothing outlives the host
-          // DOM. Only the credential form registers listeners that need an
-          // explicit tear-down.
-          render: (setting) => {
-            const host = this.claimSettingHost(setting);
-            this.renderTabBar(host);
+    return [
+      this.defineSection({
+        name: 'Credentials',
+        desc: 'API keys and tokens for Airtable, SeaTable, and Supabase.',
+        aliases: ['api key', 'api token', 'airtable', 'seatable', 'supabase', 'credential'],
+        render: (host) => {
+          this.renderCredentialsSection(host);
+          // The credential form registers listeners on the host it just
+          // built; tearing it down keeps a re-render from stacking
+          // duplicates the way display() avoids via tearDown + empty().
+          return () => this.tearDownCredentialFormUi();
+        },
+      }),
+      this.defineSection({
+        name: 'Debug logging',
+        desc: 'Verbose sync logging to the developer console.',
+        aliases: ['debug', 'log', 'console'],
+        render: (host) => { this.renderDebugSettings(host); },
+      }),
+      this.defineSection({
+        name: 'Sync configurations',
+        desc: 'Per-configuration connection, file, Bases, and bidirectional sync settings.',
+        aliases: ['config', 'sync', 'folder', 'template', 'bases', 'bidirectional', 'conflict'],
+        render: (host) => {
+          this.renderTabBar(host);
 
-            const config = this.activeConfig;
-            const credential = this.activeCredential;
-            if (!config || !credential) {
-              if (this.plugin.settings.configs.length === 0) {
-                new Setting(host)
-                  .setName('No configuration')
-                  .setDesc('Add a configuration using the + tab above.');
-              }
-              return;
+          const config = this.activeConfig;
+          const credential = this.activeCredential;
+          if (!config || !credential) {
+            if (this.plugin.settings.configs.length === 0) {
+              new Setting(host)
+                .setName('No configuration')
+                .setDesc('Add a configuration using the + tab above.');
             }
+            return;
+          }
 
-            // Async connection cards capture this generation and bail if
-            // it moved, so a declarative re-render must invalidate the
-            // previous render's in-flight fetch. Bumped here rather than in
-            // getSettingDefinitions() because only the render callback runs
-            // on an actual render — the definitions are also built for
-            // search indexing alone. Narrower than display()'s
-            // unconditional bump, which is fine: every async card lives
-            // inside renderConfigCardStack, below this guard.
-            this.renderGeneration++;
-            this.renderConfigHeader(host, config);
-            this.renderConfigCardStack(host, config, credential);
-            this.renderDeleteConfigButton(host, config);
-          },
-        }],
-      },
+          // Invalidate the previous render's in-flight card fetches. Bumped
+          // here rather than in getSettingDefinitions() because only the
+          // render callback runs on an actual render — the definitions are
+          // also built for search indexing alone.
+          this.renderGeneration++;
+          this.renderConfigHeader(host, config);
+          this.renderConfigCardStack(host, config, credential);
+          this.renderDeleteConfigButton(host, config);
+        },
+      }),
     ];
-    return groups;
   }
 
   /**
-   * Turns a declarative setting row into a plain container for the imperative
-   * renderers. They build their own headings and layout, so the row's default
-   * name/control scaffolding is cleared out first.
+   * Wraps one imperative renderer as a searchable declarative section.
+   *
+   * No group `heading`: every renderer draws its own, and a group heading
+   * would render a second copy above it. The renderer is handed a plain
+   * container — the setting row's default name/control scaffolding is
+   * cleared first — and may return a cleanup function for anything that
+   * outlives that DOM (only the credential form's listeners do).
    */
-  private claimSettingHost(setting: Setting): HTMLElement {
-    setting.settingEl.empty();
-    setting.settingEl.addClass('ani-declarative-host');
-    return setting.settingEl;
+  private defineSection(section: {
+    name: string;
+    desc: string;
+    aliases: string[];
+    render: (host: HTMLElement) => void | (() => void);
+  }): SettingDefinitionItem {
+    const { name, desc, aliases, render } = section;
+    return {
+      type: 'group',
+      items: [{
+        name,
+        desc,
+        aliases,
+        render: (setting) => {
+          setting.settingEl.empty();
+          setting.settingEl.addClass('ani-declarative-host');
+          return render(setting.settingEl);
+        },
+      }],
+    };
   }
 
   display(): void {

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -125,20 +125,29 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
       return app.setting.pluginTabs.find(t => t.id === '${pluginId}');
     }
 
+    // Render through whichever path the host actually uses, mirroring the
+    // plugin's own requestRerender(). Calling display() unconditionally
+    // would force the imperative tree even on Obsidian 1.13+, so the suites
+    // would never exercise the declarative path the host really renders.
+    function renderTab(tab) {
+      if (typeof tab.update === 'function') tab.update();
+      else tab.display();
+    }
+
     async function openSettingsTab() {
       app.setting.open();
       await new Promise(r => setTimeout(r, 200));
       const tab = getSettingsTab();
       if (!tab) throw new Error('Plugin settings tab not found');
       app.setting.openTab(tab);
-      tab.display();
+      renderTab(tab);
       await new Promise(r => setTimeout(r, 400));
       return tab;
     }
 
     async function rerenderTab() {
       const tab = getSettingsTab();
-      if (tab) tab.display();
+      if (tab) renderTab(tab);
       await new Promise(r => setTimeout(r, 300));
       return tab;
     }

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -125,13 +125,16 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
       return app.setting.pluginTabs.find(t => t.id === '${pluginId}');
     }
 
-    // Render through whichever path the host actually uses, mirroring the
-    // plugin's own requestRerender(). Calling display() unconditionally
-    // would force the imperative tree even on Obsidian 1.13+, so the suites
-    // would never exercise the declarative path the host really renders.
+    // Call the plugin's own dispatch rather than re-deriving it here.
+    // TypeScript privacy is erased at runtime, so the suites exercise the
+    // real render-path decision instead of a copy that can drift out of
+    // sync. (Calling display() unconditionally, as this used to, forced the
+    // imperative tree even on Obsidian 1.13+ — so the declarative path the
+    // host actually renders was never under test.)
+    // NOTE: no backticks anywhere in this file — these helpers are injected
+    // as a template literal, so a backtick here terminates the string.
     function renderTab(tab) {
-      if (typeof tab.update === 'function') tab.update();
-      else tab.display();
+      tab.requestRerender();
     }
 
     async function openSettingsTab() {

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -244,7 +244,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         const tab = getSettingsTab();
         await openSettingsTab();
         tab.editingCredentialId = '${E2E_CRED_ID}';
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 300));
 
         const c = getContainer();
@@ -252,7 +252,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         const testBtn = Array.from(c.querySelectorAll('button')).find(b => b.textContent === 'Test');
 
         tab.editingCredentialId = null;
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 200));
 
         return JSON.stringify({

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -87,16 +87,17 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
             tabBarExists: !!tabBar,
           });
         }
-        // Check DOM order: debug should come before tab bar
-        const allEls = Array.from(c.children);
-        const debugIdx = allEls.indexOf(debug);
-        const tabBarIdx = allEls.indexOf(tabBar);
+        // Document order, not child index: on Obsidian 1.13+ the sections
+        // are nested inside declarative setting rows, so neither element is
+        // a direct child of the container. The invariant under test is the
+        // visual order, which compareDocumentPosition expresses on both
+        // the imperative and the declarative render path.
+        const debugBeforeTabBar =
+          !!(debug.compareDocumentPosition(tabBar) & Node.DOCUMENT_POSITION_FOLLOWING);
         return JSON.stringify({
           debugExists: true,
           tabBarExists: true,
-          debugBeforeTabBar: debugIdx < tabBarIdx,
-          debugIdx,
-          tabBarIdx,
+          debugBeforeTabBar,
         });
       })()`, 10000);
       const pass = r.debugExists && r.tabBarExists && r.debugBeforeTabBar;
@@ -127,12 +128,16 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         ${HELPERS}
         const c = getContainer();
         const stack = c.querySelector('.ani-card-stack');
+        // contains(), not parentElement: the declarative path (1.13+) nests
+        // the stack inside a setting row. What must hold either way is that
+        // the stack lives in the tab's container rather than floating
+        // detached or leaking into another tab.
         return JSON.stringify({
           exists: !!stack,
-          parentIsContainer: stack?.parentElement === c,
+          insideContainer: !!(stack && c.contains(stack)),
         });
       })()`, 10000);
-      return { pass: r.exists && r.parentIsContainer, detail: `exists=${r.exists} parent=${r.parentIsContainer}` };
+      return { pass: r.exists && r.insideContainer, detail: `exists=${r.exists} inside=${r.insideContainer}` };
     });
 
     // ════════════════════════════════════════════════════════════════
@@ -451,7 +456,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         // Clear state so all cards start collapsed
         const tab = getSettingsTab();
         tab.expandedSections.clear();
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 400));
 
         const cards = queryCards();
@@ -533,7 +538,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         const tab = getSettingsTab();
         tab.expandedSections.clear();
         tab.expandedSections.add('bidirectional-sync');
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 400));
 
         const cards = queryCards();
@@ -561,7 +566,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         // Clear expandedSections to ensure all cards start collapsed
         const tab = getSettingsTab();
         tab.expandedSections?.clear();
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 400));
 
         // Verify first card starts collapsed
@@ -753,7 +758,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         const tab = getSettingsTab();
         await openSettingsTab();
         tab.editingCredentialId = cred.id;
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 300));
 
         const c = getContainer();
@@ -763,7 +768,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
         // Cleanup
         tab.editingCredentialId = null;
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 200));
 
         return JSON.stringify({
@@ -798,7 +803,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         await openSettingsTab();
         const tab = getSettingsTab();
         tab.editingCredentialId = fakeId;
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 300));
 
         const c = getContainer();

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -300,7 +300,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
         // renderCredentialAddDetails initializes credentialFormUi.
         tab.addingCredential = true;
         tab.addingCredentialType = 'supabase';
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 200));
 
         const c = getContainer();
@@ -343,7 +343,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
         // Cleanup form
         tab.addingCredential = false;
-        tab.display();
+        renderTab(tab);
 
         return JSON.stringify(result);
       })()`, 15000);
@@ -367,7 +367,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
         tab.addingCredential = true;
         tab.addingCredentialType = 'supabase';
-        tab.display();
+        renderTab(tab);
         await new Promise(r => setTimeout(r, 200));
 
         const c = getContainer();
@@ -425,7 +425,7 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
         // Cleanup form
         tab.addingCredential = false;
-        tab.display();
+        renderTab(tab);
 
         return JSON.stringify({ beforeReset, afterReset });
       })()`, 15000);

--- a/tests/ui/settings-tab-definitions.test.ts
+++ b/tests/ui/settings-tab-definitions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Contract tests for the declarative settings definitions (Obsidian 1.13+).
+ *
+ * Two invariants matter and neither is visible from the rendered UI:
+ *   1. The array must be non-empty — that is precisely what makes Obsidian
+ *      render declaratively and skip display(). An empty array silently
+ *      falls back to the imperative path and the settings-search entry
+ *      disappears again.
+ *   2. Building the definitions must be side-effect free — the host also
+ *      calls this once at tab registration purely to build the search
+ *      index, with no render to follow. Any teardown or generation bump
+ *      here would fire against live UI state.
+ *
+ * @covers src/ui/settings-tab.ts
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { SettingDefinitionItem } from 'obsidian';
+import type { AutoNoteImporterSettings, Credential, ConfigEntry } from '../../src/types';
+import { createSettingsTabHarness } from './settings-tab-test-utils';
+
+type TestableSettingsTab = {
+  getSettingDefinitions(): SettingDefinitionItem[];
+  renderGeneration: number;
+  display: () => void;
+};
+
+const CREDENTIAL: Credential = {
+  id: 'cred-1',
+  name: 'Airtable',
+  type: 'airtable',
+  apiKey: 'key',
+} as Credential;
+
+const CONFIG = { id: 'cfg-1', name: 'Config 1', credentialId: 'cred-1' } as ConfigEntry;
+
+function createTab(settings: Partial<AutoNoteImporterSettings> = {}): TestableSettingsTab {
+  const { tab } = createSettingsTabHarness(settings);
+  const testable = tab as TestableSettingsTab;
+  testable.display = vi.fn();
+  return testable;
+}
+
+/** Group definitions carry `items`; leaf definitions carry `name`. */
+function leafNames(defs: SettingDefinitionItem[]): string[] {
+  return defs.flatMap(d => ('items' in d && d.items ? d.items : []).map(i => ('name' in i ? i.name : '')));
+}
+
+describe('getSettingDefinitions', () => {
+  it('returns a non-empty array so Obsidian renders declaratively', () => {
+    expect(createTab().getSettingDefinitions().length).toBeGreaterThan(0);
+  });
+
+  it('names every leaf item so settings search can index it', () => {
+    const names = leafNames(createTab().getSettingDefinitions());
+
+    expect(names.length).toBeGreaterThan(0);
+    expect(names.every(n => n.trim().length > 0)).toBe(true);
+  });
+
+  it('stays non-empty with no configs — the empty state must still be searchable', () => {
+    const defs = createTab({ credentials: [], configs: [] }).getSettingDefinitions();
+
+    expect(defs.length).toBeGreaterThan(0);
+    expect(leafNames(defs)).toContain('Credentials');
+  });
+
+  // The host calls this at tab registration purely for search indexing, with
+  // no render to follow. Side effects there would hit live UI state.
+  it('does not touch render state when only building definitions', () => {
+    const tab = createTab({ credentials: [CREDENTIAL], configs: [CONFIG], activeConfigId: 'cfg-1' });
+    const before = tab.renderGeneration;
+
+    tab.getSettingDefinitions();
+
+    expect(tab.renderGeneration).toBe(before);
+    expect(tab.display).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — repeated indexing yields the same shape', () => {
+    const tab = createTab({ credentials: [CREDENTIAL], configs: [CONFIG], activeConfigId: 'cfg-1' });
+
+    expect(leafNames(tab.getSettingDefinitions())).toEqual(leafNames(tab.getSettingDefinitions()));
+  });
+
+  it('omits group headings so the imperative renderers own their own', () => {
+    // renderCredentialsSection() and friends draw their own headings; a group
+    // heading would render a second copy above them (observed on 1.13.4).
+    const defs = createTab().getSettingDefinitions();
+
+    for (const def of defs) {
+      if ('heading' in def) expect(def.heading).toBeUndefined();
+    }
+  });
+});

--- a/tests/ui/settings-tab-definitions.test.ts
+++ b/tests/ui/settings-tab-definitions.test.ts
@@ -23,6 +23,8 @@ type TestableSettingsTab = {
   getSettingDefinitions(): SettingDefinitionItem[];
   renderGeneration: number;
   display: () => void;
+  requestRerender(): void;
+  update?: () => void;
 };
 
 const CREDENTIAL: Credential = {
@@ -83,13 +85,40 @@ describe('getSettingDefinitions', () => {
     expect(leafNames(tab.getSettingDefinitions())).toEqual(leafNames(tab.getSettingDefinitions()));
   });
 
+  it('re-renders through update() when the host provides it (1.13+)', () => {
+    // Calling display() here would empty() the container the declarative
+    // host owns and repaint the imperative tree outside its lifecycle, so
+    // the declarative structure would last only until the first click.
+    const tab = createTab();
+    tab.update = vi.fn();
+
+    tab.requestRerender();
+
+    expect(tab.update).toHaveBeenCalledTimes(1);
+    expect(tab.display).not.toHaveBeenCalled();
+  });
+
+  it('falls back to display() on hosts without update() (pre-1.13)', () => {
+    const tab = createTab();
+    expect(tab.update).toBeUndefined();
+
+    tab.requestRerender();
+
+    // Exactly once — an early version of this helper recursed into itself
+    // here and blew the stack on every pre-1.13 re-render.
+    expect(tab.display).toHaveBeenCalledTimes(1);
+  });
+
   it('omits group headings so the imperative renderers own their own', () => {
     // renderCredentialsSection() and friends draw their own headings; a group
     // heading would render a second copy above them (observed on 1.13.4).
+    // Read the key directly — `'heading' in def` is false for every current
+    // group, so an `in` guard would make this assert nothing at all.
     const defs = createTab().getSettingDefinitions();
 
+    expect(defs.length).toBeGreaterThan(0);
     for (const def of defs) {
-      if ('heading' in def) expect(def.heading).toBeUndefined();
+      expect((def as Record<string, unknown>).heading).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Implements `getSettingDefinitions()` so the plugin's settings are indexed by Obsidian's settings search on 1.13+, clearing the `obsidianmd/settings-tab/prefer-setting-definitions` warning the directory scanner reported against merged `master`
- **`minAppVersion` stays at 1.4.10** — no users are dropped
- Routes every internal re-render through the render path the host is actually using
- Verified live on Obsidian 1.13.4, not just statically

## The issue's premise was wrong

#114 states that adopting the 1.13 APIs "forces `minAppVersion: 1.13.0`". The typings say otherwise:

> Not called when `getSettingDefinitions` returns a non-empty array; the tab is rendered declaratively from those definitions instead. **Only implement `display()` as a fallback for plugins that need to support Obsidian versions older than 1.13.0.**

So the dual path is the officially sanctioned shape: 1.13+ renders declaratively and never calls `display()`, while older hosts never call `getSettingDefinitions()`. Keeping both costs nothing at runtime and keeps 1.4.10 – 1.12.x users.

## Changes

Three groups (Credentials / Debug / Configurations), each a single `render` item delegating to **the same private renderer `display()` uses**. Two independent section lists would drift the first time a card is added, so the card stack was extracted into `renderConfigCardStack()` and is now shared by both entry points.

**Re-renders go through `requestRerender()`**, never `display()` directly. Returning definitions makes the host own the container; calling `display()` would `empty()` it and repaint the imperative tree outside the settings-definition lifecycle, so the declarative structure would survive only until the user's first click. Measured on 1.13.4:

| State | declarative hosts | `.setting-item` |
|:---|---:|---:|
| declarative render | 3 | 18 |
| after a direct `tab.display()` | **0** | 15 |
| after `tab.update()` | 3 | 18 |

All 18 call sites now route through the helper, which picks `update()` when the host has it and `display()` otherwise.

Two further design constraints, both load-bearing:

| Constraint | Why |
|:---|:---|
| `getSettingDefinitions()` is side-effect free | The host also calls it once at tab registration purely to build the search index, with **no render to follow**. A `renderGeneration++` or teardown there fires against live UI state. Lifecycle work lives in the `render` callback's cleanup return. |
| Groups carry no `heading` | The imperative renderers draw their own headings; a group heading rendered a **second copy** above them. Caught by observing 1.13.4, invisible to static checks. |

`ButtonComponent.setDestructive()` is deliberately not adopted: unlike an uncalled method, calling it on a pre-1.13 host throws. It stays gated behind the `minAppVersion` decision and remains tracked in #114.

## E2E harness fix

`openSettingsTab()` called `tab.display()` unconditionally, so **the settings suites forced the imperative tree even on 1.13** and could never have caught the re-render bug above. The helper now mirrors `requestRerender()`.

Switching it surfaced two layout tests that assumed direct children of `containerEl` (`c.children.indexOf(...)`, `parentElement === c`); declaratively both elements are nested inside setting rows. The invariants they were written for still hold — verified on 1.13.4 that `debug` precedes `tabBar` in document order and the card stack is inside the container — so they now use `compareDocumentPosition` / `contains`, which hold on both paths.

## Verification

Observed on a real Obsidian 1.13.4 instance (CDP, plugin deployed to the e2e vault):

- `app.setting.pluginTabs` shows `auto-note-importer` at **`items: 0 → 3`** — the same shape as core plugins (canvas: 8, daily-notes: 4). Community plugins without this API sit at 0, which is where we were.
- Clicking "+ Add credential" (a real `requestRerender()` path) keeps the declarative host count at 3 before, during, and after.

- [x] `npm run build` — exit 0
- [x] `npm run lint` — exit 0
- [x] `npm run test:run` — 808/808 (38 files), incl. 8 contract tests
- [x] `npm run test:e2e:settings` — 47/47 **on the declarative path** (after the harness fix)
- [x] `npm run test:e2e:seatable:settings` — 16/16, same
- [x] Local scanner reproduction — `prefer-setting-definitions`: 1 → 0

The contract tests pin what the rendered UI cannot show: that the array stays non-empty (an empty one silently falls back to `display()` and the search entry disappears again), that building definitions has no side effects, and that `requestRerender()` picks the right path on each host version. The side-effect test was confirmed to fail when a `renderGeneration++` is introduced.

Refs #114