### PR TITLE
fix: restore block flow in declarative settings section hosts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,14 +6,8 @@
 
 /* @handbook 5.1-ui-components */
 
-/* defineSection() empties one declarative setting row and renders a whole
-   section into it (settings-tab.ts). Obsidian's base `.setting-item` rule
-   lays setting rows out as a horizontal flex line (display: flex;
-   align-items: center), which strings the section's children out sideways
-   at content width — the config section overflowed its group box and the
-   credential form width changed with the selected provider. Block flow
-   restores the container semantics the imperative display() path gives
-   the same renderers via containerEl. */
+/* Obsidian 1.13 renders sections into .setting-item flex rows; block flow
+   restores the vertical stacking the imperative containerEl path provides. */
 .setting-item.ani-declarative-host {
   display: block;
 }

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,22 @@
  * Auto Note Importer plugin styles.
  */
 
+/* ─── Declarative Section Host (Obsidian 1.13+) ──────────────────── */
+
+/* @handbook 5.1-ui-components */
+
+/* defineSection() empties one declarative setting row and renders a whole
+   section into it (settings-tab.ts). Obsidian's base `.setting-item` rule
+   lays setting rows out as a horizontal flex line (display: flex;
+   align-items: center), which strings the section's children out sideways
+   at content width — the config section overflowed its group box and the
+   credential form width changed with the selected provider. Block flow
+   restores the container semantics the imperative display() path gives
+   the same renderers via containerEl. */
+.setting-item.ani-declarative-host {
+  display: block;
+}
+
 /* ─── Credentials Table ──────────────────────────────────────────── */
 
 .ani-credentials-section {

--- a/tests/e2e/run-settings-e2e.mjs
+++ b/tests/e2e/run-settings-e2e.mjs
@@ -143,6 +143,62 @@ const setConfigAndQuery = makeSetConfigAndQuery({ helpers: HELPERS, run });
       return { pass: r.exists && r.insideContainer, detail: `exists=${r.exists} inside=${r.insideContainer}` };
     });
 
+    await test('layout / declarative hosts stack children vertically at full width', async () => {
+      const r = await run(`(async () => {
+        ${HELPERS}
+        const c = getContainer();
+        // Obsidian 1.13+ renders each section into a declarative setting
+        // row (.ani-declarative-host). The host's base .setting-item rule
+        // is a horizontal flex row, so without the plugin's block-flow
+        // override the section children string out sideways at content
+        // width: the config section overflowed its box and the credential
+        // form width jumped between providers. Pre-1.13 the imperative
+        // path renders no hosts — nothing to measure, report and pass.
+        const hosts = Array.from(c.querySelectorAll('.ani-declarative-host'));
+        if (hosts.length === 0) {
+          return JSON.stringify({ path: 'imperative', ok: true });
+        }
+        const reports = hosts.map((host, i) => {
+          const cs = getComputedStyle(host);
+          const pad = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+          const contentWidth = host.clientWidth - pad;
+          const kids = Array.from(host.children).filter(k => {
+            const b = k.getBoundingClientRect();
+            return b.width > 0 || b.height > 0;   // ignore display:none children
+          });
+          // Block stretch: each child's border box spans the host's content
+          // width minus the child's own horizontal margins (e.g. the tab
+          // bar keeps a 16px margin-right by design). Flex-row shrinks
+          // children to content size instead, which is what this catches.
+          const fullWidth = kids.every(k => {
+            const kcs = getComputedStyle(k);
+            const margins = parseFloat(kcs.marginLeft) + parseFloat(kcs.marginRight);
+            return k.getBoundingClientRect().width >= contentWidth - margins - 2;
+          });
+          const stacked = kids.slice(1).every((k, j) => {
+            const prev = kids[j].getBoundingClientRect();   // j indexes the unsliced predecessor
+            return k.getBoundingClientRect().top >= prev.bottom - 1;
+          });
+          return {
+            host: i,
+            childCount: kids.length,
+            fullWidth,
+            stacked,
+            overflowX: host.scrollWidth - host.clientWidth,
+          };
+        });
+        const ok = reports.every(rep => rep.fullWidth && rep.stacked && rep.overflowX <= 1);
+        return JSON.stringify({ path: 'declarative', ok, reports });
+      })()`, 10000);
+      const pass = r.ok === true;
+      return {
+        pass,
+        detail: r.path === 'imperative'
+          ? 'imperative path (pre-1.13), no hosts'
+          : JSON.stringify(r.reports),
+      };
+    });
+
     // ════════════════════════════════════════════════════════════════
     // Group 2: Badge Status — Individual Card Boundaries
     // ════════════════════════════════════════════════════════════════

--- a/tests/e2e/start-e2e.sh
+++ b/tests/e2e/start-e2e.sh
@@ -80,7 +80,9 @@ if [ -n "$TARGET_ID" ]; then
 
   if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR" ]; then
     echo "→ Deploying to ${PLUGIN_DIR}..."
-    cp main.js manifest.json "$PLUGIN_DIR/"
+    # styles.css too — the settings tab's layout depends on it, and a stale
+    # copy in the vault masks (or fakes) visual regressions.
+    cp main.js manifest.json styles.css "$PLUGIN_DIR/"
     echo "✓ Plugin deployed"
 
     # Reload plugin


### PR DESCRIPTION
## Summary
- Obsidian 1.13's declarative settings path renders each plugin section inside a `.setting-item` row, whose base rule is a horizontal flex card (`display: flex; align-items: center`) — section children strung out sideways at content width: the Sync configurations section overflowed its group box by ~1,369px and the credential form's width changed with the selected provider
- Add `.setting-item.ani-declarative-host { display: block; }` so the declarative host gets the same block-container semantics the imperative `display()` path gets from `containerEl`
- Add a settings e2e layout guard asserting every declarative host stacks its children vertically at full width with no horizontal overflow (fails on the old CSS, 48/48 after the fix)
- Fix the e2e deploy script to ship `styles.css` alongside `main.js`/`manifest.json` — a stale vault copy could mask (or fake) visual regressions

## Test plan
- [x] Settings e2e suite: 48/48 (new layout guard included; observed FAIL pre-fix → PASS post-fix)
- [x] Credential form width measured identical (571px) across Airtable / SeaTable / Supabase forms
- [x] Unit tests 808/808, lint clean, `npm run build` OK
- [x] Visual before/after screenshots of the settings window via CDP