### PR TITLE
fix: guard in_trash pages and coerce numeric checkbox on push

### DIFF
--- a/src/services/notion-client.ts
+++ b/src/services/notion-client.ts
@@ -136,6 +136,10 @@ export class NotionClient implements DatabaseProvider {
 
       const json = response.json as { results: NotionPage[]; has_more: boolean; next_cursor: string | null };
       for (const page of json.results) {
+        // The query endpoint normally excludes trashed pages, but the wire
+        // type carries `in_trash` — skip defensively, mirroring the
+        // listDataSources guard in notion-schema-cache.
+        if (page.in_trash) continue;
         allNotes.push({ id: page.id, primaryField: page.id, fields: flattenNotionProperties(page.properties) });
       }
 

--- a/src/services/notion-client.ts
+++ b/src/services/notion-client.ts
@@ -170,6 +170,10 @@ export class NotionClient implements DatabaseProvider {
     }
 
     const json = response.json as NotionPage;
+    // A trashed page still resolves by ID — treat it like 404 so single-note
+    // pulls and conflict lookups never re-hydrate trashed content (mirrors
+    // the fetchNotes guard).
+    if (json.in_trash) return null;
     return { id: json.id, primaryField: json.id, fields: flattenNotionProperties(json.properties) };
   }
 

--- a/src/services/notion-value-converter.ts
+++ b/src/services/notion-value-converter.ts
@@ -194,6 +194,9 @@ export function wrapForNotionPush(notionType: string, value: unknown): WrapResul
       if (typeof value === 'boolean') return { ok: true, payload: { checkbox: value } };
       if (value === 'true') return { ok: true, payload: { checkbox: true } };
       if (value === 'false') return { ok: true, payload: { checkbox: false } };
+      // Some editors round-trip YAML booleans as 0/1 — coerce those two
+      // exact values; anything else is still rejected.
+      if (value === 0 || value === 1) return { ok: true, payload: { checkbox: value === 1 } };
       return { ok: false, reason: `Value is not a boolean: ${String(value)}` };
     }
     case 'select':

--- a/tests/services/notion-client.test.ts
+++ b/tests/services/notion-client.test.ts
@@ -79,6 +79,7 @@ describe('NotionClient.fetchNotes', () => {
         json: {
           results: [
             { id: 'page-2', properties: { Name: { type: 'title', title: [{ plain_text: 'Beta' }] } } },
+            { id: 'page-3', in_trash: true, properties: { Name: { type: 'title', title: [{ plain_text: 'Trashed' }] } } },
           ],
           has_more: false,
           next_cursor: null,

--- a/tests/services/notion-client.test.ts
+++ b/tests/services/notion-client.test.ts
@@ -115,6 +115,15 @@ describe('NotionClient.fetchRecord', () => {
     const result = await c.fetchRecord('page-1');
     expect(result).toEqual({ id: 'page-1', primaryField: 'page-1', fields: { Name: 'Alpha' } });
   });
+
+  it('returns null for a trashed page (mirrors the fetchNotes guard)', async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: { id: 'page-1', in_trash: true, properties: { Name: { type: 'title', title: [{ plain_text: 'Gone' }] } } },
+    });
+    const c = new NotionClient(cred, makeConfig(), new RateLimiter(0), false, new NotionSchemaCache());
+    expect(await c.fetchRecord('page-1')).toBeNull();
+  });
 });
 
 describe('NotionClient.batchUpdate', () => {

--- a/tests/services/notion-value-converter.test.ts
+++ b/tests/services/notion-value-converter.test.ts
@@ -197,6 +197,12 @@ describe('wrapForNotionPush', () => {
     expect(wrapForNotionPush('checkbox', 'false')).toEqual({ ok: true, payload: { checkbox: false } });
   });
 
+  it('coerces numeric 0/1 checkbox values (YAML round-trip from some editors)', () => {
+    expect(wrapForNotionPush('checkbox', 1)).toEqual({ ok: true, payload: { checkbox: true } });
+    expect(wrapForNotionPush('checkbox', 0)).toEqual({ ok: true, payload: { checkbox: false } });
+    expect(wrapForNotionPush('checkbox', 2).ok).toBe(false);
+  });
+
   it('wraps select/status; empty/null clears', () => {
     expect(wrapForNotionPush('select', 'A')).toEqual({ ok: true, payload: { select: { name: 'A' } } });
     expect(wrapForNotionPush('select', '')).toEqual({ ok: true, payload: { select: null } });


### PR DESCRIPTION
## Summary
- Address the two remaining low/nit items from PR #125's bot review (missed in the original triage — the review comment was read truncated)
- `fetchNotes` now defensively skips `in_trash` pages, mirroring the existing `listDataSources` guard
- `wrapForNotionPush('checkbox', 0|1)` coerces to boolean — some editors round-trip YAML booleans as 0/1; other numbers are still rejected

## Test plan
- [x] `npm run test:run` — 928 passed at this commit (2 new tests, pre-fail observed)
- [x] `npm run lint` / `npm run build` — clean

First of a 3-PR stack: this → #124 contract → #122 body sync.