### PR TITLE
test: give each settings e2e suite its own starting state

### DIFF
--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -137,6 +137,24 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
       tab.requestRerender();
     }
 
+    // Transient UI state lives on the settings-tab instance, which outlives
+    // a suite run — only a plugin reload recreates it. A suite must set up
+    // its own starting state instead of inheriting the previous suite's
+    // leftovers: run-settings-e2e clears expandedSections and never
+    // restores it, so later suites queried collapsed cards and saw empty
+    // connection bodies (#116). Values mirror the field initialisers in
+    // src/ui/settings-tab.ts.
+    function resetSettingsTabState(tab) {
+      if (!tab) return;
+      tab.editingCredentialId = null;
+      tab.addingCredential = false;
+      tab.pendingDeleteConfigId = null;
+      tab.pendingDeleteCredentialId = null;
+      tab.expandedSections.clear();
+      ['airtable-connection', 'seatable-connection', 'supabase-connection']
+        .forEach(id => tab.expandedSections.add(id));
+    }
+
     async function openSettingsTab() {
       app.setting.open();
       await new Promise(r => setTimeout(r, 200));

--- a/tests/e2e/obsidian-helpers.mjs
+++ b/tests/e2e/obsidian-helpers.mjs
@@ -148,9 +148,20 @@ export function buildSettingsHarnessHelpers({ pluginId }) {
       if (!tab) return;
       tab.editingCredentialId = null;
       tab.addingCredential = false;
+      // Reset the type too, not just the open/closed flag: the Supabase
+      // suite leaves it on 'supabase', so the next suite's first Add
+      // Credential click would open the wrong provider form.
+      tab.addingCredentialType = 'airtable';
       tab.pendingDeleteConfigId = null;
       tab.pendingDeleteCredentialId = null;
+      // Tear down rather than null out — credentialFormUi holds listener
+      // removal handles that would otherwise leak.
+      tab.tearDownCredentialFormUi();
       tab.expandedSections.clear();
+      // Keep in sync with the Set initialiser in src/ui/settings-tab.ts.
+      // A provider added for epic #11 needs its card id here too, or its
+      // suite will query a collapsed card and read an empty body — the
+      // exact symptom this helper exists to prevent.
       ['airtable-connection', 'seatable-connection', 'supabase-connection']
         .forEach(id => tab.expandedSections.add(id));
     }

--- a/tests/e2e/run-seatable-settings-e2e.mjs
+++ b/tests/e2e/run-seatable-settings-e2e.mjs
@@ -95,7 +95,10 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       ${HELPERS}
       ensureSeaCredentialAndConfig();
       await getPlugin().saveSettings();
-      await openSettingsTab();
+      const tab = await openSettingsTab();
+      resetSettingsTabState(tab);   // do not inherit a prior suite's UI state (#116)
+      renderTab(tab);
+      await new Promise(r => setTimeout(r, 300));
       return JSON.stringify({ ok: true });
     })()`, 10000);
 

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -66,7 +66,10 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
 
     await run(`(async () => {
       ${HELPERS}
-      await openSettingsTab();
+      const tab = await openSettingsTab();
+      resetSettingsTabState(tab);   // do not inherit a prior suite's UI state (#116)
+      renderTab(tab);
+      await new Promise(r => setTimeout(r, 300));
       return JSON.stringify({ ok: true });
     })()`, 10000);
     log('Settings tab opened');

--- a/tests/e2e/run-supabase-settings-e2e.mjs
+++ b/tests/e2e/run-supabase-settings-e2e.mjs
@@ -110,7 +110,10 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       ${HELPERS}
       ensureSupabaseCredentialAndConfig();
       await getPlugin().saveSettings();
-      await openSettingsTab();
+      const tab = await openSettingsTab();
+      resetSettingsTabState(tab);   // do not inherit a prior suite's UI state (#116)
+      renderTab(tab);
+      await new Promise(r => setTimeout(r, 300));
       return JSON.stringify({ ok: true });
     })()`, 10000);
 


### PR DESCRIPTION
## Summary

- Fixes the cross-suite state leak that made `test:e2e:seatable:settings` fail 5/16 whenever it ran after `test:e2e:settings`
- Each settings suite now establishes its own starting state instead of trusting the previous suite's cleanup

Closes #116

## Root cause

`expandedSections` is an in-memory `Set` on the settings-tab **instance**, initialised to the three connection cards. `run-settings-e2e.mjs` calls `tab.expandedSections.clear()` in three places and never restores it.

A collapsed summary card renders no body at all, so anything inside it is **absent from the DOM** rather than merely hidden. That is why the leaked state showed up as `dropdowns=0` *and* `inputs=0` together — not "the fallback branch rendered instead of the dropdown branch", but "the connection card body never rendered". The subfolder toggle lives in the same card, hence its three failures.

It also explains why a plugin reload between suites worked around it: the reload recreates the tab instance, restoring the field initialiser.

## Fix

`resetSettingsTabState(tab)` in the shared harness, called from each settings suite's setup. It resets `expandedSections` to the default plus the other transient instance state that can leak the same way — `editingCredentialId`, `addingCredential`, `pendingDeleteConfigId`, `pendingDeleteCredentialId`.

Deliberately **not** wired into `openSettingsTab()`: several tests set this state and then re-open the tab, so resetting on every open would break them. Setup is the right seam.

## Verification

Ran the exact sequence recorded in #116, on Obsidian 1.13.4:

| Order | Before | After |
|:---|---:|---:|
| 1. `test:e2e:settings` | 47/47 | **47/47** |
| 2. `test:e2e:seatable:settings` (immediately after) | **11/16** | **16/16** |
| 3. `test:e2e:supabase:settings` (immediately after) | 8/9 | 8/9 |

The one remaining failure in step 3 is **not** an ordering issue: the `.env` Supabase project host no longer resolves in DNS, so the metadata fetch cannot succeed. It fails identically when the suite runs in isolation and on a `master` build — it is the pre-existing environment gap noted when #116 was filed, and is out of scope here.

- [x] `node --check` on all e2e modules
- [x] Full chain run above

Unit tests are unaffected — vitest collects `tests/**/*.test.ts` only, and this PR touches `.mjs` harness files.