### PR TITLE
fix: guard attachment/link field types in isPushable

### DIFF
--- a/src/services/airtable-field-mapper.ts
+++ b/src/services/airtable-field-mapper.ts
@@ -100,6 +100,7 @@ const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
   'aiText',           // { state, value, … }
   'externalSyncSource', // { id, name }
   'lookup',           // array of any shape (depends on rolled-up field)
+  'multipleAttachments', // array of { id, url, filename, size, type }
 ]);
 
 // Subfolder accepts any known Airtable type that stringifies to a reasonable

--- a/src/services/seatable-client.ts
+++ b/src/services/seatable-client.ts
@@ -87,6 +87,10 @@ export class SeaTableClient implements DatabaseProvider {
   private config: ConfigEntry;
   private rateLimiter: RateLimiter;
   private cachedToken: CachedBaseToken | null = null;
+  // Best-effort column-name → column-type map for the active tableId.
+  // Populated lazily by loadColumnTypes() and only cached on success — a
+  // fetch failure isn't remembered so the next batchUpdate can retry.
+  private columnTypesCache: Map<string, string> | null = null;
 
   constructor(
     credential: SeaTableCredential,
@@ -112,6 +116,15 @@ export class SeaTableClient implements DatabaseProvider {
       credential.serverUrl !== this.credential.serverUrl
     ) {
       this.cachedToken = null;
+    }
+    // Column types are keyed on tableId too — a table swap invalidates the
+    // cache even when the credential is unchanged.
+    if (
+      credential.apiToken !== this.credential.apiToken ||
+      credential.serverUrl !== this.credential.serverUrl ||
+      config.tableId !== this.config.tableId
+    ) {
+      this.columnTypesCache = null;
     }
     this.credential = credential;
     this.config = config;
@@ -174,6 +187,52 @@ export class SeaTableClient implements DatabaseProvider {
 
   private buildDtableUrl(token: CachedBaseToken, path: string): string {
     return `${token.dtableServer}/api/v2/dtables/${token.dtableUuid}/${path}`;
+  }
+
+  /**
+   * Best-effort GET of the base's `/metadata/` endpoint to resolve the
+   * active tableId's column-name → column-type map, so batchUpdate can
+   * filter out read-only / object-shaped columns via
+   * `seatableFieldMapper.isPushable` before writing (#121 — orchestrator's
+   * FieldCache is Airtable-only and gates on `settings.apiKey`, which is
+   * always `''` for SeaTable, so the guard has to live here).
+   *
+   * Tables are matched by `_id` — `config.tableId` always stores the
+   * table's `_id`, never its display name (see settings-tab.ts table
+   * dropdown). Returns `null` on any fetch/parse failure or when the
+   * table isn't found, so callers can fail open ("send everything").
+   * Success is cached on the instance; failures are not, so the next
+   * batchUpdate call gets another chance.
+   */
+  private async loadColumnTypes(): Promise<Map<string, string> | null> {
+    if (this.columnTypesCache) return this.columnTypesCache;
+
+    try {
+      const token = await this.getBaseToken();
+      const url = this.buildDtableUrl(token, 'metadata/');
+      const response = await this.rateLimiter.execute(() =>
+        requestUrl({ url, method: 'GET', headers: this.buildHeaders(token) }),
+      );
+
+      if (response.status < 200 || response.status >= 300) return null;
+
+      const json = response.json as
+        | { metadata?: { tables?: Array<{ _id?: string; columns?: Array<{ name?: string; type?: string }> }> } }
+        | undefined;
+      const table = json?.metadata?.tables?.find(t => t._id === this.config.tableId);
+      if (!table) return null;
+
+      const columnTypes = new Map<string, string>();
+      for (const c of table.columns ?? []) {
+        if (typeof c.name === 'string' && typeof c.type === 'string') {
+          columnTypes.set(c.name, c.type);
+        }
+      }
+      this.columnTypesCache = columnTypes;
+      return columnTypes;
+    } catch {
+      return null;
+    }
   }
 
   private buildHeaders(token: CachedBaseToken): Record<string, string> {
@@ -293,9 +352,30 @@ export class SeaTableClient implements DatabaseProvider {
       const token = await this.getBaseToken();
       const headers = this.buildHeaders(token);
       const url = this.buildDtableUrl(token, 'rows/');
+
+      // Column-type lookup is best-effort — failures fall through to
+      // "send everything unchanged" rather than blocking the sync.
+      // isPushable is applied here, at body composition (not inside
+      // loadColumnTypes), so a formula/file/link/digital-sign column's
+      // structured remote value is preserved instead of getting
+      // clobbered by a scalar frontmatter string. A column name absent
+      // from the metadata (custom alias, race with a freshly added
+      // column) passes through unfiltered — fail-open per field.
+      const columnTypes = await this.loadColumnTypes();
+      const filteredFields = updates.map(u => {
+        if (!columnTypes) return u.fields;
+        const filtered: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(u.fields)) {
+          const providerType = columnTypes.get(k);
+          if (providerType && !seatableFieldMapper.isPushable(providerType)) continue;
+          filtered[k] = v;
+        }
+        return filtered;
+      });
+
       const body = JSON.stringify({
         table_id: this.config.tableId,
-        updates: updates.map(u => ({ row_id: u.recordId, row: u.fields })),
+        updates: updates.map((u, i) => ({ row_id: u.recordId, row: filteredFields[i] })),
       });
       const response = await this.rateLimiter.execute(() =>
         requestUrl({ url, method: 'PUT', headers, body }),
@@ -307,12 +387,12 @@ export class SeaTableClient implements DatabaseProvider {
       }
 
       // SeaTable's PUT /rows/ returns `{success: true}` without echoing
-      // the updated fields, so we mirror back the requested fields as
-      // confirmed updates — matching the SyncResult contract.
-      return updates.map(u => ({
+      // the updated fields, so we mirror back the requested (post-filter)
+      // fields as confirmed updates — matching the SyncResult contract.
+      return updates.map((u, i) => ({
         success: true as const,
         recordId: u.recordId,
-        updatedFields: u.fields,
+        updatedFields: filteredFields[i],
       }));
     } catch (error) {
       return buildBatchFailures(updates, error instanceof Error ? error.message : 'Unknown error occurred');

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -77,12 +77,20 @@ const TYPE_TO_STANDARD: Record<string, StandardFieldType> = {
 
 // Types whose SeaTable API value is an object, NOT a scalar string.
 // collaborator → array of { name, email, … }; geolocation → { lng, lat,
-// country_region }; button → link-formula-like object. Their standard-type
+// country_region }; button → link-formula-like object; file → array of
+// { name, size, type, url, upload_time }; digital-sign → { username,
+// sign_image_url, sign_time }; link → array of { row_id, display_value }
+// (source: SeaTable API reference /reference/models). `image` is
+// deliberately excluded — its API value is an array of URL strings, which
+// round-trips through YAML frontmatter fine. Their standard-type
 // classification doesn't capture this — explicit exclusion.
 const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
   'collaborator',
   'geolocation',
   'button',
+  'file',
+  'digital-sign',
+  'link',
 ]);
 
 // Excludes attachment (image / file / digital-sign) and link types — they

--- a/src/services/seatable-field-mapper.ts
+++ b/src/services/seatable-field-mapper.ts
@@ -95,8 +95,11 @@ const OBJECT_SHAPED_TYPES: ReadonlySet<string> = new Set([
 
 // Excludes attachment (image / file / digital-sign) and link types — they
 // stringify to JSON / record-id garbage when used as folder names — and
-// explicit object-shaped types (see OBJECT_SHAPED_TYPES). Sorted for
-// deterministic enumeration across providers.
+// explicit object-shaped types (see OBJECT_SHAPED_TYPES). file / digital-sign
+// / link are redundantly listed in both filters (attachment/link std-type AND
+// OBJECT_SHAPED_TYPES) — belt-and-suspenders, matching the Airtable-side
+// comment on its SUBFOLDER_SAFE_TYPES. Sorted for deterministic enumeration
+// across providers.
 const SUBFOLDER_SAFE_TYPES = Object.entries(TYPE_TO_STANDARD)
   .filter(([t, std]) =>
     std !== 'attachment' &&

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -162,6 +162,11 @@ describe('airtableFieldMapper', () => {
       expect(airtableFieldMapper.isPushable('multipleCollaborators')).toBe(false);
     });
 
+    it('should return false for attachment fields (object-array API value, does not round-trip through YAML) but true for id-string link fields (#107)', () => {
+      expect(airtableFieldMapper.isPushable('multipleAttachments')).toBe(false);
+      expect(airtableFieldMapper.isPushable('multipleRecordLinks')).toBe(true);
+    });
+
     it('should fail closed for unknown and prototype-chain names', () => {
       for (const t of ['bogusType', '', 'toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
         expect(airtableFieldMapper.isPushable(t)).toBe(false);

--- a/tests/services/airtable-field-mapper.test.ts
+++ b/tests/services/airtable-field-mapper.test.ts
@@ -181,7 +181,8 @@ describe('airtableFieldMapper', () => {
     // [object Object] / record-id JSON — produces garbage folder names.
     it('should return true for stringifiable known types (text / number / date / select / formula / system)', () => {
       // Excludes OBJECT_SHAPED_TYPES (collaborator / barcode / button / aiText /
-      // externalSyncSource / lookup) — covered by a separate test below.
+      // externalSyncSource / lookup / multipleAttachments) — covered by a
+      // separate test below.
       const stringifiable = [
         'singleLineText', 'multilineText', 'richText', 'email', 'phoneNumber', 'url',
         'number', 'currency', 'percent', 'rating', 'duration',

--- a/tests/services/seatable-client.test.ts
+++ b/tests/services/seatable-client.test.ts
@@ -329,6 +329,7 @@ describe('SeaTableClient', () => {
     it('should send batch-shaped body to PUT /rows/ for a single update', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockResolvedValueOnce(mockResponse({ success: true }));
 
       const result = await client.updateRecord('r1', { Name: 'Updated' });
@@ -339,7 +340,7 @@ describe('SeaTableClient', () => {
         updatedFields: { Name: 'Updated' },
       });
 
-      const writeCall = mockRequestUrl.mock.calls[1][0];
+      const writeCall = mockRequestUrl.mock.calls[2][0];
       expect(writeCall.method).toBe('PUT');
       expect(writeCall.url).toContain('/api/v2/dtables/uuid-xxx/rows/');
       const headers = writeCall.headers as Record<string, string>;
@@ -356,6 +357,7 @@ describe('SeaTableClient', () => {
     it('should return failure result on non-200', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockResolvedValueOnce(mockResponse({ error_msg: 'Field not found' }, 400));
 
       const result = await client.updateRecord('r1', { Bad: 'x' });
@@ -368,6 +370,7 @@ describe('SeaTableClient', () => {
     it('should catch thrown errors and return failure', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockRejectedValueOnce(new Error('Network down'));
 
       const result = await client.updateRecord('r1', {});
@@ -394,6 +397,7 @@ describe('SeaTableClient', () => {
     it('should batch update rows via PUT /rows/ with updates array', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockResolvedValueOnce(mockResponse({ success: true }));
 
       const results = await client.batchUpdate([
@@ -404,7 +408,7 @@ describe('SeaTableClient', () => {
       expect(results).toHaveLength(2);
       expect(results[0]).toEqual({ success: true, recordId: 'r1', updatedFields: { Name: 'A' } });
 
-      const writeCall = mockRequestUrl.mock.calls[1][0];
+      const writeCall = mockRequestUrl.mock.calls[2][0];
       expect(writeCall.method).toBe('PUT');
       // Path is `/rows/` (single endpoint handles both single + batch),
       // not the deprecated `/batch-update-rows/` path.
@@ -440,6 +444,7 @@ describe('SeaTableClient', () => {
     it('should return failure for all records on non-200', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockResolvedValueOnce(mockResponse({ error_msg: 'Server error' }, 500));
 
       const results = await client.batchUpdate([
@@ -454,6 +459,7 @@ describe('SeaTableClient', () => {
     it('should return failure for all records on thrown error', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockRejectedValueOnce(new Error('Connection lost'));
 
       const results = await client.batchUpdate([{ recordId: 'r1', fields: {} }]);
@@ -466,6 +472,7 @@ describe('SeaTableClient', () => {
     it('accepts 2xx statuses other than 200 as success (e.g. 201 from a proxy)', async () => {
       mockRequestUrl
         .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ metadata: { tables: [] } }))
         .mockResolvedValueOnce(mockResponse({ success: true }, 201));
 
       const results = await client.batchUpdate([{ recordId: 'r1', fields: { Name: 'A' } }]);
@@ -473,6 +480,106 @@ describe('SeaTableClient', () => {
       expect(results).toEqual([
         { success: true, recordId: 'r1', updatedFields: { Name: 'A' } },
       ]);
+    });
+
+    it('drops file/digital-sign/link-typed columns but keeps image/text-typed ones', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({
+          metadata: {
+            tables: [{
+              _id: '0000',
+              name: 'Table1',
+              columns: [
+                { key: '0k', name: 'Notes', type: 'text' },
+                { key: '1k', name: 'Cover', type: 'image' },
+                { key: '2k', name: 'Attachment', type: 'file' },
+                { key: '3k', name: 'Signature', type: 'digital-sign' },
+                { key: '4k', name: 'Related', type: 'link' },
+              ],
+            }],
+          },
+        }))
+        .mockResolvedValueOnce(mockResponse({ success: true }));
+
+      const results = await client.batchUpdate([{
+        recordId: 'r1',
+        fields: { Notes: 'hi', Cover: ['url'], Attachment: 'x', Signature: 'y', Related: 'z' },
+      }]);
+
+      const writeCall = mockRequestUrl.mock.calls[2][0];
+      const body = JSON.parse(writeCall.body as string);
+      expect(body.updates[0].row).toEqual({ Notes: 'hi', Cover: ['url'] });
+
+      // (b) updatedFields echoes only the filtered set
+      expect(results[0]).toEqual({
+        success: true,
+        recordId: 'r1',
+        updatedFields: { Notes: 'hi', Cover: ['url'] },
+      });
+    });
+
+    it('sends all fields unchanged when metadata fetch fails', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({ error_msg: 'Forbidden' }, 403))
+        .mockResolvedValueOnce(mockResponse({ success: true }));
+
+      const results = await client.batchUpdate([{
+        recordId: 'r1',
+        fields: { Attachment: 'x', Notes: 'hi' },
+      }]);
+
+      const writeCall = mockRequestUrl.mock.calls[2][0];
+      const body = JSON.parse(writeCall.body as string);
+      expect(body.updates[0].row).toEqual({ Attachment: 'x', Notes: 'hi' });
+      expect(results[0]).toEqual({
+        success: true,
+        recordId: 'r1',
+        updatedFields: { Attachment: 'x', Notes: 'hi' },
+      });
+    });
+
+    it('passes through a column name absent from metadata unfiltered', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({
+          metadata: { tables: [{ _id: '0000', name: 'Table1', columns: [] }] },
+        }))
+        .mockResolvedValueOnce(mockResponse({ success: true }));
+
+      const results = await client.batchUpdate([{
+        recordId: 'r1',
+        fields: { UnknownColumn: 'still sent' },
+      }]);
+
+      const writeCall = mockRequestUrl.mock.calls[2][0];
+      const body = JSON.parse(writeCall.body as string);
+      expect(body.updates[0].row).toEqual({ UnknownColumn: 'still sent' });
+      expect(results[0]).toEqual({
+        success: true,
+        recordId: 'r1',
+        updatedFields: { UnknownColumn: 'still sent' },
+      });
+    });
+
+    it('fetches metadata once then caches it across two batchUpdate calls', async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce(mockResponse(BASE_TOKEN_RESPONSE))
+        .mockResolvedValueOnce(mockResponse({
+          metadata: { tables: [{ _id: '0000', name: 'Table1', columns: [{ name: 'Attachment', type: 'file' }] }] },
+        }))
+        .mockResolvedValueOnce(mockResponse({ success: true }))
+        .mockResolvedValueOnce(mockResponse({ success: true }));
+
+      await client.batchUpdate([{ recordId: 'r1', fields: { Attachment: 'x' } }]);
+      await client.batchUpdate([{ recordId: 'r2', fields: { Attachment: 'y' } }]);
+
+      // token (1) + metadata (1) + writes (2) = 4 total, not 6.
+      expect(mockRequestUrl).toHaveBeenCalledTimes(4);
+      const secondWriteCall = mockRequestUrl.mock.calls[3][0];
+      const body = JSON.parse(secondWriteCall.body as string);
+      expect(body.updates[0].row).toEqual({});
     });
   });
 

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -142,6 +142,13 @@ describe('seatableFieldMapper', () => {
       expect(seatableFieldMapper.isPushable('geolocation')).toBe(false);
     });
 
+    it('should return false for attachment/link fields (object / object-array API value, does not round-trip through YAML) but true for image (URL-string array) (#107)', () => {
+      expect(seatableFieldMapper.isPushable('file')).toBe(false);
+      expect(seatableFieldMapper.isPushable('digital-sign')).toBe(false);
+      expect(seatableFieldMapper.isPushable('link')).toBe(false);
+      expect(seatableFieldMapper.isPushable('image')).toBe(true);
+    });
+
     it('should fail closed for unknown and prototype-chain names', () => {
       for (const t of ['bogusType', '', 'toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
         expect(seatableFieldMapper.isPushable(t)).toBe(false);

--- a/tests/services/seatable-field-mapper.test.ts
+++ b/tests/services/seatable-field-mapper.test.ts
@@ -92,6 +92,7 @@ describe('seatableFieldMapper', () => {
       expect(seatableFieldMapper.isReadOnly('number')).toBe(false);
       expect(seatableFieldMapper.isReadOnly('image')).toBe(false);
       expect(seatableFieldMapper.isReadOnly('file')).toBe(false);
+      expect(seatableFieldMapper.isReadOnly('digital-sign')).toBe(false);
       expect(seatableFieldMapper.isReadOnly('link')).toBe(false);
     });
 
@@ -158,8 +159,8 @@ describe('seatableFieldMapper', () => {
 
   describe('isSubfolderSafe', () => {
     it('should return true for stringifiable known SeaTable types', () => {
-      // Excludes OBJECT_SHAPED_TYPES (collaborator / geolocation / button) —
-      // covered by a separate test below.
+      // Excludes OBJECT_SHAPED_TYPES (collaborator / geolocation / button /
+      // file / digital-sign / link) — covered by a separate test below.
       const stringifiable = [
         'text', 'long-text', 'email', 'url',
         'number', 'duration', 'rate',


### PR DESCRIPTION
## Summary
- Add `multipleAttachments` to Airtable `OBJECT_SHAPED_TYPES` — its API value is an object array, so pushing sent stringified garbage to the write API (422 / value corruption)
- Add `file` / `digital-sign` / `link` to SeaTable `OBJECT_SHAPED_TYPES` — value shapes verified against the SeaTable API reference (file → object array, digital-sign → object, link → `[{row_id, display_value}]`)
- **Enforce the guard at runtime for SeaTable** (Codex review P1): `SeaTableClient.batchUpdate` now filters fields through `seatableFieldMapper.isPushable` using a lazily-cached base `/metadata/` column-type map — the orchestrator's `FieldCache` gate is Airtable-only (`settings.apiKey` is `''` for SeaTable), so the mapper contract alone never ran on the SeaTable push path. Fail-open on metadata failure; `updatedFields` echoes the post-filter set. Mirrors the existing Supabase pattern.
- Keep SeaTable `image` (URL-string array) and Airtable `multipleRecordLinks` (id-string array) pushable — both round-trip through YAML frontmatter
- Pin the per-provider `isPushable` contract with unit tests (written first, observed failing before the fix)

## Test plan
- [x] `npm run test:run` — 814 passed (38 files)
- [x] `npm run lint` clean / `npm run build` (tsc + esbuild) pass
- [x] New SeaTable client tests: object-shaped column drop, fail-open (metadata fetch failure / unknown column), metadata caching across calls, filtered `updatedFields` echo
- [ ] Object-shaped push-protection E2E — split to a follow-up issue (needs live Obsidian + remote creds)

Closes #107
